### PR TITLE
refactor(logging): remove redundant verbose runtime logs

### DIFF
--- a/lib/app/providers/app_provider_observer.dart
+++ b/lib/app/providers/app_provider_observer.dart
@@ -1,42 +1,13 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 
-/// Observer that reports provider lifecycle and failures to app logging.
+/// Observer that reports provider failures to app logging.
 final class AppProviderObserver extends ProviderObserver {
-  /// Creates a Riverpod observer that logs provider lifecycle changes.
+  /// Creates a Riverpod observer that logs provider failures.
   AppProviderObserver({Logger? logger})
     : _logger = logger ?? Logger('Riverpod');
 
   final Logger _logger;
-
-  @override
-  void didAddProvider(
-    ProviderObserverContext context,
-    Object? value,
-  ) {
-    _logger.fine('add ${_providerName(context)} = ${_short(value)}');
-  }
-
-  @override
-  void didUpdateProvider(
-    ProviderObserverContext context,
-    Object? previousValue,
-    Object? newValue,
-  ) {
-    if (identical(previousValue, newValue)) {
-      return;
-    }
-
-    _logger.fine(
-      'update ${_providerName(context)} '
-      '${_short(previousValue)} -> ${_short(newValue)}',
-    );
-  }
-
-  @override
-  void didDisposeProvider(ProviderObserverContext context) {
-    _logger.fine('dispose ${_providerName(context)}');
-  }
 
   @override
   void providerDidFail(
@@ -54,17 +25,5 @@ final class AppProviderObserver extends ProviderObserver {
   String _providerName(ProviderObserverContext context) {
     final provider = context.provider;
     return provider.name ?? provider.runtimeType.toString();
-  }
-
-  String _short(Object? value) {
-    if (value == null) {
-      return 'null';
-    }
-
-    final text = value.toString().replaceAll('\n', ' ');
-    if (text.length <= 220) {
-      return text;
-    }
-    return '${text.substring(0, 217)}...';
   }
 }

--- a/lib/app/routing/router_provider.dart
+++ b/lib/app/routing/router_provider.dart
@@ -51,7 +51,7 @@ routerProvider = Provider.family<GoRouter, String>((
 ) {
   return GoRouter(
     navigatorKey: appNavigatorKey,
-    debugLogDiagnostics: true,
+    debugLogDiagnostics: false,
     initialLocation: initialLocation,
     observers: [
       routeObserver,

--- a/lib/infra/ff1/ble_transport/ff1_ble_transport.dart
+++ b/lib/infra/ff1/ble_transport/ff1_ble_transport.dart
@@ -241,15 +241,6 @@ class FF1BleTransport {
 
         _log.info('Found ${services.length} services on device');
 
-        // Log all available services for debugging
-        for (final service in services) {
-          _log.info(
-            'Service: ${service.uuid} '
-            '(primary: ${service.isPrimary}, '
-            'characteristics: ${service.characteristics.length})',
-          );
-        }
-
         // Find FF1 service by UUID
         final ff1Service = services.firstWhereOrNull(
           (s) => s.uuid.toString() == serviceUuid,

--- a/lib/infra/ff1/wifi_control/ff1_wifi_rest_client.dart
+++ b/lib/infra/ff1/wifi_control/ff1_wifi_rest_client.dart
@@ -84,13 +84,11 @@ class FF1WifiRestClient {
 
       // Handle various response formats
       if (responseData is Map<String, dynamic>) {
-        _logger.fine('Command response: $responseData');
         return responseData;
       }
 
       if (responseData is Map) {
         final result = Map<String, dynamic>.from(responseData);
-        _logger.fine('Command response: $result');
         return result;
       }
 

--- a/lib/nft_rendering/audio_rendering_widget.dart
+++ b/lib/nft_rendering/audio_rendering_widget.dart
@@ -4,9 +4,11 @@ import 'package:app/nft_rendering/nft_error_widget.dart';
 import 'package:app/nft_rendering/nft_loading_widget.dart';
 import 'package:app/nft_rendering/nft_rendering_widget.dart';
 import 'package:audio_session/audio_session.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger('AudioNFTRenderingWidget');
 
 class AudioNFTRenderingWidget extends NFTRenderingWidget {
   const AudioNFTRenderingWidget({
@@ -77,9 +79,7 @@ class _AudioNFTRenderingWidgetState
       widget.onLoaded?.call(time: _player?.duration?.inSeconds);
       await _player?.play();
     } catch (e) {
-      if (kDebugMode) {
-        print('Error while setting audio source: $audioURL. Error: $e');
-      }
+      _log.warning('Failed to play audio source: $audioURL. Error: $e');
     }
   }
 

--- a/lib/nft_rendering/webview_controller_ext.dart
+++ b/lib/nft_rendering/webview_controller_ext.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
@@ -9,9 +8,7 @@ extension WebViewControllerExtension on WebViewController {
     try {
       await runJavaScript(source);
     } catch (e) {
-      if (kDebugMode) {
-        print('Error evaluateJavascript: $e');
-      }
+      _log.fine('evaluateJavascript failed: $e');
     }
   }
 


### PR DESCRIPTION
### Motivation
- Reduce high-volume, low-signal runtime logging left over from step-by-step debugging to improve operational log clarity and controllable verbosity.
- Replace ad-hoc `print` usage with structured logger calls so output can be filtered by log level in production.
- Keep important failure/warning signals (errors, warnings, key discovery outcomes) while removing repeated success/detail traces.

### Description
- Narrowed the Riverpod observer in `AppProviderObserver` to only report provider failures and removed add/update/dispose/value-tracing code in `lib/app/providers/app_provider_observer.dart`.
- Disabled GoRouter diagnostic output by setting `debugLogDiagnostics` to `false` in `lib/app/routing/router_provider.dart`.
- Removed noisy per-service BLE discovery enumeration while preserving attempt/result/warning logs in `lib/infra/ff1/ble_transport/ff1_ble_transport.dart`.
- Dropped verbose successful-response payload logs from the FF1 WiFi REST client and kept warnings/errors in `lib/infra/ff1/wifi_control/ff1_wifi_rest_client.dart`.
- Replaced `print` debug calls with structured `Logger` usage and added logger instances in NFT helpers, `lib/nft_rendering/webview_controller_ext.dart` and `lib/nft_rendering/audio_rendering_widget.dart`.
- Files updated: `lib/app/providers/app_provider_observer.dart`, `lib/app/routing/router_provider.dart`, `lib/infra/ff1/ble_transport/ff1_ble_transport.dart`, `lib/infra/ff1/wifi_control/ff1_wifi_rest_client.dart`, `lib/nft_rendering/webview_controller_ext.dart`, and `lib/nft_rendering/audio_rendering_widget.dart`.

### Testing
- Ran code-format and unit test commands locally in the environment: `dart format <files>` and `flutter test test/unit/app/providers/app_provider_observer_test.dart` but both could not run because the environment lacks the `dart`/`flutter` toolchain, so automated checks were not executed here.
- No runtime test failures were observed in this edit session because tests could not be executed; the changes preserve existing warning/error logs so runtime failures should still be captured by current automated tests when run in CI or a developer machine with Flutter/Dart installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae9a68fc6083228bcfd75708cb6d6f)