### PR TITLE
fix: suppress transient indexer GraphQL Sentry noise

### DIFF
--- a/lib/infra/graphql/indexer_client.dart
+++ b/lib/infra/graphql/indexer_client.dart
@@ -1,12 +1,18 @@
 import 'dart:async';
 import 'dart:collection';
+import 'dart:io';
 
 import 'package:app/infra/logging/log_sanitizer.dart';
 import 'package:app/infra/logging/structured_logger.dart';
 import 'package:graphql/client.dart';
+import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 import 'package:sentry/sentry.dart';
 import 'package:sentry_link/sentry_link.dart';
+
+/// Injectable Sentry capture hook so tests can verify reporting decisions
+/// without depending on the global Sentry client.
+typedef IndexerSentryCapture = Future<SentryId> Function(SentryEvent event);
 
 /// GraphQL client for the indexer service.
 /// Handles fetching tokens from the indexer API.
@@ -19,21 +25,17 @@ class IndexerClient {
     this.mutationTimeout = const Duration(seconds: 15),
     this.maxConcurrentRequests = 10,
     this.maxRequestsPerSecond = 10,
+    GraphQLClient? client,
+    IndexerSentryCapture? sentryCaptureEvent,
     Logger? logger,
-  }) : _client = GraphQLClient(
-         link: Link.from([
-           SentryGql.link(
-             shouldStartTransaction: true,
-             graphQlErrorsMarkTransactionAsFailed: true,
-           ),
-           HttpLink(
-             '$endpoint/graphql',
+  }) : _client =
+           client ??
+           _createClient(
+             endpoint: endpoint,
              defaultHeaders: defaultHeaders,
            ),
-         ]),
-         cache: GraphQLCache(),
-       ),
        _availableRequests = maxRequestsPerSecond,
