### PR TITLE
fix(database): optimize DP1 playlist query for FF-APP-4

### DIFF
--- a/lib/infra/database/app_database.dart
+++ b/lib/infra/database/app_database.dart
@@ -89,6 +89,11 @@ class AppDatabase extends _$AppDatabase {
     );
 
     await customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_playlists_type_channel_created '
+      'ON playlists(type, channel_id, created_at_us)',
+    );
+
+    await customStatement(
       'CREATE INDEX IF NOT EXISTS idx_items_kind_updated '
       'ON items(kind, updated_at_us)',
     );
@@ -517,29 +522,28 @@ class AppDatabase extends _$AppDatabase {
   /// - 0 = DP1
   /// - 1 = address-based
   Future<List<PlaylistData>> getAllPlaylists({PlaylistType? type}) async {
-    const publisherOrderExpr = CustomExpression<int>(
+    final variables = <Variable<Object>>[];
+    final whereClause =
+        type == null
+            ? ''
+            : (() {
+              variables.add(Variable<int>(type.value));
+              return 'WHERE p.type = ?';
+            })();
+
+    final result = await customSelect(
       '''
-      COALESCE(
-        (
-          SELECT c.publisher_id
-          FROM channels c
-          WHERE c.id = playlists.channel_id
-        ),
-        2147483647
-      )
+      SELECT p.*
+      FROM playlists p
+      LEFT JOIN channels c ON c.id = p.channel_id
+      $whereClause
+      ORDER BY COALESCE(c.publisher_id, 2147483647) ASC, p.created_at_us ASC
       ''',
-    );
-    final query = select(playlists);
-    if (type != null) {
-      query.where((t) => t.type.equals(type.value));
-    }
+      variables: variables,
+      readsFrom: {playlists, channels},
+    ).map((row) => playlists.map(row.data)).get();
 
-    query.orderBy([
-      (t) => OrderingTerm.asc(publisherOrderExpr),
-      (t) => OrderingTerm.asc(t.createdAtUs),
-    ]);
-
-    return query.get();
+    return result;
   }
 
   /// Get address-based playlists.


### PR DESCRIPTION
### Motivation
- Address Sentry issue FF-APP-4 (https://bitmark-inc.sentry.io/issues/FF-APP-4/) reporting `Slow getAllPlaylists(type: dp1): 41425ms (returned: 480)` by removing a per-row correlated subquery that causes poor scaling for DP1 playlist reads.  
- Root cause: the previous ordering used a correlated `SELECT c.publisher_id FROM channels ...` per row which is expensive as playlist volume grows.  
- Goal: make curated (DP1) playlist reads fast and index-friendly while preserving the same ordering semantics used by callers.

### Description
- Replaced the correlated subquery ordering with a single `SELECT p.* FROM playlists p LEFT JOIN channels c ON c.id = p.channel_id ORDER BY COALESCE(c.publisher_id, 2147483647) ASC, p.created_at_us ASC` implemented via `customSelect` and mapped back to `PlaylistData` rows.  
- Added a composite index `idx_playlists_type_channel_created` on `(type, channel_id, created_at_us)` to support the filtered/sorted DP1 access pattern.  
- Kept compatibility with existing callers by preserving the same ordering semantics and handling optional `type` via a bound variable for the `WHERE` clause.  

### Testing
- Ran focused unit tests: `flutter test test/unit/infra/database/database_service_test.dart` and all tests in that file passed.  
- Ran the repository-level post-implementation checks via `scripts/agent-helpers/post-implementation-checks HEAD` which completed with no lint/test failures for the changed files.  
- Attempted `flutter build apk --debug` for final verification but it failed in the container due to a missing Android SDK (environment limitation); build failure is environmental and not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac14fcdcd48322909f2464579586d5)