### PR TITLE
feat(sync): treat viewability_changed is_viewable=false as removal in syncCollection

### DIFF
--- a/lib/domain/utils/token_event_grouping.dart
+++ b/lib/domain/utils/token_event_grouping.dart
@@ -19,26 +19,54 @@ class TokenEventGroupingResult {
   final Set<int> updatedTokenIds;
 }
 
-/// Transfer event types: ownership changes only.
-/// Excludes metadata_updated, enrichment_updated, viewability_changed.
-bool _isTransferEvent(TokenEvent e) =>
-    e.eventType == 'released' || e.eventType == 'acquired';
+/// Extension on [TokenEvent] for event type checks.
+extension TokenEventExtension on TokenEvent {
+  /// True if event is a transfer (released or acquired).
+  /// Excludes metadata_updated, enrichment_updated, viewability_changed.
+  bool get isTransferEvent =>
+      eventType == 'released' || eventType == 'acquired';
 
-/// Groups [TokenEvent]s into removal (transferred out) vs updated (kept/refreshed).
+  /// True if event is viewability_changed.
+  bool get isTokenViewabilityEvent => eventType == 'viewability_changed';
+
+  /// True if event is released (transfer out).
+  bool get isRelease => eventType == 'released';
+
+  /// True if viewability_changed metadata has is_viewable == false.
+  bool get isViewableFalse =>
+      eventType == 'viewability_changed' &&
+      metadata?['is_viewable'] == false;
+}
+
+/// Extension on [List<TokenEvent]> for extracting last transfer and viewability events.
+extension _TokenEventsListExtension on List<TokenEvent> {
+  /// Last transfer event (released or acquired), or null if none.
+  TokenEvent? get lastTransferEvent {
+    for (var i = length - 1; i >= 0; i--) {
+      final e = this[i];
+      if (e.isTransferEvent) return e;
+    }
+    return null;
+  }
+
+  /// Last viewability_changed event, or null if none.
+  TokenEvent? get lastTokenViewabilityEvent {
+    for (var i = length - 1; i >= 0; i--) {
+      final e = this[i];
+      if (e.isTokenViewabilityEvent) return e;
+    }
+    return null;
+  }
+}
+
+/// Groups [TokenEvent]s into removal (transferred out or hidden) vs updated (kept/refreshed).
 ///
-/// For each tokenId, takes the **last transfer event** (released or acquired),
-/// not the last event of any type. Attribute-only events (metadata_updated,
-/// enrichment_updated, viewability_changed) do not affect ownership.
-///
-/// - If last transfer is `released` AND `owner_address == address`: token was
-///   transferred out from this address -> removal.
-/// - Else (last transfer is `acquired`, or `released` to someone else):
-///   token is still owned or was re-acquired -> updated.
+/// For each tokenId:
+/// - If last transfer is `released` AND `owner_address == address`: removal.
+/// - Else if last viewability event has `metadata.is_viewable == false`: removal.
+/// - Else: updated.
 ///
 /// Each token belongs to at most one group (removal xor updated).
