### PR TITLE
fix(now-displaying): hide bar when modal or drawer is shown

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -61,7 +61,6 @@ class App extends ConsumerWidget {
         return _AppStartupBootstrap(
           router: router,
           child: NowDisplayingVisibilitySync(
-            router: router,
             child: Stack(
               children: [
                 child ?? const SizedBox.shrink(),

--- a/lib/app/now_displaying/now_displaying_visibility_config.dart
+++ b/lib/app/now_displaying/now_displaying_visibility_config.dart
@@ -1,0 +1,50 @@
+import 'package:app/app/routing/routes.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// Route paths where now displaying must not be shown.
+///
+/// This list mirrors the legacy app behavior for screens that suppress
+/// the floating now displaying bar.
+const routesThatHideNowDisplayingBar = <String>[
+  Routes.onboarding,
+  Routes.onboardingIntroducePage,
+  Routes.onboardingAddAddressPage,
+  Routes.onboardingSetupFf1Page,
+  Routes.ff1DevicePickerPage,
+  Routes.connectFF1Page,
+  Routes.addAddressPage,
+  Routes.addAliasPage,
+  Routes.startSetupFf1,
+  Routes.scanWifiNetworks,
+  Routes.enterWifiPassword,
+  Routes.deviceConfiguration,
+  Routes.ff1Updating,
+  Routes.nowDisplaying,
+  Routes.keyboardControl,
+  Routes.releaseNotes,
+  Routes.releaseNoteDetail,
+  Routes.settings,
+  Routes.settingsEula,
+  Routes.settingsPrivacy,
+  Routes.scanQrPage,
+];
+
+/// Route type checks that hide the Now Displaying bar (modal/drawer overlays).
+///
+/// Add new route types here when using showModalBottomSheet, showCupertinoModalPopup,
+/// showDialog, etc.
+bool _isModalBottomSheet(Route<dynamic> r) => r is ModalBottomSheetRoute;
+
+bool _isCupertinoModalPopup(Route<dynamic> r) => r is CupertinoModalPopupRoute;
+
+final _routeTypeChecksThatHideNowDisplayingBar = <bool Function(Route<dynamic>)>[
+  _isModalBottomSheet,
+  _isCupertinoModalPopup,
+];
+
+/// Returns true when [route] is a modal/drawer that should hide the Now Displaying bar.
+bool isRouteThatHidesNowDisplaying(Route<dynamic>? route) {
+  if (route == null) return false;
+  return _routeTypeChecksThatHideNowDisplayingBar.any((check) => check(route));
+}

--- a/lib/app/now_displaying/now_displaying_visibility_sync.dart
+++ b/lib/app/now_displaying/now_displaying_visibility_sync.dart
@@ -1,47 +1,26 @@
 import 'dart:async';
 
+import 'package:app/app/now_displaying/now_displaying_visibility_config.dart';
+import 'package:app/app/providers/current_route_provider.dart';
 import 'package:app/app/providers/now_displaying_visibility_provider.dart';
-import 'package:app/app/routing/routes.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-
-/// Route paths where now displaying must not be shown.
-///
-/// This list mirrors the legacy app behavior for screens that suppress
-/// the floating now displaying bar.
-const routesThatHideNowDisplayingBar = <String>[
-  Routes.onboarding,
-  Routes.onboardingIntroducePage,
-  Routes.onboardingAddAddressPage,
-  Routes.onboardingSetupFf1Page,
-  Routes.ff1DevicePickerPage,
-  Routes.connectFF1Page,
-  Routes.addAddressPage,
-  Routes.addAliasPage,
-  Routes.startSetupFf1,
-  Routes.scanWifiNetworks,
-  Routes.enterWifiPassword,
-  Routes.deviceConfiguration,
-  Routes.ff1Updating,
-  Routes.nowDisplaying,
-  Routes.keyboardControl,
-  Routes.releaseNotes,
-  Routes.releaseNoteDetail,
-  Routes.settings,
-  Routes.settingsEula,
-  Routes.settingsPrivacy,
-  Routes.scanQrPage,
-];
 
 /// Minimum scrollable content extent required before scroll should toggle
 /// now displaying visibility.
 const nowDisplayingScrollToggleThreshold = 100.0;
 
-/// Returns true when the now displaying bar should be visible for [path].
-bool shouldShowNowDisplayingForPath(String path) {
+/// Returns true when the now displaying bar should be visible for [routeState].
+///
+/// Route (modal/drawer) has higher priority than path: when modal/drawer
+/// is shown, returns false regardless of path.
+bool shouldShowNowDisplayingForRoute(AppRouteState routeState) {
+  if (routeState.hasModalOrDrawer) {
+    return false;
+  }
+  final path = routeState.path;
   for (final hidden in routesThatHideNowDisplayingBar) {
     if (path == hidden || path.startsWith('$hidden/')) {
       return false;
@@ -61,21 +40,18 @@ bool shouldReactToNowDisplayingScroll({
 
 /// Syncs scroll + keyboard visibility into [nowDisplayingVisibilityProvider].
 ///
-/// This keeps the provider pure: it exposes update methods; this widget
-/// is responsible for wiring platform/UI signals into those methods.
+/// Route visibility (path + modal/drawer) is driven by [currentRouteProvider],
+/// which is updated by [AppRouteObserver]. This widget only wires scroll and
+/// keyboard signals.
 class NowDisplayingVisibilitySync extends ConsumerStatefulWidget {
   /// Creates a [NowDisplayingVisibilitySync].
   const NowDisplayingVisibilitySync({
     required this.child,
-    required this.router,
     super.key,
   });
 
   /// Subtree that sends scroll notifications for visibility sync.
   final Widget child;
-
-  /// Router used to map current path into show/hide visibility.
-  final GoRouter router;
 
   @override
   ConsumerState<NowDisplayingVisibilitySync> createState() =>
@@ -98,41 +74,22 @@ class _NowDisplayingVisibilitySyncState
       notifier.setKeyboardVisibility,
     );
 
-    // Sync route/location visibility from go_router.
-    widget.router.routeInformationProvider.addListener(_handleRouteChanged);
-
     // Riverpod forbids modifying providers while the widget tree is building.
-    // Defer the "initial sync" writes until after the first frame.
+    // Defer the initial keyboard sync until after the first frame.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) {
         return;
       }
-
       ref
           .read(nowDisplayingVisibilityProvider.notifier)
           .setKeyboardVisibility(_keyboardVisibilityController.isVisible);
-      _handleRouteChanged();
     });
   }
 
   @override
   void dispose() {
-    widget.router.routeInformationProvider.removeListener(_handleRouteChanged);
     unawaited(_keyboardSubscription.cancel());
     super.dispose();
-  }
-
-  void _handleRouteChanged() {
-    final routeInfo = widget.router.routeInformationProvider.value;
-    final path = routeInfo.uri.path.isEmpty ? Routes.home : routeInfo.uri.path;
-
-    ref
-        .read(nowDisplayingVisibilityProvider.notifier)
-        .setShouldShowNowDisplaying(_shouldShowForPath(path));
-  }
-
-  bool _shouldShowForPath(String path) {
-    return shouldShowNowDisplayingForPath(path);
   }
 
   bool _onScrollNotification(UserScrollNotification notification) {

--- a/lib/app/providers/current_route_provider.dart
+++ b/lib/app/providers/current_route_provider.dart
@@ -1,0 +1,62 @@
+import 'package:app/app/now_displaying/now_displaying_visibility_config.dart';
+import 'package:app/app/routing/routes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Current route state in the app, including path and top route (modal/drawer).
+///
+/// Single source of truth for route state. Updated by [AppRouteObserver]
+/// on Navigator push/pop/replace.
+@immutable
+class AppRouteState {
+  const AppRouteState({
+    required this.path,
+    required this.currentRoute,
+  });
+
+  /// Current route path from Go Router (e.g. [Routes.home], [Routes.playlists]).
+  final String path;
+
+  /// Top route on the Navigator stack. Null when no route.
+  final Route<dynamic>? currentRoute;
+
+  /// True when the top route is a modal/drawer that hides the Now Displaying bar.
+  ///
+  /// Uses [isRouteThatHidesNowDisplaying] from config.
+  bool get hasModalOrDrawer =>
+      isRouteThatHidesNowDisplaying(currentRoute);
+
+  AppRouteState copyWith({
+    String? path,
+    Route<dynamic>? currentRoute,
+  }) {
+    return AppRouteState(
+      path: path ?? this.path,
+      currentRoute: currentRoute ?? this.currentRoute,
+    );
+  }
+}
+
+/// Provider for current route state. Updated by [AppRouteObserver].
+final currentRouteProvider =
+    NotifierProvider<CurrentRouteNotifier, AppRouteState>(
+      CurrentRouteNotifier.new,
+    );
+
+class CurrentRouteNotifier extends Notifier<AppRouteState> {
+  @override
+  AppRouteState build() {
+    return const AppRouteState(
+      path: Routes.home,
+      currentRoute: null,
+    );
+  }
+
+  /// Updates the current route state. Called by [AppRouteObserver].
+  void update(String path, Route<dynamic>? currentRoute) {
+    state = AppRouteState(
+      path: path.isEmpty ? Routes.home : path,
+      currentRoute: currentRoute,
+    );
+  }
+}

--- a/lib/app/providers/now_displaying_visibility_provider.dart
+++ b/lib/app/providers/now_displaying_visibility_provider.dart
@@ -1,3 +1,5 @@
+import 'package:app/app/now_displaying/now_displaying_visibility_sync.dart';
+import 'package:app/app/providers/current_route_provider.dart';
 import 'package:app/app/providers/ff1_bluetooth_device_providers.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -91,7 +93,30 @@ class NowDisplayingVisibilityNotifier
       });
     });
 
-    return const NowDisplayingVisibilityState.initial();
+    // Listen to current route (path + modal/drawer) from AppRouteObserver.
+    // Route (modal/drawer) has higher priority than path: when modal/drawer
+    // is shown, hide regardless of path.
+    ref.listen(currentRouteProvider, (previous, next) {
+      _applyRouteState(next);
+    });
+
+    // Initial sync from current route state
+    final routeState = ref.read(currentRouteProvider);
+    return _initialStateFromRoute(routeState);
+  }
+
+  void _applyRouteState(AppRouteState routeState) {
+    state = state.copyWith(
+      shouldShowNowDisplaying: shouldShowNowDisplayingForRoute(routeState),
+      bottomSheetVisibility: routeState.hasModalOrDrawer,
+    );
+  }
+
+  NowDisplayingVisibilityState _initialStateFromRoute(AppRouteState routeState) {
+    return NowDisplayingVisibilityState.initial().copyWith(
+      shouldShowNowDisplaying: shouldShowNowDisplayingForRoute(routeState),
+      bottomSheetVisibility: routeState.hasModalOrDrawer,
+    );
   }
 
   void setShouldShowNowDisplaying(bool value) {

--- a/lib/app/routing/app_route_observer.dart
+++ b/lib/app/routing/app_route_observer.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// NavigatorObserver that updates current route state on push/pop/replace.
+///
+/// Calls [onRouteChanged] with the current path (from Go Router) and the top
+/// route on the Navigator stack. Used to drive [currentRouteProvider].
+class AppRouteObserver extends NavigatorObserver {
+  /// Creates an [AppRouteObserver].
+  AppRouteObserver({
+    required this.onRouteChanged,
+  });
+
+  /// Called when the route stack changes (push, pop, replace).
+  ///
+  /// [path] is from [GoRouter.routerDelegate.state.matchedLocation].
+  /// [currentRoute] is the top route on the stack (null when stack is empty).
+  final void Function(String path, Route<dynamic>? currentRoute) onRouteChanged;
+
+  void _notify(Route<dynamic>? topRoute) {
+    final nav = navigator;
+    if (nav == null) return;
+
+    final context = nav.context;
+    String path;
+    try {
+      final router = GoRouter.of(context);
+      // Use state.matchedLocation for full path; currentConfiguration.uri.path
+      // can return "/" for nested/ShellRoute structures.
+      path = router.routerDelegate.state.matchedLocation;
+    } on Object {
+      path = '/';
+    }
+
+    onRouteChanged(path.isEmpty ? '/' : path, topRoute);
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    _notify(route);
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    _notify(previousRoute);
+  }
+
+  @override
+  void didReplace({
+    Route<dynamic>? newRoute,
+    Route<dynamic>? oldRoute,
+  }) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    _notify(newRoute);
+  }
+}

--- a/lib/app/routing/router_provider.dart
+++ b/lib/app/routing/router_provider.dart
@@ -1,5 +1,7 @@
+import 'package:app/app/providers/current_route_provider.dart';
 import 'package:app/app/route_observer.dart';
 import 'package:app/app/routing/app_navigator_key.dart';
+import 'package:app/app/routing/app_route_observer.dart';
 import 'package:app/app/routing/page_transitions.dart';
 import 'package:app/app/routing/routes.dart';
 import 'package:app/infra/services/release_notes_service.dart';
@@ -51,13 +53,24 @@ routerProvider = Provider.family<GoRouter, String>((
     navigatorKey: appNavigatorKey,
     debugLogDiagnostics: true,
     initialLocation: initialLocation,
-    observers: [routeObserver],
+    observers: [
+      routeObserver,
+      AppRouteObserver(
+        onRouteChanged: (path, currentRoute) {
+          // Defer to avoid "modify provider while building" when observer
+          // fires during Navigator restoreState/didChangeDependencies.
+          Future.microtask(() {
+            ref.read(currentRouteProvider.notifier).update(path, currentRoute);
+          });
+        },
+      ),
+    ],
     // Deep links like device_connect are handled by DeeplinkHandler via
     // app_links, not by GoRouter route matching. When Flutter's
-    // RouteInformationProvider also forwards the same URL to GoRouter (e.g.
-    // on a cold-start from a universal link), we redirect to the initial
-    // location so GoRouter doesn't throw and DeeplinkHandler still processes
-    // the link correctly.
+    // RouteInformationProvider also forwards the same URL to GoRouter
+    // (e.g. on a cold-start from a universal link), we redirect to the
+    // initial location so GoRouter doesn't throw and DeeplinkHandler
+    // still processes the link correctly.
     redirect: (context, state) {
       final path = state.uri.path;
       if (path.startsWith('/device_connect')) {
@@ -65,8 +78,9 @@ routerProvider = Provider.family<GoRouter, String>((
       }
       return null;
     },
-    // Safety net: redirect to initialLocation for any URL that doesn't match
-    // a registered route (e.g. future deep link schemes not yet known to GoRouter).
+    // Safety net: redirect to initialLocation for any URL that doesn't
+    // match a registered route (e.g. future deep link schemes not yet
+    // known to GoRouter).
     onException: (context, state, router) {
       _log.warning('No route found for: ${state.uri}; redirecting to $initialLocation');
       router.go(initialLocation);

--- a/test/unit/app/now_displaying/now_displaying_visibility_sync_test.dart
+++ b/test/unit/app/now_displaying/now_displaying_visibility_sync_test.dart
@@ -1,32 +1,89 @@
+import 'package:app/app/now_displaying/now_displaying_visibility_config.dart';
 import 'package:app/app/now_displaying/now_displaying_visibility_sync.dart';
+import 'package:app/app/providers/current_route_provider.dart';
 import 'package:app/app/routing/routes.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('shouldShowNowDisplayingForPath', () {
+  group('shouldShowNowDisplayingForRoute', () {
     test('returns false for hidden routes from legacy behavior', () {
       for (final path in routesThatHideNowDisplayingBar) {
-        expect(shouldShowNowDisplayingForPath(path), isFalse);
+        expect(
+          shouldShowNowDisplayingForRoute(
+            AppRouteState(path: path, currentRoute: null),
+          ),
+          isFalse,
+        );
       }
     });
 
     test('returns false for children of hidden routes', () {
       expect(
-        shouldShowNowDisplayingForPath('${Routes.settings}/nested'),
+        shouldShowNowDisplayingForRoute(
+          AppRouteState(
+            path: '${Routes.settings}/nested',
+            currentRoute: null,
+          ),
+        ),
         isFalse,
       );
       expect(
-        shouldShowNowDisplayingForPath('${Routes.onboarding}/nested'),
+        shouldShowNowDisplayingForRoute(
+          AppRouteState(
+            path: '${Routes.onboarding}/nested',
+            currentRoute: null,
+          ),
+        ),
         isFalse,
       );
     });
 
     test('returns true for home and DP-1 browsing routes', () {
-      expect(shouldShowNowDisplayingForPath(Routes.home), isTrue);
-      expect(shouldShowNowDisplayingForPath(Routes.channels), isTrue);
-      expect(shouldShowNowDisplayingForPath('${Routes.playlists}/abc'), isTrue);
-      expect(shouldShowNowDisplayingForPath('${Routes.works}/xyz'), isTrue);
+      expect(
+        shouldShowNowDisplayingForRoute(
+          AppRouteState(path: Routes.home, currentRoute: null),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldShowNowDisplayingForRoute(
+          AppRouteState(path: Routes.channels, currentRoute: null),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldShowNowDisplayingForRoute(
+          AppRouteState(
+            path: '${Routes.playlists}/abc',
+            currentRoute: null,
+          ),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldShowNowDisplayingForRoute(
+          AppRouteState(
+            path: '${Routes.works}/xyz',
+            currentRoute: null,
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false when modal/drawer is shown (route has priority)', () {
+      final modalRoute = ModalBottomSheetRoute<void>(
+        isScrollControlled: false,
+        builder: (context) => const SizedBox.shrink(),
+      );
+      expect(
+        shouldShowNowDisplayingForRoute(
+          AppRouteState(path: Routes.home, currentRoute: modalRoute),
+        ),
+        isFalse,
+      );
     });
   });
 

--- a/test/unit/app/providers/current_route_provider_test.dart
+++ b/test/unit/app/providers/current_route_provider_test.dart
@@ -1,0 +1,108 @@
+import 'package:app/app/providers/current_route_provider.dart';
+import 'package:app/app/routing/routes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CurrentRouteNotifier', () {
+    test('initial state has home path and null currentRoute', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+
+      final state = container.read(currentRouteProvider);
+
+      expect(state.path, Routes.home);
+      expect(state.currentRoute, isNull);
+      expect(state.hasModalOrDrawer, isFalse);
+    });
+
+    test('update sets path and currentRoute', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+
+      container.read(currentRouteProvider.notifier).update(
+            Routes.playlists,
+            null,
+          );
+
+      final state = container.read(currentRouteProvider);
+      expect(state.path, Routes.playlists);
+      expect(state.currentRoute, isNull);
+      expect(state.hasModalOrDrawer, isFalse);
+    });
+
+    test('update with empty path uses home', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+
+      container.read(currentRouteProvider.notifier).update('', null);
+
+      final state = container.read(currentRouteProvider);
+      expect(state.path, Routes.home);
+    });
+
+    test('hasModalOrDrawer is true when currentRoute is ModalBottomSheetRoute',
+        () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+
+      final route = ModalBottomSheetRoute<void>(
+        isScrollControlled: false,
+        builder: (context) => const SizedBox.shrink(),
+      );
+
+      container.read(currentRouteProvider.notifier).update(
+            Routes.home,
+            route,
+          );
+
+      final state = container.read(currentRouteProvider);
+      expect(state.currentRoute, isA<ModalBottomSheetRoute>());
+      expect(state.hasModalOrDrawer, isTrue);
+    });
+
+    test('hasModalOrDrawer is false when currentRoute is PageRoute', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+
+      final route = MaterialPageRoute<void>(
+        builder: (context) => const SizedBox.shrink(),
+      );
+
+      container.read(currentRouteProvider.notifier).update(
+            Routes.channels,
+            route,
+          );
+
+      final state = container.read(currentRouteProvider);
+      expect(state.currentRoute, isA<MaterialPageRoute>());
+      expect(state.hasModalOrDrawer, isFalse);
+    });
+
+    test('update with null currentRoute clears modal state', () {
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+
+      final route = ModalBottomSheetRoute<void>(
+        isScrollControlled: false,
+        builder: (context) => const SizedBox.shrink(),
+      );
+      container.read(currentRouteProvider.notifier).update(Routes.home, route);
+      expect(container.read(currentRouteProvider).hasModalOrDrawer, isTrue);
+
+      container.read(currentRouteProvider.notifier).update(Routes.home, null);
+      expect(container.read(currentRouteProvider).hasModalOrDrawer, isFalse);
+    });
+  });
+
+  group('AppRouteState', () {
+    test('copyWith preserves unspecified fields', () {
+      const state = AppRouteState(path: '/foo', currentRoute: null);
+      final updated = state.copyWith(path: '/bar');
+
+      expect(updated.path, '/bar');
+      expect(updated.currentRoute, isNull);
+    });
+  });
+}

--- a/test/unit/app/routing/app_route_observer_test.dart
+++ b/test/unit/app/routing/app_route_observer_test.dart
@@ -1,0 +1,98 @@
+import 'package:app/app/routing/app_route_observer.dart';
+import 'package:app/app/routing/routes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  group('AppRouteObserver', () {
+    testWidgets('calls onRouteChanged on didPush with path and route', (
+      tester,
+    ) async {
+      String? capturedPath;
+      Route<dynamic>? capturedRoute;
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: GoRouter(
+            initialLocation: Routes.home,
+            routes: [
+              GoRoute(
+                path: Routes.home,
+                builder: (context, state) => const Scaffold(
+                  body: Text('Home'),
+                ),
+              ),
+              GoRoute(
+                path: Routes.playlists,
+                builder: (context, state) => const Scaffold(
+                  body: Text('Playlists'),
+                ),
+              ),
+            ],
+            observers: [
+              AppRouteObserver(
+                onRouteChanged: (path, route) {
+                  capturedPath = path;
+                  capturedRoute = route;
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(capturedPath, Routes.home);
+      expect(capturedRoute, isNotNull);
+    });
+
+    testWidgets('calls onRouteChanged on push with route', (tester) async {
+      final captured = <({String path, bool hasRoute})>[];
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: GoRouter(
+            initialLocation: Routes.home,
+            routes: [
+              GoRoute(
+                path: Routes.home,
+                builder: (context, state) => Scaffold(
+                  body: Builder(
+                    builder: (context) => TextButton(
+                      onPressed: () => context.push(Routes.playlists),
+                      child: const Text('Go'),
+                    ),
+                  ),
+                ),
+              ),
+              GoRoute(
+                path: Routes.playlists,
+                builder: (context, state) => const Scaffold(
+                  body: Text('Playlists'),
+                ),
+              ),
+            ],
+            observers: [
+              AppRouteObserver(
+                onRouteChanged: (path, route) {
+                  captured.add((path: path, hasRoute: route != null));
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      final initialCount = captured.length;
+
+      await tester.tap(find.text('Go'));
+      await tester.pumpAndSettle();
+
+      expect(captured.length, greaterThan(initialCount));
+      expect(captured.last.hasRoute, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Hide the Now Displaying bar when a modal or drawer is shown (e.g. `UIHelper.showDrawerAction`, `showModalBottomSheet`, `showCupertinoModalPopup`). Previously, the bar stayed visible because Go Router's `routeInformationProvider` does not reflect modal overlays.

## Solution

- **Replace `routeInformationProvider`** with a new `currentRouteProvider` that tracks both path and top route
- **Add `AppRouteObserver`** (NavigatorObserver) to update the provider on push/pop/replace, including modal routes
- **Centralize config** in `now_displaying_visibility_config.dart`:
  - `routesThatHideNowDisplayingBar` — paths that hide the bar
  - Route type checks (ModalBottomSheetRoute, CupertinoModalPopupRoute) — modal overlays that hide the bar
- **Route has higher priority than path**: when a modal/drawer is shown, the bar is hidden regardless of the underlying path
- **Defer provider updates** via `Future.microtask` to avoid "modify provider while building" when the observer fires during Navigator restore

## Changes

- `lib/app/providers/current_route_provider.dart` — new provider for path + current route
- `lib/app/routing/app_route_observer.dart` — NavigatorObserver for route changes
- `lib/app/now_displaying/now_displaying_visibility_config.dart` — centralized path and route-type config
- `lib/app/providers/now_displaying_visibility_provider.dart` — listens to `currentRouteProvider`, uses `shouldShowNowDisplayingForRoute`
- `lib/app/now_displaying/now_displaying_visibility_sync.dart` — remove route listener, keep scroll + keyboard
- `lib/app/app.dart` — remove `router` param from `NowDisplayingVisibilitySync`
- `lib/app/routing/router_provider.dart` — add `AppRouteObserver`, use `state.matchedLocation` for path

## Testing

- Unit tests for `currentRouteProvider`, `AppRouteObserver`, `shouldShowNowDisplayingForRoute`
- All existing tests pass