### PR TITLE
Rename FF2 to FFP in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If a flow feels complex, assume the constraints are wrong and simplify until the
 ### Clone & install
 ```bash
 git clone <REPO_URL>
-cd feralfile-app
+cd ff-app
 flutter pub get
 ```
 


### PR DESCRIPTION
## Summary
- update FF2 references to FFP in product overview and pairing section
- keep documentation aligned with the new device name

## Testing
- not run (docs-only change)