### PR TITLE
refactor(onboarding): key onboarding actions for stable patrol automation

### DIFF
--- a/lib/app/patrol/gold_path_patrol_keys.dart
+++ b/lib/app/patrol/gold_path_patrol_keys.dart
@@ -29,6 +29,31 @@ abstract final class GoldPathPatrolKeys {
     'gold_path.now_displaying.bar',
   );
 
+  /// Introduce onboarding action that advances to add-address step.
+  static const onboardingIntroduceNext = ValueKey<String>(
+    'gold_path.onboarding.introduce.next',
+  );
+
+  /// Add-address onboarding action that opens add-address flow.
+  static const onboardingAddAddressPrimary = ValueKey<String>(
+    'gold_path.onboarding.add_address.primary',
+  );
+
+  /// Add-address onboarding action that advances (Skip for now / Next).
+  static const onboardingAddAddressSecondary = ValueKey<String>(
+    'gold_path.onboarding.add_address.secondary',
+  );
+
+  /// Setup-FF1 onboarding action that opens FF1 setup flow.
+  static const onboardingSetupFf1Primary = ValueKey<String>(
+    'gold_path.onboarding.setup_ff1.primary',
+  );
+
+  /// Setup-FF1 onboarding action that finishes onboarding.
+  static const onboardingSetupFf1Secondary = ValueKey<String>(
+    'gold_path.onboarding.setup_ff1.secondary',
+  );
+
   /// Stable channel row key for Curated channel carousels.
   static ValueKey<String> channelRow(String channelId) {
     return ValueKey<String>('gold_path.channels.row.$channelId');

--- a/lib/ui/screens/onboarding/introduce_page.dart
+++ b/lib/ui/screens/onboarding/introduce_page.dart
@@ -7,6 +7,7 @@
 
 import 'dart:async';
 
+import 'package:app/app/patrol/gold_path_patrol_keys.dart';
 import 'package:app/app/routing/routes.dart';
 import 'package:app/design/app_typography.dart';
 import 'package:app/design/build/primitives.dart';
@@ -22,7 +23,8 @@ import 'package:go_router/go_router.dart';
 /// Introductory onboarding page:
 /// "Explore digital art playlists"
 ///
-/// This widget is implemented using [OnboardingShell] to match the Figma screen:
+/// This widget is implemented using [OnboardingShell] to match the Figma
+/// screen:
 /// FF1 Art Computer → Onboarding B 4.
 ///
 
@@ -89,6 +91,7 @@ class IntroducePage extends StatelessWidget {
           ],
         ),
         onPrimaryPressed: () => onNext(context),
+        primaryButtonKey: GoldPathPatrolKeys.onboardingIntroduceNext,
       ),
     );
   }

--- a/lib/ui/screens/onboarding/onboarding_add_address_page.dart
+++ b/lib/ui/screens/onboarding/onboarding_add_address_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:app/app/patrol/gold_path_patrol_keys.dart';
 import 'package:app/app/providers/addresses_provider.dart';
 import 'package:app/app/providers/indexer_tokens_provider.dart';
 import 'package:app/app/providers/services_provider.dart';
@@ -85,6 +86,7 @@ class OnboardingAddAddressPage extends ConsumerWidget {
           ],
         ),
         onPrimaryPressed: () => _onAddAddressPressed(context),
+        primaryButtonKey: GoldPathPatrolKeys.onboardingAddAddressPrimary,
         secondaryButton: Consumer(
           builder: (context, ref, _) {
             final addressesAsync = ref.watch(addressesProvider);
@@ -109,6 +111,7 @@ class OnboardingAddAddressPage extends ConsumerWidget {
           },
         ),
         onSecondaryPressed: () async => _onNext(context, ref),
+        secondaryButtonKey: GoldPathPatrolKeys.onboardingAddAddressSecondary,
         hintText: 'You can always add addresses later.',
       ),
     );

--- a/lib/ui/screens/onboarding/setup_ff1_page.dart
+++ b/lib/ui/screens/onboarding/setup_ff1_page.dart
@@ -7,6 +7,7 @@
 
 import 'dart:async';
 
