### PR TITLE
docs(spec): clarify doc hierarchy and add vision-execution gap tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,13 @@ This file defines repository-level constraints for coding agents. Detailed imple
 - Specs and flow docs:
   - `docs/project_spec.md`
   - `docs/app_flows.md`
+  - `docs/vision_execution_gap.md`
   - `docs/ui_rhythm_contract.md`
+
+## Spec hierarchy
+- `docs/project_spec.md` is the canonical product contract.
+- `docs/app_flows.md` is the execution-level mapping of that contract.
+- `docs/vision_execution_gap.md` tracks known gaps and refactor follow-ups.
 
 ## Non-negotiables
 - Prefer replacing or deleting flawed code paths over narrow local tweaks when solving an issue. If a broader rewrite produces a clearer design, choose it.

--- a/docs/app_flows.md
+++ b/docs/app_flows.md
@@ -1,5 +1,13 @@
 # App Flows
 
+## Document contract
+- This document is the execution-level companion to `docs/project_spec.md`.
+- It describes how the product contract is implemented through routes,
+  providers, services, and screen transitions.
+- It must not redefine domain vocabulary or product invariants.
+- If this file diverges from `docs/project_spec.md`, treat it as outdated and
+  update it to match the spec.
+
 ## Flow: Cold Start Bootstrap
 - goal: start app into a usable state with local data and providers initialized
 - start point: app process launch (`main()`)

--- a/docs/project_spec.md
+++ b/docs/project_spec.md
@@ -1,5 +1,14 @@
 # Project Spec
 
+## Document contract
+- This document is the canonical product contract for the mobile app.
+- It defines product intent, system boundaries, flow outcomes, and invariants.
+- When `project_spec.md` conflicts with lower-level docs, this file wins.
+- `docs/app_flows.md` must stay consistent with this contract and only expand
+  execution detail (routes, transitions, failure handling).
+- Any change to onboarding/address indexing/FF1 behavior should update this doc
+  first, then update `docs/app_flows.md` in the same change.
+
 ## 1. Purpose of the app
 - The app is the mobile controller and library browser for The Digital Art System.
 - It solves two practical problems for users:

--- a/docs/vision_execution_gap.md
+++ b/docs/vision_execution_gap.md
@@ -1,0 +1,67 @@
+# Vision/Execution Gap Tracker
+
+## Purpose
+- Track gaps between intended product behavior and current implementation.
+- Keep vision gaps and engineering refactors visible without mixing them into
+  unrelated feature PRs.
+- Provide a lightweight queue for follow-up work after shipping urgent fixes.
+
+## How to use
+- Keep entries outcome-focused (what user/system behavior is missing or brittle).
+- Link each gap to owning flow(s) in `docs/project_spec.md` and
+  `docs/app_flows.md`.
+- Mark each item with scope and priority.
+- Move completed items to a short history section instead of deleting context.
+
+## Active gaps
+
+### 1) Onboarding action controls need stable automation anchors
+- Type: execution reliability + testability
+- Priority: medium
+- Affected flows:
+  - Onboarding (No Deeplink)
+  - Onboarding from Device Deeplink/QR
+- Current gap:
+  - Gold-path tests still rely on action labels like "Next"/"Finish" in parts
+    of the flow, which can be non-hit-testable during async UI transitions.
+- Desired state:
+  - All primary onboarding actions use dedicated Patrol keys and test helpers
+    target keys first, not text.
+
+### 2) FF1 connect/setup orchestration remains distributed across providers
+- Type: architecture simplification
+- Priority: medium
+- Affected flows:
+  - FF1 Pairing and Wi-Fi Setup
+  - Onboarding from Device Deeplink/QR
+- Current gap:
+  - Readiness, retries, and post-connect routing logic is spread across BLE
+    transport + connect providers + page-level handlers.
+- Desired state:
+  - A single connect session orchestrator owns attempt lifecycle, cancellation,
+    and routing outcomes.
+
+### 3) Seed-sync progress competes with first-run onboarding interaction timing
+- Type: flow resilience
+- Priority: medium
+- Affected flows:
+  - Cold Start Bootstrap
+  - Onboarding (No Deeplink)
+- Current gap:
+  - Heavy seed-sync activity can overlap onboarding transitions and create UI
+    timing sensitivity in end-to-end runs.
+- Desired state:
+  - Clear handshake contract between onboarding action readiness and seed-sync
+    state updates so interaction targets remain deterministic.
+
+## Refactor backlog (candidate follow-ups)
+- Introduce `GoldPathPatrolKeys` for onboarding primary/secondary actions and
+  migrate remaining label-based taps to key-based taps.
+- Extract FF1 connect lifecycle into a dedicated session object (attempt id,
+  readiness state, cancellation token, terminal outcome), then keep providers
+  thin.
+- Separate startup bootstrap into explicit phases (gate open, background sync,
+  deferred recovery) with typed status events for UI/test observability.
+
+## Completed items
+- None yet.


### PR DESCRIPTION
## Summary
- Define explicit documentation hierarchy so `docs/project_spec.md` is the canonical product contract and `docs/app_flows.md` remains execution mapping only.
- Add `docs/vision_execution_gap.md` as the dedicated tracker for post-ship gaps and refactor follow-ups.
- Update `AGENTS.md` to reference the new hierarchy and vision/execution gap document.

## Why
- We just finished shipping urgent UI + FF1 reliability fixes; this keeps future work scoped and prevents drift between product contract and implementation-flow docs.
- Capturing known refactors in a single tracker helps prioritize architecture cleanup without mixing it into unrelated feature PRs.

## Scope
- Docs only (no runtime behavior changes).