### PR TITLE
fix(seed): emit syncing status only on first install

### DIFF
--- a/lib/app/providers/seed_database_provider.dart
+++ b/lib/app/providers/seed_database_provider.dart
@@ -75,9 +75,9 @@ class SeedDownloadNotifier extends Notifier<SeedDownloadState> {
   ///
   /// No-ops if a sync is already in progress.
   ///
-  /// Emits [SeedDownloadStatus.syncing] only when a download actually starts
-  /// (ETag changed or no local DB). If ETag is unchanged, status stays idle
-  /// until done.
+  /// Emits [SeedDownloadStatus.syncing] only when a download starts for a
+  /// first install (!hasLocalDatabase). For updates (existing DB), status
+  /// stays idle. If ETag is unchanged, status stays idle until done.
   ///
   /// This method may be called again after startup (for example, when the app
   /// resumes from background) to check for a newer remote snapshot.
@@ -100,11 +100,18 @@ class SeedDownloadNotifier extends Notifier<SeedDownloadState> {
       final updated = await service.syncIfNeeded(
         beforeReplace: beforeReplace,
         afterReplace: afterReplace,
-        onDownloadStarted: () {
-          state = const SeedDownloadState(
-            status: SeedDownloadStatus.syncing,
-            progress: 0,
-          );
+        onDownloadStarted: ({
+          required bool hasLocalDatabase,
+          required String localEtag,
+          required String remoteEtag,
+        }) {
+          // Only show syncing for first install; updates run in background.
+          if (!hasLocalDatabase) {
+            state = const SeedDownloadState(
+              status: SeedDownloadStatus.syncing,
+              progress: 0,
+            );
+          }
         },
         failSilently: failSilently,
         onProgress: (progress) {

--- a/lib/infra/services/seed_database_sync_service.dart
+++ b/lib/infra/services/seed_database_sync_service.dart
@@ -31,12 +31,17 @@ class SeedDatabaseSyncService {
   /// Syncs seed DB from remote when ETag differs from local ObjectBox config.
   ///
   /// [onDownloadStarted] is invoked only when a download will occur (ETag
-  /// changed or no local DB). Use it to emit syncing status without flashing
-  /// when the check finds nothing to update.
+  /// changed or no local DB). Receives [hasLocalDatabase], [localEtag], and
+  /// [remoteEtag] so the caller can decide whether to emit syncing status
+  /// (e.g. only when [hasLocalDatabase] is false, first install).
   Future<bool> syncIfNeeded({
     required Future<void> Function() beforeReplace,
     required Future<void> Function() afterReplace,
-    void Function()? onDownloadStarted,
+    void Function({
+      required bool hasLocalDatabase,
+      required String localEtag,
+      required String remoteEtag,
+    })? onDownloadStarted,
     void Function(double progress)? onProgress,
     bool failSilently = false,
   }) async {
@@ -61,7 +66,11 @@ class SeedDatabaseSyncService {
       }
 
       _log.info('Seed DB refresh needed; downloading latest seed snapshot.');
-      onDownloadStarted?.call();
+      onDownloadStarted?.call(
+        hasLocalDatabase: hasLocalDatabase,
+        localEtag: localEtag,
+        remoteEtag: remoteEtag,
+      );
 
       final tempPath = await _seedDatabaseService.downloadToTemporaryFile(
         onProgress: onProgress,

--- a/test/unit/app/providers/seed_database_provider_test.dart
+++ b/test/unit/app/providers/seed_database_provider_test.dart
@@ -15,11 +15,19 @@ class _FakeSeedDatabaseSyncService implements SeedDatabaseSyncService {
   /// is not called.
   bool skipDownload = false;
 
+  /// When skipDownload is false, passed to onDownloadStarted. Use false for
+  /// first install (emits syncing), true for update (no syncing).
+  bool hasLocalDatabase = false;
+
   @override
   Future<bool> syncIfNeeded({
     required Future<void> Function() beforeReplace,
     required Future<void> Function() afterReplace,
-    void Function()? onDownloadStarted,
+    void Function({
+      required bool hasLocalDatabase,
+      required String localEtag,
+      required String remoteEtag,
+    })? onDownloadStarted,
     void Function(double progress)? onProgress,
     bool failSilently = false,
   }) async {
@@ -28,7 +36,11 @@ class _FakeSeedDatabaseSyncService implements SeedDatabaseSyncService {
     if (skipDownload) {
       return false;
     }
-    onDownloadStarted?.call();
+    onDownloadStarted?.call(
+      hasLocalDatabase: hasLocalDatabase,
+      localEtag: 'local',
+      remoteEtag: 'remote',
+    );
     await beforeReplace();
     for (final p in progressValues) {
       onProgress?.call(p);
@@ -110,6 +122,35 @@ void main() {
     expect(syncingStates, isNotEmpty);
     final withProgress = syncingStates.where((s) => s.progress != null);
     expect(withProgress, isNotEmpty);
+  });
+
+  test('does not emit syncing when updating existing DB', () async {
+    final fakeSyncService = _FakeSeedDatabaseSyncService()
+      ..hasLocalDatabase = true; // Update scenario, not first install.
+    final states = <SeedDownloadState>[];
+
+    final container = ProviderContainer.test(
+      overrides: [
+        seedDatabaseSyncServiceProvider.overrideWithValue(fakeSyncService),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.listen(seedDownloadProvider, (prev, next) => states.add(next));
+
+    await container
+        .read(seedDownloadProvider.notifier)
+        .syncAtAppStart(
+          beforeReplace: () async {},
+          afterReplace: () async {},
+        );
+
+    expect(container.read(seedDownloadProvider).status, SeedDownloadStatus.done);
+
+    final syncingStates = states.where(
+      (s) => s.status == SeedDownloadStatus.syncing,
+    );
+    expect(syncingStates, isEmpty);
   });
 
   test('does not emit syncing when ETag unchanged (no download)', () async {


### PR DESCRIPTION
## Summary
Emit `syncing` status only when downloading for first install (!hasLocalDatabase). For updates (existing DB, ETag changed) or when ETag unchanged, status stays idle.

## Changes
- Add `onDownloadStarted` callback to `syncIfNeeded` with params: `hasLocalDatabase`, `localEtag`, `remoteEtag`
- Notifier sets `syncing` only when `!hasLocalDatabase`
- Avoids loading flash on app resume when no update or when just updating existing DB

## Tests
- does not emit syncing when updating existing DB
- does not emit syncing when ETag unchanged (no download)
- progress is updated during sync (first install)

Made with [Cursor](https://cursor.com)