+import 'package:app/app/patrol/gold_path_patrol_keys.dart';
 import 'package:app/app/providers/onboarding_provider.dart';
 import 'package:app/app/routing/routes.dart';
 import 'package:app/design/app_typography.dart';
@@ -83,6 +84,7 @@ class OnboardingSetupFf1Page extends ConsumerWidget {
           ],
         ),
         onPrimaryPressed: () => _onSetupFf1(context, ref),
+        primaryButtonKey: GoldPathPatrolKeys.onboardingSetupFf1Primary,
         secondaryButton: Row(
           children: [
             Text(
@@ -92,6 +94,7 @@ class OnboardingSetupFf1Page extends ConsumerWidget {
           ],
         ),
         onSecondaryPressed: () async => _onFinish(context, ref),
+        secondaryButtonKey: GoldPathPatrolKeys.onboardingSetupFf1Secondary,
       ),
     );
   }

--- a/lib/widgets/onboarding/onboarding_shell.dart
+++ b/lib/widgets/onboarding/onboarding_shell.dart
@@ -25,8 +25,10 @@ class OnboardingShell extends StatelessWidget {
     required this.content,
     super.key,
     this.primaryButton,
+    this.primaryButtonKey,
     this.onPrimaryPressed,
     this.secondaryButton,
+    this.secondaryButtonKey,
     this.onSecondaryPressed,
     this.showBottomProgress = true,
     this.hintText,
@@ -41,12 +43,18 @@ class OnboardingShell extends StatelessWidget {
   /// Callback when the primary button is pressed.
   final VoidCallback? onPrimaryPressed;
 
+  /// Optional semantic key for the primary button.
+  final Key? primaryButtonKey;
+
   /// Optional label for the secondary (left) button.
   /// For example: "Add Address", "Setup FF1".
   final Widget? secondaryButton;
 
   /// Optional callback for the secondary button.
   final VoidCallback? onSecondaryPressed;
+
+  /// Optional semantic key for the secondary button.
+  final Key? secondaryButtonKey;
 
   /// Whether to show the white bottom progress line.
   final bool showBottomProgress;
@@ -99,6 +107,7 @@ class OnboardingShell extends StatelessWidget {
   Widget _buildButtonsRow(BuildContext context) {
     final primary = (primaryButton != null && onPrimaryPressed != null)
         ? CustomPrimaryButton(
+            key: primaryButtonKey,
             padding: EdgeInsets.symmetric(
               vertical: ContentRhythm.rowVerticalPadding,
             ),
@@ -109,6 +118,7 @@ class OnboardingShell extends StatelessWidget {
 
     final secondary = (secondaryButton != null && onSecondaryPressed != null)
         ? CustomPrimaryButton(
+            key: secondaryButtonKey,
             padding: EdgeInsets.symmetric(
               vertical: ContentRhythm.rowVerticalPadding,
             ),

--- a/patrol_test/gold_path_test.dart
+++ b/patrol_test/gold_path_test.dart
@@ -4,7 +4,8 @@ import 'package:app/app/patrol/gold_path_patrol_config.dart';
 import 'package:app/app/patrol/gold_path_patrol_keys.dart';
 import 'package:app/widgets/channels/channel_list_row.dart';
 import 'package:app/widgets/work_item_thumbnail.dart';
-import 'package:flutter/material.dart' show TextField, TextInputAction;
+import 'package:flutter/material.dart'
+    show TextField, TextInputAction, ValueKey;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 
@@ -45,32 +46,45 @@ void main() {
 
 Future<void> _completeOnboardingIfNeeded(PatrolIntegrationTester $) async {
   if ($('Explore digital art playlists').exists) {
-    await _tapOnboardingAction($, label: 'Next');
+    await _tapOnboardingAction(
+      $,
+      actionKey: GoldPathPatrolKeys.onboardingIntroduceNext,
+      actionLabel: 'Next',
+    );
   }
 
   if ($('See the art you already own').exists) {
     await _submitPersonalAddressInOnboarding($, _personalAddressName);
-    await _tapOnboardingAction($, label: 'Next');
+    await _tapOnboardingAction(
+      $,
+      actionKey: GoldPathPatrolKeys.onboardingAddAddressSecondary,
+      actionLabel: 'Next/Skip for now',
+    );
   }
 
   if ($('Add FF1 to your screens').exists) {
-    await _tapOnboardingAction($, label: 'Finish');
+    await _tapOnboardingAction(
+      $,
+      actionKey: GoldPathPatrolKeys.onboardingSetupFf1Secondary,
+      actionLabel: 'Finish',
+    );
   }
 }
 
 Future<void> _tapOnboardingAction(
   PatrolIntegrationTester $, {
-  required String label,
+  required ValueKey<String> actionKey,
+  required String actionLabel,
 }) async {
-  final textFinder = find.text(label);
-  final action = $(textFinder);
+  final actionFinder = find.byKey(actionKey);
+  final action = $(actionKey);
   final deadline = DateTime.now().add(const Duration(seconds: 20));
 
   while (DateTime.now().isBefore(deadline)) {
     await action.waitUntilExists(timeout: const Duration(seconds: 2));
 
     try {
-      await $.tester.ensureVisible(textFinder.first);
+      await $.tester.ensureVisible(actionFinder.first);
       await $.pump(const Duration(milliseconds: 200));
     } on Exception {
       // Keep retrying while screen is stabilizing.
@@ -84,7 +98,7 @@ Future<void> _tapOnboardingAction(
   }
 
   throw TimeoutException(
-    'Timed out tapping onboarding action "$label" after waiting for '
+    'Timed out tapping onboarding action "$actionLabel" after waiting for '
     'a hit-testable target.',
   );
 }
@@ -105,7 +119,7 @@ Future<void> _submitPersonalAddressInOnboarding(
 }
 
 Future<void> _openAddAddressFromOnboarding(PatrolIntegrationTester $) async {
-  final addAddressButton = $('Add Address');
+  final addAddressButton = $(GoldPathPatrolKeys.onboardingAddAddressPrimary);
   await addAddressButton.waitUntilVisible(
     timeout: const Duration(seconds: 30),
   );

--- a/test/unit/widgets/onboarding_shell_test.dart
+++ b/test/unit/widgets/onboarding_shell_test.dart
@@ -46,4 +46,28 @@ void main() {
       expect(find.text('Next'), findsOneWidget);
     },
   );
+
+  testWidgets('OnboardingShell applies provided action keys', (tester) async {
+    const primaryKey = ValueKey<String>('test.onboarding.primary');
+    const secondaryKey = ValueKey<String>('test.onboarding.secondary');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: OnboardingShell(
+            content: const SizedBox.shrink(),
+            primaryButton: const Text('Primary'),
+            primaryButtonKey: primaryKey,
+            onPrimaryPressed: () {},
+            secondaryButton: const Text('Secondary'),
+            secondaryButtonKey: secondaryKey,
+            onSecondaryPressed: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(primaryKey), findsOneWidget);
+    expect(find.byKey(secondaryKey), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- Add dedicated onboarding action keys to `GoldPathPatrolKeys` for Introduce, Add Address, and Setup FF1 steps.
- Extend `OnboardingShell` with optional `primaryButtonKey` and `secondaryButtonKey`, and wire those keys into onboarding screens.
- Update `patrol_test/gold_path_test.dart` to tap onboarding actions by key (with existing visibility safeguards) instead of relying on text labels.
- Add widget test coverage verifying `OnboardingShell` applies provided action keys.

## Why
- Recent Android gold-path failures were caused by label-based taps finding text that was present but not hit-testable during async transitions.
- Stable semantic keys make onboarding automation deterministic and less sensitive to copy/layout changes.

## Verification
- `flutter analyze lib/app/patrol/gold_path_patrol_keys.dart lib/widgets/onboarding/onboarding_shell.dart lib/ui/screens/onboarding/introduce_page.dart lib/ui/screens/onboarding/onboarding_add_address_page.dart lib/ui/screens/onboarding/setup_ff1_page.dart patrol_test/gold_path_test.dart test/unit/widgets/onboarding_shell_test.dart`
- `flutter test test/unit/widgets/onboarding_shell_test.dart`
- `scripts/agent-helpers/post-implementation-checks HEAD`