### PR TITLE
feat(routing): add deeplink support for channel and work by id

### DIFF
--- a/lib/app/routing/deeplink_handler.dart
+++ b/lib/app/routing/deeplink_handler.dart
@@ -206,6 +206,12 @@ final deeplinkActionsProvider = StreamProvider<DeeplinkNavigationAction>((ref) {
   return handler.actions;
 });
 
+/// Time window for deduplicating the same link delivered multiple times.
+/// On cold start or when link.feralfile.com redirects, app_links can deliver
+/// the same URI via both getInitialLink and uriLinkStream, or uriLinkStream
+/// can fire twice (e.g. Android onNewIntent with redirects).
+const Duration _deeplinkDedupWindow = Duration(seconds: 2);
+
 /// Coordinates deeplink ingestion and emits typed navigation actions.
 class DeeplinkHandler {
   /// Constructor
@@ -215,6 +221,7 @@ class DeeplinkHandler {
 
   final DeeplinkLinkSource _linkSource;
   final Map<String, bool> _handlingLinks = <String, bool>{};
+  final Map<String, DateTime> _recentlyProcessedLinks = <String, DateTime>{};
   final StreamController<DeeplinkNavigationAction> _actionsController =
       StreamController<DeeplinkNavigationAction>.broadcast();
 
@@ -305,6 +312,13 @@ class DeeplinkHandler {
         return null;
       }
 
+      _pruneExpiredDedupEntries();
+      final lastProcessed = _recentlyProcessedLinks[link];
+      if (lastProcessed != null &&
+          DateTime.now().difference(lastProcessed) < _deeplinkDedupWindow) {
+        return null;
+      }
+
       final action = DeeplinkNavigationAction(
         link: link,
         source: source,
@@ -315,12 +329,20 @@ class DeeplinkHandler {
       );
       if (!_actionsController.isClosed) {
         _actionsController.add(action);
+        _recentlyProcessedLinks[link] = DateTime.now();
       }
       return action;
     } finally {
       _handlingLinks.remove(link);
       await onFinished?.call();
     }
+  }
+
+  void _pruneExpiredDedupEntries() {
+    final now = DateTime.now();
+    _recentlyProcessedLinks.removeWhere(
+      (_, time) => now.difference(time) >= _deeplinkDedupWindow,
+    );
   }
 
   /// Disposes the handler.

--- a/test/unit/app/routing/deeplink_handler_test.dart
+++ b/test/unit/app/routing/deeplink_handler_test.dart
@@ -227,5 +227,24 @@ void main() {
       expect(action.location, '/works/work-456');
       expect(action.source, DeeplinkSource.appLink);
     });
+
+    test('deduplicates same link when delivered twice within dedup window',
+        () async {
+      final handler = DeeplinkHandler(
+        linkSource: _FakeDeeplinkLinkSource(),
+      );
+      addTearDown(handler.dispose);
+
+      final actions = <DeeplinkNavigationAction>[];
+      handler.actions.listen(actions.add);
+
+      const link = 'https://link.feralfile.com/playlists/dup-test-id';
+
+      await handler.handleRawLink(link, source: DeeplinkSource.appLink);
+      await handler.handleRawLink(link, source: DeeplinkSource.appLink);
+
+      expect(actions.length, 1);
+      expect(actions.first.location, '/playlists/dup-test-id');
+    });
   });
 }


### PR DESCRIPTION
## Summary
Extend deeplink handler to support navigation to channel by ID and work (item) by ID, following the same pattern as playlist deeplinks.

## Supported URL patterns

| Type | Example URL | Internal route |
|------|-------------|----------------|
| Channel by ID | `https://link.feralfile.com/channels/abc-123` | `/channels/abc-123` |
| Work by ID | `https://link.feralfile.com/works/xyz-456` | `/works/xyz-456` |
| Work alias | `https://link.feralfile.com/items/xyz-456` | `/works/xyz-456` |

## Changes
- Added `_normalizeChannelsLocation` for `/channels`, `/channels/all`, `/channels/:channelId`
- Added `_normalizeWorksLocation` for `/works/:workId` and `/items/:workId` alias
- Extended `resolveAppLocationFromDeeplink` to try playlists, then channels, then works
- Added unit tests for channel, work, and items deeplink resolution

Made with [Cursor](https://cursor.com)