### PR TITLE
refactor(playlist-item): remove subtitle, use artistName from artists list

### DIFF
--- a/lib/app/providers/now_displaying_provider.dart
+++ b/lib/app/providers/now_displaying_provider.dart
@@ -289,7 +289,10 @@ class NowDisplayingNotifier extends Notifier<NowDisplayingStatus> {
     );
     if (toSave.isEmpty) return <String, PlaylistItem>{};
 
-    await databaseService.upsertPlaylistItemsEnriched(toSave);
+    await databaseService.upsertPlaylistItemsEnriched(
+      toSave,
+      shouldForce: false,
+    );
     return {for (final p in toSave) p.id: p};
   }
 }

--- a/lib/domain/models/playlist_item.dart
+++ b/lib/domain/models/playlist_item.dart
@@ -15,7 +15,6 @@ class PlaylistItem extends DP1PlaylistItem {
     required super.id,
     required this.kind,
     super.title,
-    this.subtitle,
     this.artists,
     this.thumbnailUrl,
     super.duration = 0,
@@ -77,7 +76,6 @@ class PlaylistItem extends DP1PlaylistItem {
       id: json['id'] as String,
       kind: PlaylistItemKind.values[json['kind'] as int],
       title: json['title'] as String?,
-      subtitle: json['subtitle'] as String?,
       artists: artists,
       thumbnailUrl: json['thumbnailUrl'] as String?,
       duration: json['duration'] as int? ?? 0,
@@ -100,9 +98,6 @@ class PlaylistItem extends DP1PlaylistItem {
 
   /// Item kind (DP1 item or indexer token).
   final PlaylistItemKind kind;
-
-  /// Optional subtitle (artists string).
-  final String? subtitle;
 
   /// Optional list of artists (DP1 manifest).
   final List<DP1Artist>? artists;
@@ -137,7 +132,6 @@ class PlaylistItem extends DP1PlaylistItem {
           runtimeType == other.runtimeType &&
           super == other &&
           kind == other.kind &&
-          subtitle == other.subtitle &&
           listEquals(artists, other.artists) &&
           thumbnailUrl == other.thumbnailUrl &&
           _mapEquals(overrideData, other.overrideData) &&
@@ -149,7 +143,6 @@ class PlaylistItem extends DP1PlaylistItem {
   int get hashCode => Object.hash(
     super.hashCode,
     kind,
-    subtitle,
     Object.hashAll(artists ?? []),
     thumbnailUrl,
     overrideData != null ? _deepEquality.hash(overrideData) : null,
@@ -163,7 +156,6 @@ class PlaylistItem extends DP1PlaylistItem {
     String? id,
     PlaylistItemKind? kind,
     String? title,
-    String? subtitle,
     List<DP1Artist>? artists,
     String? thumbnailUrl,
     int? duration,
@@ -182,7 +174,6 @@ class PlaylistItem extends DP1PlaylistItem {
       id: id ?? this.id,
       kind: kind ?? this.kind,
       title: title ?? this.title,
-      subtitle: subtitle ?? this.subtitle,
       artists: artists ?? this.artists,
       thumbnailUrl: thumbnailUrl ?? this.thumbnailUrl,
       duration: duration ?? this.duration,
@@ -204,7 +195,6 @@ class PlaylistItem extends DP1PlaylistItem {
   Map<String, dynamic> toJson() {
     final j = super.toJson();
     j['kind'] = kind.index;
-    j['subtitle'] = subtitle;
     if (artists != null) {
       j['artists'] = artists!.map((e) => e.toJson()).toList();
     }

--- a/lib/infra/database/app_database.dart
+++ b/lib/infra/database/app_database.dart
@@ -523,13 +523,12 @@ class AppDatabase extends _$AppDatabase {
   /// - 1 = address-based
   Future<List<PlaylistData>> getAllPlaylists({PlaylistType? type}) async {
     final variables = <Variable<Object>>[];
-    final whereClause =
-        type == null
-            ? ''
-            : (() {
-              variables.add(Variable<int>(type.value));
-              return 'WHERE p.type = ?';
-            })();
+    final whereClause = type == null
+        ? ''
+        : (() {
+            variables.add(Variable<int>(type.value));
+            return 'WHERE p.type = ?';
+          })();
 
     final result = await customSelect(
       '''
@@ -606,9 +605,19 @@ class AppDatabase extends _$AppDatabase {
   }
 
   /// Upsert multiple items in a batch.
-  Future<void> upsertItems(List<ItemsCompanion> itemList) async {
+  ///
+  /// When [force] is true (default), conflicts overwrite existing rows.
+  /// When [force] is false, existing rows are preserved (INSERT OR IGNORE).
+  Future<void> upsertItems(
+    List<ItemsCompanion> itemList, {
+    bool force = true,
+  }) async {
     await batch((batch) {
-      batch.insertAllOnConflictUpdate(items, itemList);
+      if (force) {
+        batch.insertAllOnConflictUpdate(items, itemList);
+      } else {
+        batch.insertAll(items, itemList, mode: InsertMode.insertOrIgnore);
+      }
     });
   }
 

--- a/lib/infra/database/app_database.g.dart
+++ b/lib/infra/database/app_database.g.dart
@@ -2059,17 +2059,6 @@ class $ItemsTable extends Items with TableInfo<$ItemsTable, ItemData> {
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
-  static const VerificationMeta _subtitleMeta = const VerificationMeta(
-    'subtitle',
-  );
-  @override
-  late final GeneratedColumn<String> subtitle = GeneratedColumn<String>(
-    'subtitle',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
   static const VerificationMeta _thumbnailUriMeta = const VerificationMeta(
     'thumbnailUri',
   );
@@ -2217,7 +2206,6 @@ class $ItemsTable extends Items with TableInfo<$ItemsTable, ItemData> {
     id,
     kind,
     title,
-    subtitle,
     thumbnailUri,
     durationSec,
     provenanceJson,
@@ -2261,12 +2249,6 @@ class $ItemsTable extends Items with TableInfo<$ItemsTable, ItemData> {
       context.handle(
         _titleMeta,
         title.isAcceptableOrUnknown(data['title']!, _titleMeta),
-      );
-    }
-    if (data.containsKey('subtitle')) {
-      context.handle(
-        _subtitleMeta,
-        subtitle.isAcceptableOrUnknown(data['subtitle']!, _subtitleMeta),
       );
     }
     if (data.containsKey('thumbnail_uri')) {
@@ -2397,10 +2379,6 @@ class $ItemsTable extends Items with TableInfo<$ItemsTable, ItemData> {
         DriftSqlType.string,
         data['${effectivePrefix}title'],
       ),
-      subtitle: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}subtitle'],
-      ),
       thumbnailUri: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}thumbnail_uri'],
@@ -2472,9 +2450,6 @@ class ItemData extends DataClass implements Insertable<ItemData> {
   /// Display title.
   final String? title;
 
-  /// Artists string (subtitle).
-  final String? subtitle;
-
   /// Thumbnail image URL.
   final String? thumbnailUri;
 
@@ -2517,7 +2492,6 @@ class ItemData extends DataClass implements Insertable<ItemData> {
     required this.id,
     required this.kind,
     this.title,
-    this.subtitle,
     this.thumbnailUri,
     this.durationSec,
     this.provenanceJson,
@@ -2539,9 +2513,6 @@ class ItemData extends DataClass implements Insertable<ItemData> {
     map['kind'] = Variable<int>(kind);
     if (!nullToAbsent || title != null) {
       map['title'] = Variable<String>(title);
-    }
-    if (!nullToAbsent || subtitle != null) {
-      map['subtitle'] = Variable<String>(subtitle);
     }
     if (!nullToAbsent || thumbnailUri != null) {
       map['thumbnail_uri'] = Variable<String>(thumbnailUri);
@@ -2588,9 +2559,6 @@ class ItemData extends DataClass implements Insertable<ItemData> {
       title: title == null && nullToAbsent
           ? const Value.absent()
           : Value(title),
-      subtitle: subtitle == null && nullToAbsent
-          ? const Value.absent()
-          : Value(subtitle),
       thumbnailUri: thumbnailUri == null && nullToAbsent
           ? const Value.absent()
           : Value(thumbnailUri),
@@ -2638,7 +2606,6 @@ class ItemData extends DataClass implements Insertable<ItemData> {
       id: serializer.fromJson<String>(json['id']),
       kind: serializer.fromJson<int>(json['kind']),
       title: serializer.fromJson<String?>(json['title']),
-      subtitle: serializer.fromJson<String?>(json['subtitle']),
       thumbnailUri: serializer.fromJson<String?>(json['thumbnailUri']),
       durationSec: serializer.fromJson<int?>(json['durationSec']),
       provenanceJson: serializer.fromJson<String?>(json['provenanceJson']),
@@ -2661,7 +2628,6 @@ class ItemData extends DataClass implements Insertable<ItemData> {
       'id': serializer.toJson<String>(id),
       'kind': serializer.toJson<int>(kind),
       'title': serializer.toJson<String?>(title),
-      'subtitle': serializer.toJson<String?>(subtitle),
       'thumbnailUri': serializer.toJson<String?>(thumbnailUri),
       'durationSec': serializer.toJson<int?>(durationSec),
       'provenanceJson': serializer.toJson<String?>(provenanceJson),
@@ -2682,7 +2648,6 @@ class ItemData extends DataClass implements Insertable<ItemData> {
     String? id,
     int? kind,
     Value<String?> title = const Value.absent(),
-    Value<String?> subtitle = const Value.absent(),
     Value<String?> thumbnailUri = const Value.absent(),
     Value<int?> durationSec = const Value.absent(),
     Value<String?> provenanceJson = const Value.absent(),
@@ -2700,7 +2665,6 @@ class ItemData extends DataClass implements Insertable<ItemData> {
     id: id ?? this.id,
     kind: kind ?? this.kind,
     title: title.present ? title.value : this.title,
-    subtitle: subtitle.present ? subtitle.value : this.subtitle,
     thumbnailUri: thumbnailUri.present ? thumbnailUri.value : this.thumbnailUri,
     durationSec: durationSec.present ? durationSec.value : this.durationSec,
     provenanceJson: provenanceJson.present
@@ -2726,7 +2690,6 @@ class ItemData extends DataClass implements Insertable<ItemData> {
       id: data.id.present ? data.id.value : this.id,
       kind: data.kind.present ? data.kind.value : this.kind,
       title: data.title.present ? data.title.value : this.title,
-      subtitle: data.subtitle.present ? data.subtitle.value : this.subtitle,
       thumbnailUri: data.thumbnailUri.present
           ? data.thumbnailUri.value
           : this.thumbnailUri,
@@ -2767,7 +2730,6 @@ class ItemData extends DataClass implements Insertable<ItemData> {
           ..write('id: $id, ')
           ..write('kind: $kind, ')
           ..write('title: $title, ')
-          ..write('subtitle: $subtitle, ')
           ..write('thumbnailUri: $thumbnailUri, ')
           ..write('durationSec: $durationSec, ')
           ..write('provenanceJson: $provenanceJson, ')
@@ -2790,7 +2752,6 @@ class ItemData extends DataClass implements Insertable<ItemData> {
     id,
     kind,
     title,
-    subtitle,
     thumbnailUri,
     durationSec,
     provenanceJson,
@@ -2812,7 +2773,6 @@ class ItemData extends DataClass implements Insertable<ItemData> {
           other.id == this.id &&
           other.kind == this.kind &&
           other.title == this.title &&
-          other.subtitle == this.subtitle &&
           other.thumbnailUri == this.thumbnailUri &&
           other.durationSec == this.durationSec &&
           other.provenanceJson == this.provenanceJson &&
@@ -2832,7 +2792,6 @@ class ItemsCompanion extends UpdateCompanion<ItemData> {
   final Value<String> id;
   final Value<int> kind;
   final Value<String?> title;
-  final Value<String?> subtitle;
   final Value<String?> thumbnailUri;
   final Value<int?> durationSec;
   final Value<String?> provenanceJson;
@@ -2851,7 +2810,6 @@ class ItemsCompanion extends UpdateCompanion<ItemData> {
     this.id = const Value.absent(),
     this.kind = const Value.absent(),
     this.title = const Value.absent(),
-    this.subtitle = const Value.absent(),
     this.thumbnailUri = const Value.absent(),
     this.durationSec = const Value.absent(),
     this.provenanceJson = const Value.absent(),
@@ -2871,7 +2829,6 @@ class ItemsCompanion extends UpdateCompanion<ItemData> {
     required String id,
     required int kind,
     this.title = const Value.absent(),
-    this.subtitle = const Value.absent(),
     this.thumbnailUri = const Value.absent(),
     this.durationSec = const Value.absent(),
     this.provenanceJson = const Value.absent(),
@@ -2893,7 +2850,6 @@ class ItemsCompanion extends UpdateCompanion<ItemData> {
     Expression<String>? id,
     Expression<int>? kind,
     Expression<String>? title,
-    Expression<String>? subtitle,
     Expression<String>? thumbnailUri,
     Expression<int>? durationSec,
     Expression<String>? provenanceJson,
@@ -2913,7 +2869,6 @@ class ItemsCompanion extends UpdateCompanion<ItemData> {
       if (id != null) 'id': id,
       if (kind != null) 'kind': kind,
       if (title != null) 'title': title,
-      if (subtitle != null) 'subtitle': subtitle,
       if (thumbnailUri != null) 'thumbnail_uri': thumbnailUri,
       if (durationSec != null) 'duration_sec': durationSec,
       if (provenanceJson != null) 'provenance_json': provenanceJson,
@@ -2935,7 +2890,6 @@ class ItemsCompanion extends UpdateCompanion<ItemData> {
     Value<String>? id,
     Value<int>? kind,
     Value<String?>? title,
-    Value<String?>? subtitle,
     Value<String?>? thumbnailUri,
     Value<int?>? durationSec,
     Value<String?>? provenanceJson,
@@ -2955,7 +2909,6 @@ class ItemsCompanion extends UpdateCompanion<ItemData> {
       id: id ?? this.id,
       kind: kind ?? this.kind,
       title: title ?? this.title,
-      subtitle: subtitle ?? this.subtitle,
       thumbnailUri: thumbnailUri ?? this.thumbnailUri,
       durationSec: durationSec ?? this.durationSec,
       provenanceJson: provenanceJson ?? this.provenanceJson,
@@ -2984,9 +2937,6 @@ class ItemsCompanion extends UpdateCompanion<ItemData> {
     }
     if (title.present) {
       map['title'] = Variable<String>(title.value);
-    }
-    if (subtitle.present) {
-      map['subtitle'] = Variable<String>(subtitle.value);
     }
     if (thumbnailUri.present) {
       map['thumbnail_uri'] = Variable<String>(thumbnailUri.value);
@@ -3039,7 +2989,6 @@ class ItemsCompanion extends UpdateCompanion<ItemData> {
           ..write('id: $id, ')
           ..write('kind: $kind, ')
           ..write('title: $title, ')
-          ..write('subtitle: $subtitle, ')
           ..write('thumbnailUri: $thumbnailUri, ')
           ..write('durationSec: $durationSec, ')
           ..write('provenanceJson: $provenanceJson, ')
@@ -4634,7 +4583,6 @@ typedef $$ItemsTableCreateCompanionBuilder =
       required String id,
       required int kind,
       Value<String?> title,
-      Value<String?> subtitle,
       Value<String?> thumbnailUri,
       Value<int?> durationSec,
       Value<String?> provenanceJson,
@@ -4655,7 +4603,6 @@ typedef $$ItemsTableUpdateCompanionBuilder =
       Value<String> id,
       Value<int> kind,
       Value<String?> title,
-      Value<String?> subtitle,
       Value<String?> thumbnailUri,
       Value<int?> durationSec,
       Value<String?> provenanceJson,
@@ -4692,11 +4639,6 @@ class $$ItemsTableFilterComposer extends Composer<_$AppDatabase, $ItemsTable> {
 
   ColumnFilters<String> get title => $composableBuilder(
     column: $table.title,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<String> get subtitle => $composableBuilder(
-    column: $table.subtitle,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -4790,11 +4732,6 @@ class $$ItemsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
-  ColumnOrderings<String> get subtitle => $composableBuilder(
-    column: $table.subtitle,
-    builder: (column) => ColumnOrderings(column),
-  );
-
   ColumnOrderings<String> get thumbnailUri => $composableBuilder(
     column: $table.thumbnailUri,
     builder: (column) => ColumnOrderings(column),
@@ -4878,9 +4815,6 @@ class $$ItemsTableAnnotationComposer
 
   GeneratedColumn<String> get title =>
       $composableBuilder(column: $table.title, builder: (column) => column);
-
-  GeneratedColumn<String> get subtitle =>
-      $composableBuilder(column: $table.subtitle, builder: (column) => column);
 
   GeneratedColumn<String> get thumbnailUri => $composableBuilder(
     column: $table.thumbnailUri,
@@ -4971,7 +4905,6 @@ class $$ItemsTableTableManager
                 Value<String> id = const Value.absent(),
                 Value<int> kind = const Value.absent(),
                 Value<String?> title = const Value.absent(),
-                Value<String?> subtitle = const Value.absent(),
                 Value<String?> thumbnailUri = const Value.absent(),
                 Value<int?> durationSec = const Value.absent(),
                 Value<String?> provenanceJson = const Value.absent(),
@@ -4990,7 +4923,6 @@ class $$ItemsTableTableManager
                 id: id,
                 kind: kind,
                 title: title,
-                subtitle: subtitle,
                 thumbnailUri: thumbnailUri,
                 durationSec: durationSec,
                 provenanceJson: provenanceJson,
@@ -5011,7 +4943,6 @@ class $$ItemsTableTableManager
                 required String id,
                 required int kind,
                 Value<String?> title = const Value.absent(),
-                Value<String?> subtitle = const Value.absent(),
                 Value<String?> thumbnailUri = const Value.absent(),
                 Value<int?> durationSec = const Value.absent(),
                 Value<String?> provenanceJson = const Value.absent(),
@@ -5030,7 +4961,6 @@ class $$ItemsTableTableManager
                 id: id,
                 kind: kind,
                 title: title,
-                subtitle: subtitle,
                 thumbnailUri: thumbnailUri,
                 durationSec: durationSec,
                 provenanceJson: provenanceJson,

--- a/lib/infra/database/converters.dart
+++ b/lib/infra/database/converters.dart
@@ -246,7 +246,6 @@ class DatabaseConverters {
       id: data.id,
       kind: PlaylistItemKind.values[data.kind],
       title: data.title ?? '',
-      subtitle: data.subtitle,
       thumbnailUrl: data.thumbnailUri,
       duration: data.durationSec ?? 0,
       provenance: provenance,
@@ -286,7 +285,6 @@ class DatabaseConverters {
       id: data.id,
       kind: PlaylistItemKind.values[data.kind],
       title: data.title ?? '',
-      subtitle: data.subtitle,
       thumbnailUrl: data.thumbnailUri,
       duration: data.durationSec ?? 0,
       source: data.sourceUri,
@@ -333,7 +331,6 @@ class DatabaseConverters {
         item.updatedAt?.microsecondsSinceEpoch ?? nowUs.toInt(),
       ),
       title: Value(item.title),
-      subtitle: Value(item.subtitle),
       thumbnailUri: Value(item.thumbnailUrl),
       durationSec: Value(item.duration),
       provenanceJson: Value(provenanceJson),
@@ -447,33 +444,45 @@ class DatabaseConverters {
   }
 
   /// Convert DP1PlaylistItem (wire) to PlaylistItem domain model.
-  /// When [token] is provided, thumbnail and artists are taken from the token;
-  /// otherwise they are null.
+  /// When [token] is provided, any null/empty fields from [item] fall back to
+  /// token data (title, thumbnailUrl, artists, source).
   static PlaylistItem dp1PlaylistItemToPlaylistItem(
     DP1PlaylistItem item, {
     AssetToken? token,
   }) {
-    final thumbnailUrl = token?.getGalleryThumbnailUrl();
-    final artists = token?.metadata?.artists
-        ?.map((a) => DP1Artist(name: a.name, id: a.did))
+    // Use item value when non-empty; otherwise fall back to token.
+    final title = _nonEmptyString(item.title) ??
+        token?.displayTitle ??
+        'Unknown';
+    final source = _nonEmptyString(item.source) ?? token?.getPreviewUrl();
+    final ref = _nonEmptyString(item.ref);
+    final thumbnailUrl =
+        token?.getGalleryThumbnailUrl();
+    final artists = (token?.getArtists ?? <Artist>[])
+        .map((a) => DP1Artist(name: a.name, id: a.did))
         .toList();
+    final artistsOrNull = artists.isEmpty ? null : artists;
 
     return PlaylistItem(
       id: item.id,
       kind: PlaylistItemKind.dp1Item,
-      title: item.title ?? token?.displayTitle ?? 'Unknown',
-      source: item.source,
-      ref: item.ref,
+      title: title,
+      source: source,
+      ref: ref,
       license: item.license,
       duration: item.duration,
       provenance: item.provenance,
       repro: item.repro,
       display: item.display,
       thumbnailUrl: thumbnailUrl,
-      artists: artists,
+      artists: artistsOrNull,
       updatedAt: DateTime.now(),
     );
   }
+
+  /// Returns [s] if non-null and non-empty; otherwise null.
+  static String? _nonEmptyString(String? s) =>
+      (s != null && s.isNotEmpty) ? s : null;
 
   /// Convert ChannelData + playlist full URLs to DP1Channel (wire model).
   /// Matches old repo's Channel in ChannelReference.

--- a/lib/infra/database/database_service.dart
+++ b/lib/infra/database/database_service.dart
@@ -464,7 +464,13 @@ class DatabaseService {
   /// This is used by the enrichment service to update items with indexer token
   /// data without touching playlist_entries. Wraps writes in a transaction for
   /// efficiency.
-  Future<void> upsertPlaylistItemsEnriched(List<PlaylistItem> items) async {
+  ///
+  /// When [shouldForce] is true (default), existing rows are overwritten.
+  /// When [shouldForce] is false, existing rows are preserved.
+  Future<void> upsertPlaylistItemsEnriched(
+    List<PlaylistItem> items, {
+    bool shouldForce = true,
+  }) async {
     if (items.isEmpty) return;
 
     try {
@@ -472,7 +478,7 @@ class DatabaseService {
         final companions = items
             .map(DatabaseConverters.playlistItemToCompanion)
             .toList();
-        await _db.upsertItems(companions);
+        await _db.upsertItems(companions, force: shouldForce);
       });
 
       _log.info('Upserted ${items.length} enriched playlist items');
@@ -1707,7 +1713,6 @@ class DatabaseService {
       id: Value(itemId),
       kind: const Value(1), // indexer token
       title: Value(enrichedItem.title),
-      subtitle: Value(enrichedItem.subtitle),
       thumbnailUri: Value(enrichedItem.thumbnailUrl),
       provenanceJson: enrichedItem.provenance != null
           ? Value(jsonEncode(enrichedItem.provenance!.toJson()))

--- a/lib/infra/database/tables.dart
+++ b/lib/infra/database/tables.dart
@@ -136,9 +136,6 @@ class Items extends Table {
   /// Display title.
   TextColumn get title => text().nullable()();
 
-  /// Artists string (subtitle).
-  TextColumn get subtitle => text().nullable()();
-
   /// Thumbnail image URL.
   TextColumn get thumbnailUri => text().nullable()();
 

--- a/lib/infra/database/token_transformer.dart
+++ b/lib/infra/database/token_transformer.dart
@@ -22,10 +22,6 @@ class TokenTransformer {
   }) {
     final title = token.displayTitle ?? 'Untitled';
     final artists = token.enrichmentSource?.artists ?? token.metadata?.artists;
-    final subtitle = artists == null || artists.isEmpty
-        ? null
-        : artists.map((a) => a.name).where((n) => n.isNotEmpty).join(', ');
-
     final dp1Artists = artists
         ?.map((a) => DP1Artist(name: a.name, id: a.did))
         .toList();
@@ -42,7 +38,6 @@ class TokenTransformer {
       id: token.cid,
       kind: PlaylistItemKind.indexerToken,
       title: title,
-      subtitle: subtitle,
       source: token.getPreviewUrl(),
       thumbnailUrl: _resolveThumbnailUrl(token),
       provenance: provenance,

--- a/lib/ui/screens/now_displaying_screen.dart
+++ b/lib/ui/screens/now_displaying_screen.dart
@@ -3,6 +3,7 @@ import 'package:app/app/routing/routes.dart';
 import 'package:app/design/app_typography.dart';
 import 'package:app/design/build/primitives.dart';
 import 'package:app/design/layout_constants.dart';
+import 'package:app/domain/extensions/playlist_item_ext.dart';
 import 'package:app/domain/models/now_displaying_object.dart';
 import 'package:app/domain/models/playlist_item.dart';
 import 'package:app/theme/app_color.dart';
@@ -221,7 +222,7 @@ class _DP1NowDisplayingContent extends StatelessWidget {
         SliverToBoxAdapter(
           child: _InfoHeader(
             title: item.title ?? '',
-            subTitle: item.subtitle ?? '',
+            subTitle: item.artistName,
           ),
         ),
         SliverToBoxAdapter(

--- a/lib/widgets/work_detail/work_detail_sections.dart
+++ b/lib/widgets/work_detail/work_detail_sections.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'package:app/design/app_typography.dart';
 import 'package:app/design/layout_constants.dart';
 import 'package:app/domain/extensions/asset_token_ext.dart';
+import 'package:app/domain/extensions/extensions.dart';
 import 'package:app/domain/models/indexer/asset_token.dart';
 import 'package:app/domain/models/playlist_item.dart';
 import 'package:app/theme/app_color.dart';
@@ -301,14 +302,9 @@ String _localTimeString(DateTime timestamp) {
   return Jiffy.parseFromDateTime(timestamp).format(pattern: 'MMM d, y • H:mm');
 }
 
-/// Build artist string from PlaylistItem.
+/// Build artist string from PlaylistItem (derived from artists list).
 String artistStringFromPlaylistItem(PlaylistItem item) {
-  if (item.subtitle != null && item.subtitle!.isNotEmpty) {
-    return item.subtitle!;
-  }
-  final artists = item.artists;
-  if (artists == null || artists.isEmpty) return '';
-  return artists.map((a) => a.name).join(', ');
+  return item.artistName;
 }
 
 /// Metadata section: from token when available, else item-only.

--- a/lib/widgets/work_grid_card.dart
+++ b/lib/widgets/work_grid_card.dart
@@ -27,7 +27,7 @@ class WorkGridCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final title = item.title;
-    final artistName = item.subtitle ?? item.artistName;
+    final artistName = item.artistName;
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,

--- a/scripts/build_feed_indexer_sqlite.js
+++ b/scripts/build_feed_indexer_sqlite.js
@@ -544,7 +544,6 @@ function mergeFeedItem(existing, feedItem) {
     id: String(feedItem.id),
     kind: 0,
     title: null,
-    subtitle: null,
     thumbnail_uri: FALLBACK_THUMBNAIL_URI,
     duration_sec: null,
     provenance_json: null,
@@ -708,7 +707,6 @@ function applyIndexerEnrichment(itemsMap, cidToItemIds, tokensByCid) {
       const enriched = tokenToItemPatch(token);
       row.kind = 1;
       row.title = enriched.title;
-      row.subtitle = enriched.subtitle;
       row.thumbnail_uri = enriched.thumbnailUri;
       row.list_artist_json = enriched.listArtistJson;
       row.token_data_json = JSON.stringify(toRestTokenJson(token));
@@ -725,18 +723,11 @@ function tokenToItemPatch(token) {
       id: artist.did || '',
       name: artist.name || '',
     }));
-  const subtitle = artists.length > 0
-    ? artists
-      .map((artist) => artist.name)
-      .filter((name) => Boolean(name))
-      .join(', ')
-    : null;
   return {
     title:
       token?.enrichment_source?.name ||
       token?.metadata?.name ||
       'Untitled',
-    subtitle,
     thumbnailUri: resolveThumbnailUrl(token),
     listArtistJson: artists.length > 0 ? JSON.stringify(artists) : null,
   };
@@ -988,7 +979,6 @@ CREATE TABLE IF NOT EXISTS items (
   id TEXT NOT NULL PRIMARY KEY,
   kind INTEGER NOT NULL,
   title TEXT,
-  subtitle TEXT,
   thumbnail_uri TEXT,
   duration_sec INTEGER,
   provenance_json TEXT,
@@ -1182,7 +1172,6 @@ END;`);
       'id',
       'kind',
       'title',
-      'subtitle',
       'thumbnail_uri',
       'duration_sec',
       'provenance_json',

--- a/test/unit/app/providers/now_displaying_provider_test.dart
+++ b/test/unit/app/providers/now_displaying_provider_test.dart
@@ -301,7 +301,10 @@ class _RecordingDatabaseService extends DatabaseService {
   }
 
   @override
-  Future<void> upsertPlaylistItemsEnriched(List<PlaylistItem> items) async {
+  Future<void> upsertPlaylistItemsEnriched(
+    List<PlaylistItem> items, {
+    bool shouldForce = true,
+  }) async {
     savedEnriched = List<PlaylistItem>.from(items);
     if (!enrichmentDone.isCompleted) {
       enrichmentDone.complete();

--- a/test/unit/domain/models/playlist_item_test.dart
+++ b/test/unit/domain/models/playlist_item_test.dart
@@ -64,7 +64,7 @@ void main() {
         id: 'item_test',
         kind: PlaylistItemKind.indexerToken,
         title: 'Test Item',
-        subtitle: 'Test Artist',
+        artists: [DP1Artist(name: 'Test Artist', id: 'artist_1')],
       );
 
       final json = item.toJson();
@@ -72,7 +72,7 @@ void main() {
       expect(json['id'], equals('item_test'));
       expect(json['kind'], equals(1)); // indexerToken
       expect(json['title'], equals('Test Item'));
-      expect(json['subtitle'], equals('Test Artist'));
+      expect(json['artists'], isNotNull);
     });
 
     test('fromJson deserializes correctly', () {
@@ -80,7 +80,9 @@ void main() {
         'id': 'item_test',
         'kind': 1,
         'title': 'Test Item',
-        'subtitle': 'Test Artist',
+        'artists': [
+          {'name': 'Test Artist', 'id': 'artist_1'},
+        ],
       };
 
       final item = PlaylistItem.fromJson(json);
@@ -88,7 +90,7 @@ void main() {
       expect(item.id, equals('item_test'));
       expect(item.kind, equals(PlaylistItemKind.indexerToken));
       expect(item.title, equals('Test Item'));
-      expect(item.subtitle, equals('Test Artist'));
+      expect(item.artistName, equals('Test Artist'));
     });
   });
 }

--- a/test/unit/infra/database/converters_test.dart
+++ b/test/unit/infra/database/converters_test.dart
@@ -1,4 +1,5 @@
 import 'package:app/domain/models/channel.dart';
+import 'package:app/domain/models/dp1/dp1_manifest.dart';
 import 'package:app/domain/models/playlist.dart';
 import 'package:app/domain/models/playlist_item.dart';
 import 'package:app/infra/database/app_database.dart';
@@ -122,7 +123,7 @@ void main() {
           id: 'item_test',
           kind: PlaylistItemKind.indexerToken,
           title: 'Test Item',
-          subtitle: 'Test Artist',
+          artists: [const DP1Artist(name: 'Test Artist', id: 'artist_1')],
           thumbnailUrl: 'https://example.com/thumb.jpg',
           duration: 120,
           updatedAt: DateTime(2024),
@@ -133,7 +134,6 @@ void main() {
         expect(companion.id.value, 'item_test');
         expect(companion.kind.value, 1); // IndexerToken
         expect(companion.title.value, 'Test Item');
-        expect(companion.subtitle.value, 'Test Artist');
         expect(companion.thumbnailUri.value, 'https://example.com/thumb.jpg');
         expect(companion.durationSec.value, 120);
       });
@@ -143,7 +143,6 @@ void main() {
           id: 'item_test',
           kind: 1,
           title: 'Test Item',
-          subtitle: 'Test Artist',
           thumbnailUri: 'https://example.com/thumb.jpg',
           durationSec: 120,
           enrichmentStatus: 0,
@@ -155,7 +154,6 @@ void main() {
         expect(item.id, 'item_test');
         expect(item.kind, PlaylistItemKind.indexerToken);
         expect(item.title, 'Test Item');
-        expect(item.subtitle, 'Test Artist');
         expect(item.thumbnailUrl, 'https://example.com/thumb.jpg');
         expect(item.duration, 120);
       });

--- a/test/unit/infra/database/token_transformer_test.dart
+++ b/test/unit/infra/database/token_transformer_test.dart
@@ -1,3 +1,4 @@
+import 'package:app/domain/extensions/playlist_item_ext.dart';
 import 'package:app/domain/models/indexer/asset_token.dart';
 import 'package:app/domain/models/playlist_item.dart';
 import 'package:app/infra/database/token_transformer.dart';
@@ -30,7 +31,7 @@ void main() {
         expect(item.id, 'cid_test123');
         expect(item.kind, PlaylistItemKind.indexerToken);
         expect(item.title, 'Test Artwork');
-        expect(item.subtitle, 'Artist 1, Artist 2');
+        expect(item.artistName, 'Artist 1, Artist 2');
         expect(item.artists?.map((a) => a.name), ['Artist 1', 'Artist 2']);
         expect(item.source, 'https://example.com/animation.mp4');
         expect(item.thumbnailUrl, 'https://example.com/thumb.jpg');


### PR DESCRIPTION
## Summary
- Remove `subtitle` field from `PlaylistItem` domain model
- Derive artist string from `List<DP1Artist>` via `artistName` getter (in `playlist_item_ext.dart`)
- Update `dp1PlaylistItemToPlaylistItem` to fallback item fields to token when empty/null
- Remove `subtitle` column from Items table (schema v4 migration)
- Update converters, token_transformer, database_service, build script
- Update UI: work_grid_card, work_detail_sections, now_displaying_screen

## Why
`subtitle` was redundant—it stored the artist string, which can be derived from `artists` list via `artistName`.

Made with [Cursor](https://cursor.com)