### PR TITLE
refactor(address): unify address normalization with toNormalizedAddress

### DIFF
--- a/lib/app/providers/indexer_tokens_provider.dart
+++ b/lib/app/providers/indexer_tokens_provider.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:app/app/providers/services_provider.dart';
+import 'package:app/domain/utils/address_deduplication.dart';
 import 'package:app/infra/config/app_state_service.dart';
 import 'package:app/infra/database/database_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -152,7 +153,7 @@ class TokensSyncCoordinatorNotifier extends Notifier<TokensSyncState> {
     for (final address in addresses) {
       final trimmed = address.trim();
       if (trimmed.isEmpty) continue;
-      byKey.putIfAbsent(trimmed.toUpperCase(), () => trimmed);
+      byKey.putIfAbsent(trimmed.toNormalizedAddress(), trimmed.toNormalizedAddress);
     }
     final normalized = byKey.values.toList(growable: false);
     if (normalized.isEmpty) return;

--- a/lib/app/providers/sync_provider.dart
+++ b/lib/app/providers/sync_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:app/app/providers/indexer_tokens_provider.dart';
+import 'package:app/domain/utils/address_deduplication.dart';
 import 'package:app/infra/database/database_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
@@ -84,7 +85,7 @@ class IncrementalSyncNotifier extends Notifier<IncrementalSyncState> {
       final addresses = playlists
           .map((p) => p.ownerAddress)
           .whereType<String>()
-          .map((a) => a.toUpperCase())
+          .map((a) => a.toNormalizedAddress())
           .toList();
 
       if (addresses.isEmpty) {

--- a/lib/domain/extensions/playlist_ext.dart
+++ b/lib/domain/extensions/playlist_ext.dart
@@ -3,6 +3,7 @@ import 'package:app/domain/models/dp1/dp1_playlist.dart';
 import 'package:app/domain/models/playlist.dart';
 import 'package:app/domain/models/playlist_item.dart';
 import 'package:app/domain/models/wallet_address.dart';
+import 'package:app/domain/utils/address_deduplication.dart';
 import 'package:app/infra/config/app_config.dart';
 import 'package:uuid/uuid.dart';
 
@@ -35,10 +36,7 @@ extension PlaylistExt on Playlist {
   // Get the playlist id for an address-based playlist
   static String addressPlaylistId(String ownerAddress) {
     final chain = Chain.fromAddress(ownerAddress).toString();
-    final normalizedAddress = _normalizeAddressForPlaylist(
-      ownerAddress,
-      chain,
-    );
+    final normalizedAddress = ownerAddress.toNormalizedAddress();
     return 'addr:$chain:$normalizedAddress';
   }
 
@@ -50,10 +48,7 @@ extension PlaylistExt on Playlist {
     String? name,
   }) {
     final chain = walletAddress.chain;
-    final normalizedAddress = _normalizeAddressForPlaylist(
-      walletAddress.address,
-      chain,
-    );
+    final normalizedAddress = walletAddress.address.toNormalizedAddress();
     final now = DateTime.now();
 
     final dynamicQueries = [
@@ -79,18 +74,4 @@ extension PlaylistExt on Playlist {
       dynamicQueries: dynamicQueries,
     );
   }
-}
-
-/// Normalizes address for address-based playlist ID (Ethereum lowercase).
-String _normalizeAddressForPlaylist(String address, String chain) {
-  final trimmed = address.trim();
-  final chainLower = chain.toLowerCase();
-  if (chainLower == 'eth' ||
-      chainLower == 'ethereum' ||
-      (trimmed.startsWith('0x') || trimmed.startsWith('0X'))) {
-    return trimmed.startsWith('0X')
-        ? '0x${trimmed.substring(2)}'
-        : trimmed.toLowerCase();
-  }
-  return trimmed;
 }

--- a/lib/infra/services/personal_tokens_sync_service.dart
+++ b/lib/infra/services/personal_tokens_sync_service.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: public_member_api_docs // Reason: small service API is self-descriptive and covered by provider usage.
 
+import 'package:app/domain/utils/address_deduplication.dart';
 import 'package:app/infra/config/app_state_service.dart';
 import 'package:app/infra/database/database_service.dart';
 import 'package:app/infra/services/indexer_service.dart';
@@ -107,7 +108,7 @@ class PersonalTokensSyncService {
     );
   }
 
-  String _addressKey(String address) => address.trim().toUpperCase();
+  String _addressKey(String address) => address.toNormalizedAddress();
 
   String _addressForIndexer(String address) {
     final trimmed = address.trim();

--- a/test/integration/app/providers/indexer_tokens_provider_integration_test.dart
+++ b/test/integration/app/providers/indexer_tokens_provider_integration_test.dart
@@ -143,7 +143,7 @@ void main() {
         'Address $address',
         nowUs,
         nowUs,
-        address.toUpperCase(),
+        address.toNormalizedAddress(),
       ],
     );
   }