-///
-/// Example: A transfers to B, B back to A. For address A, the last transfer
-/// is `acquired` (A received it back), so the token is in updated, not removal.
 TokenEventGroupingResult groupTokenEvents({
   required List<TokenEvent> events,
   required String address,
@@ -65,27 +93,23 @@ TokenEventGroupingResult groupTokenEvents({
     final tokenEvents = entry.value;
     if (tokenEvents.isEmpty) continue;
 
-    // Last transfer event (released or acquired) - ignore attribute-only events.
-    final transferEvents = tokenEvents
-        .where(_isTransferEvent)
-        .toList(growable: false);
-    if (transferEvents.isEmpty) {
-      // No transfer events: treat as updated (e.g. metadata-only changes).
-      updatedTokenIds.add(tokenId);
+    final lastTransfer = tokenEvents.lastTransferEvent;
+    if (lastTransfer != null) {
+      final ownerMatches =
+          lastTransfer.ownerAddress?.toNormalizedAddress() == normalizedAddress;
+      if (lastTransfer.isRelease && ownerMatches) {
+        removalTokenIds.add(tokenId);
+        continue;
+      }
+    }
+
+    final lastViewability = tokenEvents.lastTokenViewabilityEvent;
+    if (lastViewability != null && lastViewability.isViewableFalse) {
+      removalTokenIds.add(tokenId);
       continue;
     }
 
-    final lastTransfer = transferEvents.last;
-
-    final isReleased = lastTransfer.eventType == 'released';
-    final ownerMatches =
-        lastTransfer.ownerAddress?.toNormalizedAddress() == normalizedAddress;
-
-    if (isReleased && ownerMatches) {
-      removalTokenIds.add(tokenId);
-    } else {
-      updatedTokenIds.add(tokenId);
-    }
+    updatedTokenIds.add(tokenId);
   }
 
   return TokenEventGroupingResult(

--- a/lib/infra/graphql/queries/sync_collection_queries.dart
+++ b/lib/infra/graphql/queries/sync_collection_queries.dart
@@ -1,7 +1,7 @@
 /// GraphQL queries for the indexer syncCollection API.
 ///
 /// Fetches token events for an address with checkpoint-based pagination.
-/// Requests only fields used for grouping (token_id, event_type, owner_address).
+/// Requests fields used for grouping (token_id, event_type, owner_address, metadata).
 const String syncCollectionQuery = r'''
   query syncCollection(
     $address: String!
@@ -19,6 +19,7 @@ const String syncCollectionQuery = r'''
         token_id
         event_type
         owner_address
+        metadata
       }
       next_checkpoint {
         timestamp

--- a/test/unit/domain/utils/token_event_grouping_test.dart
+++ b/test/unit/domain/utils/token_event_grouping_test.dart
@@ -121,5 +121,194 @@ void main() {
       expect(result.removalTokenIds, {100});
       expect(result.updatedTokenIds, {200, 300});
     });
+
+    test('viewability_changed with is_viewable: false -> removal', () {
+      final events = [
+        TokenEvent(
+          id: 1,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024),
+          metadata: {'is_viewable': true},
+        ),
+        TokenEvent(
+          id: 2,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 2),
+          metadata: {'is_viewable': false},
+        ),
+        TokenEvent(
+          id: 3,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 3),
+          metadata: {'is_viewable': true},
+        ),
+        TokenEvent(
+          id: 4,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 4),
+          metadata: {'is_viewable': false},
+        ),
+        TokenEvent(
+          id: 5,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 5),
+          metadata: {'is_viewable': false},
+        ),
+      ];
+      final result = groupTokenEvents(
+        events: events,
+        address: '0xAAA',
+      );
+      expect(result.removalTokenIds, {100});
+      expect(result.updatedTokenIds, isEmpty);
+    });
+
+    test('viewability_changed with is_viewable: true -> updated', () {
+      final events = [
+        TokenEvent(
+          id: 1,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024),
+          metadata: {'is_viewable': false},
+        ),
+        TokenEvent(
+          id: 2,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 2),
+          metadata: {'is_viewable': true},
+        ),
+        TokenEvent(
+          id: 3,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 3),
+          metadata: {'is_viewable': false},
+        ),
+        TokenEvent(
+          id: 4,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 4),
+          metadata: {'is_viewable': true},
+        ),
+        TokenEvent(
+          id: 5,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 5),
+          metadata: {'is_viewable': true},
+        ),
+      ];
+      final result = groupTokenEvents(
+        events: events,
+        address: '0xAAA',
+      );
+      expect(result.removalTokenIds, isEmpty);
+      expect(result.updatedTokenIds, {100});
+    });
+
+    test('viewability_changed with metadata null or missing is_viewable -> updated',
+        () {
+      final events = [
+        TokenEvent(
+          id: 1,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024),
+          metadata: {'is_viewable': false},
+        ),
+        TokenEvent(
+          id: 2,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 2),
+        ),
+        TokenEvent(
+          id: 3,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 3),
+          metadata: {'is_viewable': true},
+        ),
+        TokenEvent(
+          id: 4,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 4),
+        ),
+        TokenEvent(
+          id: 5,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 5),
+        ),
+      ];
+      final result = groupTokenEvents(
+        events: events,
+        address: '0xAAA',
+      );
+      expect(result.removalTokenIds, isEmpty);
+      expect(result.updatedTokenIds, {100});
+    });
+
+    test('viewability_changed is_viewable: false overrides prior acquired', () {
+      final events = [
+        TokenEvent(
+          id: 1,
+          tokenId: 100,
+          eventType: 'acquired',
+          ownerAddress: '0xaaa',
+          occurredAt: DateTime.utc(2024),
+        ),
+        TokenEvent(
+          id: 2,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 2),
+          metadata: {'is_viewable': true},
+        ),
+        TokenEvent(
+          id: 3,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 3),
+          metadata: {'is_viewable': false},
+        ),
+        TokenEvent(
+          id: 4,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 4),
+          metadata: {'is_viewable': true},
+        ),
+        TokenEvent(
+          id: 5,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 5),
+          metadata: {'is_viewable': false},
+        ),
+        TokenEvent(
+          id: 6,
+          tokenId: 100,
+          eventType: 'viewability_changed',
+          occurredAt: DateTime.utc(2024, 1, 6),
+          metadata: {'is_viewable': false},
+        ),
+      ];
+      final result = groupTokenEvents(
+        events: events,
+        address: '0xAAA',
+      );
+      expect(result.removalTokenIds, {100});
+      expect(result.updatedTokenIds, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
## Summary
Treat `viewability_changed` events with `metadata.is_viewable == false` as removal (not update) in syncCollection grouping, aligning with indexer behavior where unviewable tokens are filtered from collections.

## Changes
- Add `metadata` to syncCollection GraphQL query for viewability_changed events
- Add `TokenEventExtension` with `isTransferEvent`, `isTokenViewabilityEvent`, `isRelease`, `isViewableFalse`
- Add `List<TokenEvent>` extension with `lastTransferEvent`, `lastTokenViewabilityEvent`
- Group viewability_changed with is_viewable=false into removal group
- Add unit tests with 5+ viewability_changed events per token

## Verification
- All unit tests pass
- Post-implementation checks pass

Made with [Cursor](https://cursor.com)