### PR TITLE
fix(playlist): preserve work count when scrolling carousel in Me section

### DIFF
--- a/lib/app/providers/playlist_details_provider.dart
+++ b/lib/app/providers/playlist_details_provider.dart
@@ -201,11 +201,13 @@ class PlaylistDetailsNotifier
         return;
       }
       final newItemsList = [...current.items, ...newItems];
+      // Preserve total from DB watcher; it must not change when loading more
+      // pages (otherwise "Up to date. X works" would jump as user scrolls).
       state = AsyncValue.data(
         PlaylistDetailsState(
           playlist: current.playlist,
           items: newItemsList,
-          total: newItemsList.length,
+          total: current.total,
           hasMore: newItems.length >= _pageSize,
           offset: current.offset + newItems.length,
         ),


### PR DESCRIPTION
## Problem
When scrolling the Carousel Items in the Me section (address playlists), the work number in "Up to date. X works" was changing incorrectly.

## Root cause
In `playlist_details_provider.dart`, `loadMore()` was setting `total: newItemsList.length` — the count of loaded items — instead of preserving the actual total from the DB watcher. Each time the user scrolled and triggered load more, the displayed count would jump (10, 20, 30...).

## Solution
Preserve `current.total` in `loadMore()` since it is correctly set by `_onDatabaseChanged` from the full playlist count in the database.

Made with [Cursor](https://cursor.com)