@@ -192,7 +192,7 @@ void main() {
       final db = sqlite3.open(context.databaseFile.path);
       addTearDown(db.dispose);
 
-      final ownerAddress = resolvedAddress.toUpperCase();
+      final ownerAddress = resolvedAddress.toNormalizedAddress();
       final tokenCountRows = db.select(
         '''
         SELECT COUNT(*) AS token_count
@@ -408,7 +408,7 @@ void main() {
       final db = sqlite3.open(context.databaseFile.path);
       addTearDown(db.dispose);
 
-      final ownerAddress = resolvedAddress.toUpperCase();
+      final ownerAddress = resolvedAddress.toNormalizedAddress();
       final releasedCid = tokenToRelease.cid;
       final releasedStillInPlaylist = db.select(
         '''

--- a/test/integration/infra/services/address_indexing_flow_integration_test.dart
+++ b/test/integration/infra/services/address_indexing_flow_integration_test.dart
@@ -112,7 +112,7 @@ void main() {
         final playlists =
             await context.databaseService.getAddressPlaylists();
         final match = playlists.where(
-          (p) => p.ownerAddress?.toUpperCase() == resolvedAddress.toUpperCase(),
+          (p) => p.ownerAddress?.toNormalizedAddress() == resolvedAddress.toNormalizedAddress(),
         ).toList();
         if (match.isNotEmpty) {
           tokenCount = match.first.itemCount;
@@ -131,7 +131,7 @@ void main() {
       final playlists =
           await context.databaseService.getAddressPlaylists();
       final playlistForAddress = playlists.where(
-        (p) => p.ownerAddress?.toUpperCase() == resolvedAddress.toUpperCase(),
+        (p) => p.ownerAddress?.toNormalizedAddress() == resolvedAddress.toNormalizedAddress(),
       ).firstOrNull;
       expect(
         playlistForAddress?.name,

--- a/test/unit/app/providers/indexer_tokens_provider_test.dart
+++ b/test/unit/app/providers/indexer_tokens_provider_test.dart
@@ -1,5 +1,6 @@
 import 'package:app/app/providers/indexer_tokens_provider.dart';
 import 'package:app/app/providers/services_provider.dart';
+import 'package:app/domain/utils/address_deduplication.dart';
 import 'package:app/infra/config/app_state_service.dart';
 import 'package:app/infra/database/app_database.dart';
 import 'package:app/infra/database/database_provider.dart';
@@ -16,7 +17,7 @@ class _TestAppStateService implements AppStateService {
 
   @override
   Future<void> trackPersonalAddress(String address) async {
-    tracked.add(address.toUpperCase());
+    tracked.add(address.toNormalizedAddress());
   }
 
   @override
@@ -73,7 +74,7 @@ Future<void> _seedAddressPlaylist(AppDatabase database, String address) async {
       'Address $address',
       nowUs,
       nowUs,
-      address.toUpperCase(),
+      address.toNormalizedAddress(),
     ],
   );
 }


### PR DESCRIPTION
## Summary
Unifies address normalization across the codebase by replacing `toUpperCase()` and `_normalizeAddressForPlaylist` with `toNormalizedAddress()`.

## Changes
- **playlist_ext**: Replace `_normalizeAddressForPlaylist` with `toNormalizedAddress()` (fixes 0X-prefix bug where hex was not lowercased)
- **personal_tokens_sync_service**: `_addressKey` now uses `toNormalizedAddress()`
- **indexer_tokens_provider**: Deduplication uses `toNormalizedAddress()` for key and value
- **sync_provider**: Address mapping uses `toNormalizedAddress()`
- **Tests**: Updated unit and integration tests to use `toNormalizedAddress()`

## Benefits
- Single canonical normalization approach
- Correct Ethereum (lowercase) and Tezos (case-sensitive) handling
- Bug fix for `0X...` addresses

Made with [Cursor](https://cursor.com)