### PR TITLE
fix(playlist): preserve metadata in details load race

### DIFF
--- a/lib/app/providers/playlist_details_provider.dart
+++ b/lib/app/providers/playlist_details_provider.dart
@@ -68,6 +68,7 @@ class PlaylistDetailsNotifier
   static final _log = Logger('PlaylistDetailsNotifier');
   StreamSubscription<List<PlaylistItem>>? _dbSubscription;
   bool _isPlaylistLoaded = false;
+  Playlist? _loadedPlaylist;
 
   @override
   AsyncValue<PlaylistDetailsState> build() {
@@ -96,6 +97,7 @@ class PlaylistDetailsNotifier
       final playlist = await ref
           .read(databaseServiceProvider)
           .getPlaylistById(_playlistId);
+      _loadedPlaylist = playlist;
       if (!ref.mounted) return;
       final current = switch (state) {
         AsyncData(value: final v) => v,
@@ -139,7 +141,7 @@ class PlaylistDetailsNotifier
       final hasMore = fullList.length > initialItems.length;
       state = AsyncValue.data(
         PlaylistDetailsState(
-          playlist: current?.playlist,
+          playlist: current?.playlist ?? _loadedPlaylist,
           items: initialItems,
           total: fullList.length,
           hasMore: hasMore,
@@ -160,7 +162,7 @@ class PlaylistDetailsNotifier
     if (hasChanged) {
       state = AsyncValue.data(
         PlaylistDetailsState(
-          playlist: current.playlist,
+          playlist: current.playlist ?? _loadedPlaylist,
           items: newSlice,
           total: fullList.length,
           hasMore: fullList.length > loadedCount,

--- a/test/unit/app/providers/playlist_details_provider_test.dart
+++ b/test/unit/app/providers/playlist_details_provider_test.dart
@@ -1,4 +1,8 @@
+import 'dart:async';
+
 import 'package:app/app/providers/playlist_details_provider.dart';
+import 'package:app/domain/models/playlist.dart';
+import 'package:app/domain/models/playlist_item.dart';
 import 'package:app/infra/database/app_database.dart';
 import 'package:app/infra/database/database_provider.dart';
 import 'package:app/infra/database/database_service.dart';
@@ -8,7 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('playlistDetailsProvider starts in loading state', () {
-    // Unit test: verifies playlist details provider initializes with AsyncLoading.
+    // Unit test: playlist details provider initializes with AsyncLoading.
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
     final container = ProviderContainer.test(
@@ -21,4 +25,98 @@ void main() {
     final state = container.read(playlistDetailsProvider('pl_missing'));
     expect(state, isA<AsyncLoading<PlaylistDetailsState>>());
   });
+
+  test(
+    'playlistDetailsProvider keeps metadata when playlist loads'
+    ' before items stream',
+    () async {
+      const playlistId = 'pl_test';
+      final controller = StreamController<List<PlaylistItem>>();
+      addTearDown(controller.close);
+
+      final fakeService = _FakeDatabaseService(
+        playlist: const Playlist(
+          id: playlistId,
+          name: 'Test Playlist',
+          type: PlaylistType.dp1,
+        ),
+        itemsStream: controller.stream,
+      );
+      addTearDown(fakeService.close);
+
+      final container = ProviderContainer.test(
+        overrides: [
+          databaseServiceProvider.overrideWith((ref) => fakeService),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Let metadata load before the first items stream emission.
+      container.listen(
+        playlistDetailsProvider(playlistId),
+        (_, _) {},
+      );
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      controller.add(
+        const [
+          PlaylistItem(
+            id: 'it_1',
+            kind: PlaylistItemKind.dp1Item,
+            title: 'Item 1',
+            duration: 1,
+          ),
+        ],
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      final state = container.read(playlistDetailsProvider(playlistId));
+      expect(state, isA<AsyncData<PlaylistDetailsState>>());
+      expect(state.value?.playlist?.id, playlistId);
+    },
+  );
+}
+
+class _FakeDatabaseService extends DatabaseService {
+  factory _FakeDatabaseService({
+    required Playlist? playlist,
+    required Stream<List<PlaylistItem>> itemsStream,
+  }) {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    return _FakeDatabaseService._(
+      db,
+      playlist: playlist,
+      itemsStream: itemsStream,
+    );
+  }
+
+  _FakeDatabaseService._(
+    this._ownedDb, {
+    required this.playlist,
+    required this.itemsStream,
+  }) : super(_ownedDb);
+
+  final Playlist? playlist;
+  final Stream<List<PlaylistItem>> itemsStream;
+  final AppDatabase _ownedDb;
+
+  @override
+  Future<Playlist?> getPlaylistById(String id) async => playlist;
+
+  @override
+  Stream<List<PlaylistItem>> watchPlaylistItems(String playlistId) =>
+      itemsStream;
+
+  @override
+  Future<List<PlaylistItem>> getPlaylistItems(
+    String playlistId, {
+    int? limit,
+    int? offset,
+  }) async {
+    return const <PlaylistItem>[];
+  }
+
+  @override
+  Future<void> close() => _ownedDb.close();
 }


### PR DESCRIPTION
## Summary
- fix a race in `PlaylistDetailsNotifier` where playlist metadata could be lost if metadata loaded before the first items stream emission
- cache loaded playlist metadata and reuse it when building initial/updated detail state from DB stream updates
- add a regression unit test for the metadata-first timing scenario

## Validation
- flutter test test/unit/app/providers/playlist_details_provider_test.dart
- scripts/agent-helpers/post-implementation-checks HEAD
