### PR TITLE
fix: correct FF1WifiSendLogRequest command name to uploadLogs

### DIFF
--- a/lib/infra/ff1/wifi_protocol/ff1_wifi_messages.dart
+++ b/lib/infra/ff1/wifi_protocol/ff1_wifi_messages.dart
@@ -569,7 +569,7 @@ class FF1WifiSendLogRequest extends FF1WifiCommandRequest {
   final String apiKey;
 
   @override
-  String get command => 'sendLog';
+  String get command => 'uploadLogs';
 
   @override
   Map<String, dynamic> get params => SendLogRequest(


### PR DESCRIPTION
## Summary
- Fix incorrect command string in `FF1WifiSendLogRequest`: changed `'sendLog'` → `'uploadLogs'` to match the actual FF1 WiFi protocol spec

## Test plan
- [ ] Verify log upload command is sent correctly to the FF1 device over WiFi


Made with [Cursor](https://cursor.com)