### PR TITLE
fix(nft-rendering): prevent iOS webview callbacks from crashing after dispose

### DIFF
--- a/lib/nft_rendering/feralfile_webview.dart
+++ b/lib/nft_rendering/feralfile_webview.dart
@@ -56,6 +56,9 @@ class FeralFileWebview extends StatefulWidget {
 }
 
 class FeralFileWebviewState extends State<FeralFileWebview> {
+  static final Set<WebViewController> _retainedControllers =
+      <WebViewController>{};
+
   late WebViewController _webViewController;
   double _loadingProgress = 0;
 
@@ -118,9 +121,19 @@ class FeralFileWebviewState extends State<FeralFileWebview> {
 
   @override
   void dispose() {
-    super.dispose();
+    _retainControllerForDeferredNativeCallbacks(_webViewController);
     // webViewController dispose itself
     _webViewController.onDispose();
+    super.dispose();
+  }
+
+  void _retainControllerForDeferredNativeCallbacks(
+    WebViewController controller,
+  ) {
+    _retainedControllers.add(controller);
+    Future<void>.delayed(const Duration(seconds: 5), () {
+      _retainedControllers.remove(controller);
+    });
   }
 
   @override
@@ -162,13 +175,11 @@ class FeralFileWebviewState extends State<FeralFileWebview> {
       })
       ..setNavigationDelegate(
         NavigationDelegate(
-          onProgress: (progress) {
-            setState(() {
-              _loadingProgress = progress / 100;
-            });
-          },
           onPageStarted: (url) async {
             _log.info('Page started loading: $url');
+            if (!mounted) {
+              return;
+            }
             setState(() {
               _loadingProgress = 0.0;
             });
@@ -176,6 +187,9 @@ class FeralFileWebviewState extends State<FeralFileWebview> {
             widget.onStarted?.call(webViewController);
           },
           onPageFinished: (url) async {
+            if (!mounted) {
+              return;
+            }
             setState(() {
               _loadingProgress = 1.0;
             });
@@ -196,9 +210,6 @@ class FeralFileWebviewState extends State<FeralFileWebview> {
           onNavigationRequest: (request) async {
             _log.info('Navigation request to: ${request.url}');
             return NavigationDecision.navigate;
-          },
-          onUrlChange: (url) {
-            _log.info('Url changed: $url');
           },
         ),
       );


### PR DESCRIPTION
### Motivation
- Fix Sentry crashes FF-APP-8 and FF-APP-9 caused by iOS WebKit callbacks hitting null/ disposed widget state during WebView teardown. 
- Reduce race conditions between native WebKit callbacks and Flutter widget lifecycle when preview WebViews are torn down.

### Description
- Keep a short-lived strong reference to disposed controllers by adding `static final Set<WebViewController> _retainedControllers` and a `_retainControllerForDeferredNativeCallbacks` helper that holds the controller for 5 seconds. 
- Guard lifecycle callbacks with `if (!mounted) return;` before calling `setState` in `onPageStarted` and `onPageFinished` to avoid post-dispose state updates. 
- Stop registering non-essential `NavigationDelegate` callbacks (`onProgress` and `onUrlChange`) to reduce callback surface that can race during teardown. 
- Adjust dispose ordering to retain controller, call `onDispose()`, then call `super.dispose()`.

### Testing
- Retrieved and inspected issue events with the project helper via `scripts/agent-helpers/sentry_issue_report.sh --org-name bitmark-inc --project-id ff-app --issue-id FF-APP-8` and `FF-APP-9`, which confirmed the WebKit callback stack traces. 
- Ran post-implementation checks with `scripts/agent-helpers/post-implementation-checks HEAD` which produced a clean report for the changed file(s). 
- Attempted `flutter build` but it was not possible in this environment because `flutter` is not available (`command not found`). 

Sentry issue links: https://bitmark-inc.sentry.io/issues/FF-APP-8/ and https://bitmark-inc.sentry.io/issues/FF-APP-9/

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac3ab6269c8322862bc775748f25cf)