### PR TITLE
Update script to build seed db

### DIFF
--- a/.github/workflows/create-db-snapshot.yml
+++ b/.github/workflows/create-db-snapshot.yml
@@ -12,7 +12,7 @@ on:
         description: Curated channel source (URL or file path)
         required: false
         type: string
-        default: 'https://feralfile-remote-configs.pages.dev/ff-app.json'
+        default: 'https://dp1-feed-operator-api-prod.autonomy-system.workers.dev/api/v1/registry/channels'
       feed_endpoint:
         description: Optional feed endpoint origin to ingest all channels
         required: false

--- a/scripts/build_feed_indexer_sqlite.js
+++ b/scripts/build_feed_indexer_sqlite.js
@@ -74,7 +74,8 @@ query getTokens(
   }
 }
 `;
-const REMOTE_CONFIG_URL = 'https://feralfile-remote-configs.pages.dev/ff-app.json';
+const REMOTE_CONFIG_URL =
+  'https://dp1-feed-operator-api-prod.autonomy-system.workers.dev/api/v1/registry/channels';
 const DEFAULT_CHANNEL_SOURCE = REMOTE_CONFIG_URL;
 const INDEXER_API_URL = 'https://indexer-v2.feralfile.com';
 const INDEXER_BATCH_SIZE = 50;


### PR DESCRIPTION
This PR aims to update the `scripts/build_feed_indexer_sqlite.js` that uses the latest indexer API and new [curated channel registry format](https://dp1-feed-operator-api-dev.autonomy-system.workers.dev/api/v1/registry/channels). 

This supports the Orbit 2 Publish-to-Play pipeline.