+       _captureSentryEvent = sentryCaptureEvent ?? Sentry.captureEvent,
        _structuredLog = AppStructuredLog.forLogger(
          logger ?? Logger('IndexerClient'),
          context: {
@@ -63,6 +65,7 @@ class IndexerClient {
 
   /// Max requests allowed to start per second.
   final int maxRequestsPerSecond;
+  final IndexerSentryCapture _captureSentryEvent;
   final StructuredLogger _structuredLog;
 
   final Queue<_QueuedIndexerRequest<dynamic>> _pendingRequests =
@@ -71,6 +74,25 @@ class IndexerClient {
   int _activeRequests = 0;
   int _availableRequests;
   bool _isDisposed = false;
+
+  static GraphQLClient _createClient({
+    required String endpoint,
+    required Map<String, String> defaultHeaders,
+  }) {
+    return GraphQLClient(
+      link: Link.from([
+        SentryGql.link(
+          shouldStartTransaction: true,
+          graphQlErrorsMarkTransactionAsFailed: true,
+        ),
+        HttpLink(
+          '$endpoint/graphql',
+          defaultHeaders: defaultHeaders,
+        ),
+      ]),
+      cache: GraphQLCache(),
+    );
+  }
 
   /// Executes a raw GraphQL query.
   ///
@@ -97,8 +119,9 @@ class IndexerClient {
           'variables': LogSanitizer.sanitizeGraphqlVariables(vars),
         },
       );
+      final QueryResult result;
       try {
-        final result = await _client.query(
+        result = await _client.query(
           QueryOptions(
             document: gql(doc),
             variables: vars,
@@ -106,52 +129,6 @@ class IndexerClient {
             queryRequestTimeout: queryTimeout,
           ),
         );
-
-        if (result.hasException) {
-          _structuredLog.error(
-            event: 'graphql_operation_failed',
-            message:
-                'query ${operation.name} failed durationMs='
-                '${stopwatch.elapsedMilliseconds}',
-            error: result.exception,
-            payload: {
-              'operationType': operation.type,
-              'operationName': operation.name,
-              'durationMs': stopwatch.elapsedMilliseconds,
-              'variables': LogSanitizer.sanitizeGraphqlVariables(vars),
-              'error': _sanitizeGraphqlException(result.exception),
-            },
-          );
-          _captureGraphQLError(
-            operation: 'query',
-            doc: doc,
-            vars: vars,
-            exception: result.exception,
-          );
-          throw Exception('GraphQL error: ${result.exception}');
-        }
-
-        final data = result.data;
-        _structuredLog.info(
-          category: LogCategory.graphql,
-          event: 'graphql_operation_completed',
-          message:
-              'query ${operation.name} completed durationMs='
-              '${stopwatch.elapsedMilliseconds}',
-          payload: {
-            'operationType': operation.type,
-            'operationName': operation.name,
-            'durationMs': stopwatch.elapsedMilliseconds,
-            'hasData': data != null,
-          },
-        );
-        if (data == null) return null;
-        if (subKey == null) return Map<String, dynamic>.from(data);
-
-        final value = data[subKey];
-        return value is Map<String, dynamic>
-            ? value
-            : Map<String, dynamic>.from(data);
       } catch (e, stack) {
         _structuredLog.error(
           event: 'graphql_operation_failed',
@@ -177,6 +154,52 @@ class IndexerClient {
         );
         rethrow;
       }
+
+      if (result.hasException) {
+        _structuredLog.error(
+          event: 'graphql_operation_failed',
+          message:
+              'query ${operation.name} failed durationMs='
+              '${stopwatch.elapsedMilliseconds}',
+          error: result.exception,
+          payload: {
+            'operationType': operation.type,
+            'operationName': operation.name,
+            'durationMs': stopwatch.elapsedMilliseconds,
+            'variables': LogSanitizer.sanitizeGraphqlVariables(vars),
+            'error': _sanitizeGraphqlException(result.exception),
+          },
+        );
+        _captureGraphQLError(
+          operation: 'query',
+          doc: doc,
+          vars: vars,
+          exception: result.exception,
+        );
+        throw Exception('GraphQL error: ${result.exception}');
+      }
+
+      final data = result.data;
+      _structuredLog.info(
+        category: LogCategory.graphql,
+        event: 'graphql_operation_completed',
+        message:
+            'query ${operation.name} completed durationMs='
+            '${stopwatch.elapsedMilliseconds}',
+        payload: {
+          'operationType': operation.type,
+          'operationName': operation.name,
+          'durationMs': stopwatch.elapsedMilliseconds,
+          'hasData': data != null,
+        },
+      );
+      if (data == null) return null;
+      if (subKey == null) return Map<String, dynamic>.from(data);
+
+      final value = data[subKey];
+      return value is Map<String, dynamic>
+          ? value
+          : Map<String, dynamic>.from(data);
     });
   }
 
@@ -202,8 +225,9 @@ class IndexerClient {
           'variables': LogSanitizer.sanitizeGraphqlVariables(vars),
         },
       );
+      final QueryResult result;
       try {
-        final result = await _client
+        result = await _client
             .mutate(
               MutationOptions(
                 document: gql(doc),
@@ -213,52 +237,6 @@ class IndexerClient {
               ),
             )
             .timeout(mutationTimeout);
-
-        if (result.hasException) {
-          _structuredLog.error(
-            event: 'graphql_operation_failed',
-            message:
-                'mutation ${operation.name} failed durationMs='
-                '${stopwatch.elapsedMilliseconds}',
-            error: result.exception,
-            payload: {
-              'operationType': operation.type,
-              'operationName': operation.name,
-              'durationMs': stopwatch.elapsedMilliseconds,
-              'variables': LogSanitizer.sanitizeGraphqlVariables(vars),
-              'error': _sanitizeGraphqlException(result.exception),
-            },
-          );
-          _captureGraphQLError(
-            operation: 'mutation',
-            doc: doc,
-            vars: vars,
-            exception: result.exception,
-          );
-          throw Exception('GraphQL error: ${result.exception}');
-        }
-
-        final data = result.data;
-        _structuredLog.info(
-          category: LogCategory.graphql,
-          event: 'graphql_operation_completed',
-          message:
-              'mutation ${operation.name} completed durationMs='
-              '${stopwatch.elapsedMilliseconds}',
-          payload: {
-            'operationType': operation.type,
-            'operationName': operation.name,
-            'durationMs': stopwatch.elapsedMilliseconds,
-            'hasData': data != null,
-          },
-        );
-        if (data == null) return null;
-        if (subKey == null) return Map<String, dynamic>.from(data);
-
-        final value = data[subKey];
-        return value is Map<String, dynamic>
-            ? value
-            : Map<String, dynamic>.from(data);
       } catch (e, stack) {
         _structuredLog.error(
           event: 'graphql_operation_failed',
@@ -284,6 +262,52 @@ class IndexerClient {
         );
         rethrow;
       }
+
+      if (result.hasException) {
+        _structuredLog.error(
+          event: 'graphql_operation_failed',
+          message:
+              'mutation ${operation.name} failed durationMs='
+              '${stopwatch.elapsedMilliseconds}',
+          error: result.exception,
+          payload: {
+            'operationType': operation.type,
+            'operationName': operation.name,
+            'durationMs': stopwatch.elapsedMilliseconds,
+            'variables': LogSanitizer.sanitizeGraphqlVariables(vars),
+            'error': _sanitizeGraphqlException(result.exception),
+          },
+        );
+        _captureGraphQLError(
+          operation: 'mutation',
+          doc: doc,
+          vars: vars,
+          exception: result.exception,
+        );
+        throw Exception('GraphQL error: ${result.exception}');
+      }
+
+      final data = result.data;
+      _structuredLog.info(
+        category: LogCategory.graphql,
+        event: 'graphql_operation_completed',
+        message:
+            'mutation ${operation.name} completed durationMs='
+            '${stopwatch.elapsedMilliseconds}',
+        payload: {
+          'operationType': operation.type,
+          'operationName': operation.name,
+          'durationMs': stopwatch.elapsedMilliseconds,
+          'hasData': data != null,
+        },
+      );
+      if (data == null) return null;
+      if (subKey == null) return Map<String, dynamic>.from(data);
+
+      final value = data[subKey];
+      return value is Map<String, dynamic>
+          ? value
+          : Map<String, dynamic>.from(data);
     });
   }
 
@@ -356,15 +380,51 @@ class IndexerClient {
     }
   }
 
