### PR TITLE
refactor(ff1): isolate connect attempt session lifecycle

### DIFF
--- a/lib/app/providers/connect_ff1_providers.dart
+++ b/lib/app/providers/connect_ff1_providers.dart
@@ -156,7 +156,8 @@ class ConnectFF1Notifier extends AsyncNotifier<ConnectFF1State> {
       }
     }
 
-    // Set initial connecting state
+    // BT is ready (or not required for direct-device flow).
+    // Now it is safe to show the connecting state and start the timer.
     _setStateIfSessionActive(
       session,
       ConnectFF1Connecting(blDevice: bluetoothDevice),


### PR DESCRIPTION
## Summary
- Introduce a dedicated in-provider connect-attempt session object to own cancellation and still-connecting timer lifecycle.
- Guard all connect flow side effects (`Connecting`/`StillConnecting`/`Connected`/`Error` state emissions and post-connect steps) behind session-activity checks.
- Wire transport connect with `shouldContinue` from the active session so retries stop as soon as the attempt is cancelled or replaced.

## Why
- FF1 connect flow previously mixed timer, cancellation, and post-connect transitions as notifier-global mutable state.
- When multiple connect attempts overlapped (retry, back navigation, rapid reconnect), stale async work could still emit state.
- Session-scoped orchestration keeps attempt lifecycle explicit and prevents stale transitions without changing transport/protocol contracts.

## Verification
- `flutter analyze lib/app/providers/connect_ff1_providers.dart`
- `flutter test test/unit/app/providers/connect_ff1_providers_test.dart`
- `scripts/agent-helpers/post-implementation-checks HEAD`