### PR TITLE
fix(favorite): skip ingest when adding existing work to favorite

### DIFF
--- a/lib/infra/services/favorite_playlist_service.dart
+++ b/lib/infra/services/favorite_playlist_service.dart
@@ -16,8 +16,15 @@ class FavoritePlaylistService {
   late final Logger _log;
 
   /// Add a work to the Favorite playlist.
+  ///
+  /// Skips ingest when the item already exists in the database. This avoids
+  /// triggering the work-detail watch stream and thus prevents the work
+  /// detail screen from rebuilding when adding to favorite from that screen.
   Future<void> addWorkToFavorite(PlaylistItem item) async {
-    await _db.ingestPlaylistItem(item);
+    final existing = await _db.getPlaylistItemById(item.id);
+    if (existing == null) {
+      await _db.ingestPlaylistItem(item);
+    }
     final sortKeyUs = DateTime.now().microsecondsSinceEpoch;
     await _db.addPlaylistEntry(
       playlistId: favoritePlaylistId,

--- a/test/unit/infra/services/favorite_playlist_service_test.dart
+++ b/test/unit/infra/services/favorite_playlist_service_test.dart
@@ -1,0 +1,73 @@
+import 'package:app/domain/models/playlist.dart';
+import 'package:app/domain/models/playlist_item.dart';
+import 'package:app/infra/database/app_database.dart';
+import 'package:app/infra/database/database_service.dart';
+import 'package:app/infra/services/favorite_playlist_service.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FavoritePlaylistService', () {
+    late AppDatabase db;
+    late DatabaseService dbService;
+    late FavoritePlaylistService favoriteService;
+
+    setUp(() {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      dbService = DatabaseService(db);
+      favoriteService = FavoritePlaylistService(databaseService: dbService);
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('addWorkToFavorite skips ingest when item already exists', () async {
+      await dbService.ingestPlaylist(Playlist.favorite());
+
+      final originalItem = PlaylistItem(
+        id: 'wk_existing',
+        kind: PlaylistItemKind.indexerToken,
+        title: 'Original Title',
+        updatedAt: DateTime.now(),
+      );
+      await dbService.ingestPlaylistItem(originalItem);
+
+      final itemWithDifferentContent = PlaylistItem(
+        id: 'wk_existing',
+        kind: PlaylistItemKind.indexerToken,
+        title: 'Updated Title',
+        updatedAt: DateTime.now(),
+      );
+      await favoriteService.addWorkToFavorite(itemWithDifferentContent);
+
+      final retrieved = await dbService.getPlaylistItemById('wk_existing');
+      expect(retrieved, isNotNull);
+      expect(retrieved!.title, 'Original Title');
+
+      final favoriteItems =
+          await dbService.getPlaylistItems(Playlist.favoriteId);
+      expect(favoriteItems.map((i) => i.id), contains('wk_existing'));
+    });
+
+    test('addWorkToFavorite ingests when item does not exist', () async {
+      await dbService.ingestPlaylist(Playlist.favorite());
+
+      final newItem = PlaylistItem(
+        id: 'wk_new',
+        kind: PlaylistItemKind.indexerToken,
+        title: 'New Work',
+        updatedAt: DateTime.now(),
+      );
+      await favoriteService.addWorkToFavorite(newItem);
+
+      final retrieved = await dbService.getPlaylistItemById('wk_new');
+      expect(retrieved, isNotNull);
+      expect(retrieved!.title, 'New Work');
+
+      final favoriteItems =
+          await dbService.getPlaylistItems(Playlist.favoriteId);
+      expect(favoriteItems.map((i) => i.id), contains('wk_new'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Fixes the issue where the work detail screen rebuilds when adding an artwork to favorite.

## Root cause
- `addWorkToFavorite` always called `ingestPlaylistItem` → `upsertItem` on DB
- `watchItemById` emitted on items table change
- `WorkDetailNotifier` received the emission and rebuilt state with incomplete data (no token, no mimeType)
- Entire work detail screen rebuilt

## Solution
Skip `ingestPlaylistItem` when the item already exists in the database. Only add the playlist entry. This prevents `watchPlaylistItemById` from emitting when adding to favorite from the work detail screen.

## Changes
- `lib/infra/services/favorite_playlist_service.dart`: Check `getPlaylistItemById` before ingest
- `test/unit/infra/services/favorite_playlist_service_test.dart`: Unit tests for skip-ingest and ingest-when-new behavior

## Related
- GitHub issue: https://github.com/orgs/feral-file/projects/2/views/1?filterQuery=favo&pane=issue&itemId=166147990&issue=feral-file%7Cff-app%7C121

Made with [Cursor](https://cursor.com)