+  bool _shouldCaptureGraphQlException(OperationException? exception) {
+    if (exception == null) return true;
+    if (exception.graphqlErrors.isNotEmpty) return true;
+
+    final linkException = exception.linkException;
+    if (linkException == null) return true;
+    if (linkException is NetworkException) return false;
+
+    final originalException = linkException.originalException;
+    if (originalException is ClientException ||
+        originalException is SocketException) {
+      return false;
+    }
+
+    // We suppress known transport-level failures here so transient connectivity
+    // during startup does not become Sentry error noise. GraphQL/schema errors
+    // still report because those indicate server or client contract issues.
+    final combinedMessage = '$linkException ${originalException ?? ''}'
+        .toLowerCase();
+    const transportFailureMarkers = <String>[
+      'bad file descriptor',
+      'connection reset',
+      'connection refused',
+      'failed host lookup',
+      'network is unreachable',
+      'software caused connection abort',
+      'connection closed before full header was received',
+      'timed out',
+    ];
+    return !transportFailureMarkers.any(combinedMessage.contains);
+  }
+
   void _captureGraphQLError({
     required String operation,
     required String doc,
     required Map<String, dynamic> vars,
     required OperationException? exception,
   }) {
+    if (!_shouldCaptureGraphQlException(exception)) {
+      return;
+    }
+
     try {
       unawaited(
-        Sentry.captureEvent(
+        _captureSentryEvent(
           SentryEvent(
             message: SentryMessage(
               'IndexerClient $operation GraphQL exception',
@@ -401,7 +461,7 @@ class IndexerClient {
   }) {
     try {
       unawaited(
-        Sentry.captureEvent(
+        _captureSentryEvent(
           SentryEvent(
             message: SentryMessage('IndexerClient $operation failed'),
             level: SentryLevel.error,

--- a/test/unit/infra/graphql/indexer_client_sentry_test.dart
+++ b/test/unit/infra/graphql/indexer_client_sentry_test.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:app/infra/graphql/indexer_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:http/http.dart' show ClientException;
+import 'package:sentry/sentry.dart';
+
+void main() {
+  group('IndexerClient Sentry filtering', () {
+    test(
+      'query skips Sentry capture for transient network link failures',
+      () async {
+        final capturedEvents = <SentryEvent>[];
+        final client = IndexerClient(
+          endpoint: 'https://example.invalid',
+          client: _buildClient(
+            handler: (_) => Stream<Response>.error(
+              ServerException(
+                originalException: ClientException(
+                  'Bad file descriptor',
+                  Uri.parse('https://example.invalid/graphql'),
+                ),
+              ),
+            ),
+          ),
+          sentryCaptureEvent: (event) async {
+            capturedEvents.add(event);
+            return const SentryId.empty();
+          },
+        );
+
+        await expectLater(
+          client.query(
+            doc: 'query TestOperation { viewer { id } }',
+            vars: const {'owner': '0x123'},
+          ),
+          throwsA(isA<Exception>()),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(capturedEvents, isEmpty);
+
+        client.dispose();
+      },
+    );
+
+    test(
+      'mutation skips Sentry capture for transient network link failures',
+      () async {
+        final capturedEvents = <SentryEvent>[];
+        final client = IndexerClient(
+          endpoint: 'https://example.invalid',
+          client: _buildClient(
+            handler: (_) => Stream<Response>.error(
+              NetworkException.fromException(
+                originalException: const SocketException('Connection refused'),
+                originalStackTrace: StackTrace.current,
+                uri: Uri.parse('https://example.invalid/graphql'),
+              ),
+            ),
+          ),
+          sentryCaptureEvent: (event) async {
+            capturedEvents.add(event);
+            return const SentryId.empty();
+          },
+        );
+
+        await expectLater(
+          client.mutate(
+            doc: 'mutation TestMutation { triggerMetadataIndexing }',
+            vars: const {'owner': '0x123'},
+          ),
+          throwsA(isA<Exception>()),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(capturedEvents, isEmpty);
+
+        client.dispose();
+      },
+    );
+
+    test('query captures Sentry event for GraphQL response errors', () async {
+      final capturedEvents = <SentryEvent>[];
+      final client = IndexerClient(
+        endpoint: 'https://example.invalid',
+        client: _buildClient(
+          handler: (_) => Stream<Response>.value(
+            const Response(
+              errors: [
+                GraphQLError(message: 'Unauthorized'),
+              ],
+              response: {
+                'errors': [
+                  {'message': 'Unauthorized'},
+                ],
+              },
+            ),
+          ),
+        ),
+        sentryCaptureEvent: (event) async {
+          capturedEvents.add(event);
+          return const SentryId.empty();
+        },
+      );
+
+      await expectLater(
+        client.query(
+          doc: 'query TestOperation { viewer { id } }',
+          vars: const {'owner': '0x123'},
+        ),
+        throwsA(isA<Exception>()),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(capturedEvents, hasLength(1));
+      expect(
+        capturedEvents.single.message?.formatted,
+        'IndexerClient query GraphQL exception',
+      );
+      expect(capturedEvents.single.level, SentryLevel.error);
+
+      client.dispose();
+    });
+  });
+}
+
+GraphQLClient _buildClient({
+  required Stream<Response> Function(Request request) handler,
+}) {
+  return GraphQLClient(
+    link: Link.function((request, [forward]) => handler(request)),
+    cache: GraphQLCache(),
+  );
+}


### PR DESCRIPTION
## Summary
- suppress Sentry capture for transient indexer transport/link failures without muting real GraphQL response errors
- restructure `IndexerClient.query()` and `mutate()` so handled GraphQL exceptions do not fall through the unhandled-error capture path
- add unit coverage for the real query/mutate paths using injected GraphQL clients

## Verification
- `flutter test test/unit/infra/graphql/indexer_client_sentry_test.dart`
- `flutter test test/unit/infra/graphql test/unit/infra/services/indexer_service_test.dart`
- `scripts/agent-helpers/post-implementation-checks HEAD`
- `scripts/report_business_coverage.sh`
- `flutter build ios --simulator --debug --no-codesign`

Fixes #106