### PR TITLE
Refactor search filter UI and seed sync loading components

### DIFF
--- a/lib/ui/screens/tabs/channels_tab_page.dart
+++ b/lib/ui/screens/tabs/channels_tab_page.dart
@@ -9,9 +9,8 @@ import 'package:app/domain/models/playlist_item.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:app/widgets/channels/channel_list_row.dart';
 import 'package:app/widgets/channels/channel_section.dart';
-import 'package:app/widgets/delayed_loading.dart';
 import 'package:app/widgets/error_view.dart';
-import 'package:app/widgets/loading_view.dart';
+import 'package:app/widgets/seed_sync_loading_indicator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -94,16 +93,8 @@ class ChannelsTabPageState extends ConsumerState<ChannelsTabPage>
 
     final seedState = ref.watch(seedDownloadProvider);
     if (seedState.status == SeedDownloadStatus.syncing) {
-      return Center(
-        child: DelayedLoadingGate(
-          isLoading: true,
-          child: LoadingWidget(
-            backgroundColor: Colors.transparent,
-            text:
-                'Updating art library... '
-                '${((seedState.progress ?? 0) * 100).round()}%',
-          ),
-        ),
+      return SeedSyncLoadingIndicator(
+        progress: seedState.progress,
       );
     }
     if (seedState.status == SeedDownloadStatus.error) {

--- a/lib/ui/screens/tabs/playlists_tab_page.dart
+++ b/lib/ui/screens/tabs/playlists_tab_page.dart
@@ -7,11 +7,10 @@ import 'package:app/app/routing/routes.dart';
 import 'package:app/design/layout_constants.dart';
 import 'package:app/domain/models/playlist.dart';
 import 'package:app/theme/app_color.dart';
-import 'package:app/widgets/delayed_loading.dart';
 import 'package:app/widgets/error_view.dart';
-import 'package:app/widgets/loading_view.dart';
 import 'package:app/widgets/playlist/playlist_header_with_collection_state.dart';
 import 'package:app/widgets/playlist/playlist_section.dart';
+import 'package:app/widgets/seed_sync_loading_indicator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -104,16 +103,8 @@ class PlaylistsTabPageState extends ConsumerState<PlaylistsTabPage>
 
     final seedState = ref.watch(seedDownloadProvider);
     if (seedState.status == SeedDownloadStatus.syncing) {
-      return Center(
-        child: DelayedLoadingGate(
-          isLoading: true,
-          child: LoadingWidget(
-            backgroundColor: Colors.transparent,
-            text:
-                'Updating art library... '
-                '${((seedState.progress ?? 0) * 100).round()}%',
-          ),
-        ),
+      return SeedSyncLoadingIndicator(
+        progress: seedState.progress,
       );
     }
     if (seedState.status == SeedDownloadStatus.error) {

--- a/lib/ui/screens/tabs/search/widgets/filter_bar.dart
+++ b/lib/ui/screens/tabs/search/widgets/filter_bar.dart
@@ -53,7 +53,7 @@ class FilterBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final typeOptions = availableTypes.toList();
+    final typeOptions = availableTypes.toList(growable: false);
     if (typeOptions.isEmpty) {
       return const SizedBox.shrink();
     }
@@ -67,15 +67,13 @@ class FilterBar extends StatelessWidget {
     const sourceOptions = SearchSourceFilter.values;
     const dateOptions = SearchDateFilter.values;
     final textStyle = AppTypography.body(context).white;
-    final currentSortLabel = sortOrder.label;
-    final currentSourceLabel = sourceFilter.label;
-    final currentDateLabel = dateFilter.label;
     final pillHeight = LayoutConstants.buttonHeightDefault;
     final pillPadding = EdgeInsets.symmetric(
       horizontal: LayoutConstants.space3,
       vertical: LayoutConstants.space2,
     );
     final iconSize = LayoutConstants.iconSizeDefault;
+
     final sortControlWidth = _menuControlWidth(
       context,
       labels: sortOptions.map((option) => option.label).toList(growable: false),
@@ -103,22 +101,6 @@ class FilterBar extends StatelessWidget {
       iconGap: LayoutConstants.space1,
     );
 
-    Widget staticLabel(String label) {
-      return SizedBox(
-        height: pillHeight,
-        child: Align(
-          alignment: Alignment.center,
-          child: Padding(
-            padding: pillPadding,
-            child: Text(
-              label,
-              style: AppTypography.body(context).white,
-            ),
-          ),
-        ),
-      );
-    }
-
     return Padding(
       padding: EdgeInsets.symmetric(
         vertical: LayoutConstants.space3,
@@ -133,170 +115,76 @@ class FilterBar extends StatelessWidget {
               ...typeOptions.map(
                 (type) => Padding(
                   padding: EdgeInsets.only(right: LayoutConstants.space2),
-                  child: TextButton(
-                    onPressed: () {
-                      if (type != selectedFilterType) {
-                        onFilterTypeChanged(type);
-                      }
-                    },
-                    style: TextButton.styleFrom(
-                      padding: pillPadding,
-                      minimumSize: Size(0, pillHeight),
-                      backgroundColor: type == currentType
-                          ? Colors.white.withValues(alpha: 0.16)
-                          : Colors.transparent,
-                    ),
-                    child: Text(
-                      type.label,
-                      style: AppTypography.body(context).white,
-                    ),
+                  child: _TypeFilterPill(
+                    type: type,
+                    isSelected: type == currentType,
+                    height: pillHeight,
+                    padding: pillPadding,
+                    textStyle: textStyle,
+                    onSelected: onFilterTypeChanged,
                   ),
                 ),
               )
             else
-              staticLabel(currentType.label),
+              _StaticFilterLabel(
+                label: currentType.label,
+                height: pillHeight,
+                padding: pillPadding,
+                textStyle: textStyle,
+              ),
             SizedBox(width: LayoutConstants.space1),
             if (sortOptions.length > 1)
-              TextButton(
-                onPressed: () async {
-                  final optionItems = sortOptions
-                      .map(
-                        (order) => OptionItem(
-                          title: order.label,
-                          onTap: () async {
-                            Navigator.of(context).pop();
-                            if (order != sortOrder) {
-                              onSortOrderChanged(order);
-                            }
-                          },
-                        ),
-                      )
-                      .toList();
-
-                  await UIHelper.showCenterMenu(context, options: optionItems);
-                },
-                style: TextButton.styleFrom(
-                  padding: pillPadding,
-                  minimumSize: Size(0, pillHeight),
-                ),
-                child: SizedBox(
-                  width: sortControlWidth,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Flexible(
-                        child: Text(
-                          currentSortLabel,
-                          style: textStyle,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                      SizedBox(width: LayoutConstants.space1),
-                      Icon(
-                        Icons.expand_more,
-                        size: iconSize,
-                        color: Colors.white,
-                      ),
-                    ],
-                  ),
-                ),
+              _FacetMenuButton<SearchSortOrder>(
+                selected: sortOrder,
+                options: sortOptions,
+                optionLabel: (option) => option.label,
+                onChanged: onSortOrderChanged,
+                width: sortControlWidth,
+                height: pillHeight,
+                padding: pillPadding,
+                textStyle: textStyle,
+                iconSize: iconSize,
               ),
             SizedBox(width: LayoutConstants.space2),
             if (sourceOptions.length > 1)
-              TextButton(
-                onPressed: () async {
-                  final optionItems = sourceOptions
-                      .map(
-                        (source) => OptionItem(
-                          title: source.label,
-                          onTap: () async {
-                            Navigator.of(context).pop();
-                            if (source != sourceFilter) {
-                              onSourceFilterChanged(source);
-                            }
-                          },
-                        ),
-                      )
-                      .toList();
-
-                  await UIHelper.showCenterMenu(context, options: optionItems);
-                },
-                style: TextButton.styleFrom(
-                  padding: pillPadding,
-                  minimumSize: Size(0, pillHeight),
-                ),
-                child: SizedBox(
-                  width: sourceControlWidth,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Flexible(
-                        child: Text(
-                          currentSourceLabel,
-                          style: textStyle,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                      SizedBox(width: LayoutConstants.space1),
-                      Icon(
-                        Icons.expand_more,
-                        size: iconSize,
-                        color: Colors.white,
-                      ),
-                    ],
-                  ),
-                ),
+              _FacetMenuButton<SearchSourceFilter>(
+                selected: sourceFilter,
+                options: sourceOptions,
+                optionLabel: (option) => option.label,
+                onChanged: onSourceFilterChanged,
+                width: sourceControlWidth,
+                height: pillHeight,
+                padding: pillPadding,
+                textStyle: textStyle,
+                iconSize: iconSize,
               )
             else
-              staticLabel(currentSourceLabel),
+              _StaticFilterLabel(
+                label: sourceFilter.label,
+                height: pillHeight,
+                padding: pillPadding,
+                textStyle: textStyle,
+              ),
             SizedBox(width: LayoutConstants.space2),
             if (dateOptions.length > 1)
-              TextButton(
-                onPressed: () async {
-                  final optionItems = dateOptions
-                      .map(
-                        (date) => OptionItem(
-                          title: date.label,
-                          onTap: () async {
-                            Navigator.of(context).pop();
-                            if (date != dateFilter) {
-                              onDateFilterChanged(date);
-                            }
-                          },
-                        ),
-                      )
-                      .toList();
-
-                  await UIHelper.showCenterMenu(context, options: optionItems);
-                },
-                style: TextButton.styleFrom(
-                  padding: pillPadding,
-                  minimumSize: Size(0, pillHeight),
-                ),
-                child: SizedBox(
-                  width: dateControlWidth,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Flexible(
-                        child: Text(
-                          currentDateLabel,
-                          style: textStyle,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                      SizedBox(width: LayoutConstants.space1),
-                      Icon(
-                        Icons.expand_more,
-                        size: iconSize,
-                        color: Colors.white,
-                      ),
-                    ],
-                  ),
-                ),
+              _FacetMenuButton<SearchDateFilter>(
+                selected: dateFilter,
+                options: dateOptions,
+                optionLabel: (option) => option.label,
+                onChanged: onDateFilterChanged,
+                width: dateControlWidth,
+                height: pillHeight,
+                padding: pillPadding,
+                textStyle: textStyle,
+                iconSize: iconSize,
               )
             else
-              staticLabel(currentDateLabel),
+              _StaticFilterLabel(
+                label: dateFilter.label,
+                height: pillHeight,
+                padding: pillPadding,
+                textStyle: textStyle,
+              ),
           ],
         ),
       ),
@@ -335,5 +223,148 @@ class FilterBar extends StatelessWidget {
       textDirection: Directionality.of(context),
     )..layout();
     return painter.width;
+  }
+}
+
+class _TypeFilterPill extends StatelessWidget {
+  const _TypeFilterPill({
+    required this.type,
+    required this.isSelected,
+    required this.height,
+    required this.padding,
+    required this.textStyle,
+    required this.onSelected,
+  });
+
+  final SearchFilterType type;
+  final bool isSelected;
+  final double height;
+  final EdgeInsets padding;
+  final TextStyle textStyle;
+  final ValueChanged<SearchFilterType> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: () {
+        if (!isSelected) {
+          onSelected(type);
+        }
+      },
+      style: TextButton.styleFrom(
+        padding: padding,
+        minimumSize: Size(0, height),
+        backgroundColor: isSelected
+            ? Colors.white.withValues(alpha: 0.16)
+            : Colors.transparent,
+      ),
+      child: Text(
+        type.label,
+        style: textStyle,
+      ),
+    );
+  }
+}
+
+class _StaticFilterLabel extends StatelessWidget {
+  const _StaticFilterLabel({
+    required this.label,
+    required this.height,
+    required this.padding,
+    required this.textStyle,
+  });
+
+  final String label;
+  final double height;
+  final EdgeInsets padding;
+  final TextStyle textStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      child: Align(
+        alignment: Alignment.center,
+        child: Padding(
+          padding: padding,
+          child: Text(
+            label,
+            style: textStyle,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FacetMenuButton<T> extends StatelessWidget {
+  const _FacetMenuButton({
+    required this.selected,
+    required this.options,
+    required this.optionLabel,
+    required this.onChanged,
+    required this.width,
+    required this.height,
+    required this.padding,
+    required this.textStyle,
+    required this.iconSize,
+  });
+
+  final T selected;
+  final List<T> options;
+  final String Function(T) optionLabel;
+  final ValueChanged<T> onChanged;
+  final double width;
+  final double height;
+  final EdgeInsets padding;
+  final TextStyle textStyle;
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: () async {
+        final optionItems = options
+            .map(
+              (option) => OptionItem(
+                title: optionLabel(option),
+                onTap: () async {
+                  Navigator.of(context).pop();
+                  if (option != selected) {
+                    onChanged(option);
+                  }
+                },
+              ),
+            )
+            .toList();
+
+        await UIHelper.showCenterMenu(context, options: optionItems);
+      },
+      style: TextButton.styleFrom(
+        padding: padding,
+        minimumSize: Size(0, height),
+      ),
+      child: SizedBox(
+        width: width,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Flexible(
+              child: Text(
+                optionLabel(selected),
+                style: textStyle,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            SizedBox(width: LayoutConstants.space1),
+            Icon(
+              Icons.expand_more,
+              size: iconSize,
+              color: Colors.white,
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/ui/screens/tabs/works_tab_page.dart
+++ b/lib/ui/screens/tabs/works_tab_page.dart
@@ -6,10 +6,9 @@ import 'package:app/app/routing/routes.dart';
 import 'package:app/design/layout_constants.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:app/ui/ui_helper.dart';
-import 'package:app/widgets/delayed_loading.dart';
 import 'package:app/widgets/error_view.dart';
 import 'package:app/widgets/load_more_indicator.dart';
-import 'package:app/widgets/loading_view.dart';
+import 'package:app/widgets/seed_sync_loading_indicator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -90,16 +89,8 @@ class WorksTabPageState extends ConsumerState<WorksTabPage>
 
     final seedState = ref.watch(seedDownloadProvider);
     if (seedState.status == SeedDownloadStatus.syncing) {
-      return Center(
-        child: DelayedLoadingGate(
-          isLoading: true,
-          child: LoadingWidget(
-            backgroundColor: Colors.transparent,
-            text:
-                'Updating art library... '
-                '${((seedState.progress ?? 0) * 100).round()}%',
-          ),
-        ),
+      return SeedSyncLoadingIndicator(
+        progress: seedState.progress,
       );
     }
     if (seedState.status == SeedDownloadStatus.error) {

--- a/lib/widgets/seed_sync_loading_indicator.dart
+++ b/lib/widgets/seed_sync_loading_indicator.dart
@@ -1,0 +1,29 @@
+import 'package:app/widgets/delayed_loading.dart';
+import 'package:app/widgets/loading_view.dart';
+import 'package:flutter/material.dart';
+
+/// Loading indicator shown while seed data is downloading.
+class SeedSyncLoadingIndicator extends StatelessWidget {
+  /// Creates a [SeedSyncLoadingIndicator].
+  const SeedSyncLoadingIndicator({
+    required this.progress,
+    super.key,
+  });
+
+  /// Seed download progress in the 0.0 to 1.0 range.
+  final double? progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final progressPercent = ((progress ?? 0) * 100).round();
+    return Center(
+      child: DelayedLoadingGate(
+        isLoading: true,
+        child: LoadingWidget(
+          backgroundColor: Colors.transparent,
+          text: 'Updating art library... $progressPercent%',
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extracts shared seed-sync loading presentation into a dedicated `SeedSyncLoadingIndicator` widget and reuses it across channels, playlists, and works tabs
- refactors `FilterBar` internals into focused private widgets (`_TypeFilterPill`, `_FacetMenuButton`, `_StaticFilterLabel`) to reduce duplication and improve readability without changing behavior
- keeps existing user-facing copy and filter interactions intact while reducing maintenance surface for future updates

## Tests
- flutter test test/unit/ui/screens/tabs/search/search_filtering_test.dart test/unit/ui/screens/tabs/search/search_tab_page_widget_test.dart
- Android compile validation: `./gradlew :app:compileDevelopmentDebugJavaWithJavac`