### PR TITLE
feat(ff1): WiFi observability logs, discrepancy tracking, and Sentry

### DIFF
--- a/lib/app/providers/app_lifecycle_provider.dart
+++ b/lib/app/providers/app_lifecycle_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:app/app/providers/ff1_wifi_providers.dart';
 import 'package:app/app/providers/indexer_tokens_provider.dart';
+import 'package:app/infra/logging/structured_logger.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
@@ -14,11 +15,13 @@ import 'package:logging/logging.dart';
 /// Lifecycle changes are used to coordinate app-level background/foreground work.
 class AppLifecycleNotifier extends Notifier<AppLifecycleState> {
   late final Logger _log;
+  late final StructuredLogger _slog;
   late final _Observer _observer;
 
   @override
   AppLifecycleState build() {
     _log = Logger('AppLifecycleNotifier');
+    _slog = AppStructuredLog.forLogger(_log, context: {'component': 'app_lifecycle'});
     _observer = _Observer(_onLifecycleChanged);
     WidgetsBinding.instance.addObserver(_observer);
 
@@ -47,6 +50,11 @@ class AppLifecycleNotifier extends Notifier<AppLifecycleState> {
       coordinator.startSyncCollectionPolling();
       // Reconnect relayer WebSocket when app resumes; Timer-based reconnect
       // does not fire while app is suspended.
+      _slog.info(
+        category: LogCategory.wifi,
+        event: 'lifecycle_resumed',
+        message: 'app resumed — triggering relayer reconnect',
+      );
       unawaited(
         ref.read(ff1WifiConnectionProvider.notifier).reconnect(),
       );
@@ -55,6 +63,15 @@ class AppLifecycleNotifier extends Notifier<AppLifecycleState> {
         state == AppLifecycleState.detached) {
       coordinator.pauseSyncCollectionPolling();
       // Pause relayer WebSocket to free resources; reconnect on resume.
+      // Note: `inactive` fires frequently on iOS (notification shade, control
+      // centre) so it also triggers pause/resume cycles — tracked as
+      // lifecycle_paused events to help diagnose false "Device not connected".
+      _slog.info(
+        category: LogCategory.wifi,
+        event: 'lifecycle_paused',
+        message: 'app lifecycle: $state — pausing relayer connection',
+        payload: {'lifecycleState': state.name},
+      );
       ref.read(ff1WifiConnectionProvider.notifier).pauseConnection();
     }
   }

--- a/lib/app/providers/bootstrap_provider.dart
+++ b/lib/app/providers/bootstrap_provider.dart
@@ -153,12 +153,14 @@ class BootstrapNotifier extends Notifier<BootstrapStatus> {
       _log.info('My Collection channel created');
 
       // Keep the auto-connect watcher alive to automatically connect to relayer
-      // when active FF1 device changes
+      // when active FF1 device changes. Also activate the discrepancy watcher
+      // that detects and reports the false "Device not connected" gap to Sentry.
       state = state.copyWith(
         phase: BootstrapPhase.activatingAutoConnectWatcher,
         message: 'Activating FF1 auto-connect watcher...',
       );
       ref.watch(ff1AutoConnectWatcherProvider);
+      ref.watch(ff1ConnectionDiscrepancyWatcherProvider);
 
       state = const BootstrapStatus(
         phase: BootstrapPhase.completed,

--- a/lib/app/providers/ff1_wifi_providers.dart
+++ b/lib/app/providers/ff1_wifi_providers.dart
@@ -9,9 +9,27 @@ import 'package:app/infra/ff1/wifi_control/ff1_wifi_rest_client.dart';
 import 'package:app/infra/ff1/wifi_protocol/ff1_wifi_messages.dart';
 import 'package:app/infra/ff1/wifi_transport/ff1_relayer_transport.dart';
 import 'package:app/infra/ff1/wifi_transport/ff1_wifi_transport.dart';
+import 'package:app/infra/logging/structured_logger.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:riverpod/src/providers/future_provider.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+Future<void> _captureFf1WifiConnectFailureToSentry({
+  required String operation,
+  required Object exception,
+  StackTrace? stackTrace,
+}) async {
+  await Sentry.captureException(
+    exception,
+    stackTrace: stackTrace ?? StackTrace.current,
+    withScope: (scope) {
+      scope
+        ..setTag('component', 'ff1_wifi')
+        ..setTag('ff1_operation', operation);
+    },
+  );
+}
 
 // ============================================================================
 // Custom Retry Logic for WiFi Operations
@@ -173,7 +191,14 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
         isConnecting: false,
         device: device,
       );
-    } on Exception catch (e) {
+    } on Exception catch (e, stackTrace) {
+      unawaited(
+        _captureFf1WifiConnectFailureToSentry(
+          operation: 'wifi_connect',
+          exception: e,
+          stackTrace: stackTrace,
+        ),
+      );
       state = state.copyWith(
         isConnected: false,
         isConnecting: false,
@@ -226,7 +251,14 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
       await _control.reconnect();
 
       state = state.copyWith(isConnected: true);
-    } on Exception catch (e) {
+    } on Exception catch (e, stackTrace) {
+      unawaited(
+        _captureFf1WifiConnectFailureToSentry(
+          operation: 'wifi_reconnect',
+          exception: e,
+          stackTrace: stackTrace,
+        ),
+      );
       state = state.copyWith(
         isConnected: false,
         error: e,
@@ -493,4 +525,102 @@ ff1WifiSendCommandProvider = FutureProvider.autoDispose
 
         return params.commandFn(control, params.topicId);
       },
+    );
+
+// ============================================================================
+// Connection discrepancy watcher
+// ============================================================================
+
+/// How long the transport can be connected while device-level "connected" is
+/// false before we consider it a discrepancy worth reporting.
+const _kDiscrepancyThreshold = Duration(seconds: 10);
+
+/// Notifier backing [ff1ConnectionDiscrepancyWatcherProvider].
+///
+/// Holds the timer as a field so it persists across dependency-driven rebuilds.
+/// A `Provider` body re-runs on each watched dependency change, which would
+/// silently drop a locally-scoped timer; a `Notifier` field survives rebuilds.
+class FF1ConnectionDiscrepancyWatcher extends Notifier<void> {
+  final _log = Logger('FF1ConnectionDiscrepancyWatcher');
+  late final StructuredLogger _slog;
+  Timer? _timer;
+
+  @override
+  void build() {
+    _slog = AppStructuredLog.forLogger(
+      _log,
+      context: {'component': 'ff1_discrepancy_watcher'},
+    );
+
+    // Watch the transport-level connection (WebSocket up/down).
+    final transportConnected = ref.watch(ff1WifiConnectionProvider).isConnected;
+    // Watch the device-level connection notification (FF1 connection message).
+    final deviceConnected = ref.watch(ff1DeviceConnectedProvider);
+
+    if (transportConnected && !deviceConnected) {
+      // Arm the timer once per gap opening — field persists across rebuilds
+      // so subsequent dependency-change rebuilds while the gap is still open
+      // will hit the already-running timer and skip re-arming.
+      _timer ??= Timer(_kDiscrepancyThreshold, _onDiscrepancyDetected);
+    } else {
+      // Gap closed (transport dropped or device confirmed connected).
+      _cancelTimer();
+    }
+
+    ref.onDispose(_cancelTimer);
+  }
+
+  void _cancelTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  void _onDiscrepancyDetected() {
+    _timer = null;
+
+    // Re-read to confirm the discrepancy still exists at fire time; the timer
+    // fires asynchronously so state may have resolved by then.
+    final stillTransportUp = ref.read(ff1WifiConnectionProvider).isConnected;
+    final stillDeviceDown = !ref.read(ff1DeviceConnectedProvider);
+    if (!stillTransportUp || !stillDeviceDown) {
+      return;
+    }
+
+    _slog.warning(
+      category: LogCategory.wifi,
+      event: 'connection_discrepancy',
+      message:
+          'transport connected but device-level not connected for '
+          '>${_kDiscrepancyThreshold.inSeconds}s — possible false '
+          '"Device not connected" in UI',
+      payload: {'thresholdSeconds': _kDiscrepancyThreshold.inSeconds},
+    );
+    unawaited(
+      Sentry.captureEvent(
+        SentryEvent(
+          message: SentryMessage(
+            'FF1 connection discrepancy: transport up but device-level '
+            'not connected for >${_kDiscrepancyThreshold.inSeconds}s',
+          ),
+          level: SentryLevel.warning,
+          tags: {'component': 'ff1_wifi'},
+        ),
+      ),
+    );
+  }
+}
+
+/// Connection discrepancy watcher provider.
+///
+/// Watches both the WebSocket transport state and the device-level connection
+/// notification state. When the transport is up but the device has not
+/// confirmed "connected" within [_kDiscrepancyThreshold], captures a Sentry
+/// event so we can track the frequency and circumstances of the false
+/// "Device not connected" UI state in production.
+///
+/// Keep this provider alive at the root level alongside
+/// [ff1AutoConnectWatcherProvider].
+final ff1ConnectionDiscrepancyWatcherProvider =
+    NotifierProvider<FF1ConnectionDiscrepancyWatcher, void>(
+      FF1ConnectionDiscrepancyWatcher.new,
     );

--- a/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
+++ b/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
@@ -20,8 +20,10 @@ import 'package:app/domain/models/ff1/loop_mode.dart';
 import 'package:app/domain/models/ff1_device.dart';
 import 'package:app/infra/ff1/wifi_protocol/ff1_wifi_messages.dart';
 import 'package:app/infra/ff1/wifi_transport/ff1_wifi_transport.dart';
+import 'package:app/infra/logging/structured_logger.dart';
 import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 // ============================================================================
 // WiFi Control (orchestration)
@@ -45,12 +47,14 @@ class FF1WifiControl {
   }) : _transport = transport,
        _restClient = restClient,
        _log = logger ?? Logger('FF1WifiControl') {
+    _slog = AppStructuredLog.forLogger(_log, context: {'component': 'ff1_wifi_control'});
     _startListening();
   }
 
   final FF1WifiTransport _transport;
   final dynamic _restClient;
   final Logger _log;
+  late final StructuredLogger _slog;
 
   // Stream controllers for state changes
   final _playerStatusController = BehaviorSubject<FF1PlayerStatus>();
@@ -190,8 +194,24 @@ class FF1WifiControl {
         final connectionStatus = FF1ConnectionStatus.fromJson(
           notification.message,
         );
+        final prev = _isDeviceConnected;
         _isDeviceConnected = connectionStatus.isConnected;
         _connectionStatusController.add(connectionStatus);
+        // Track every device-level connection notification so we can see
+        // when the device sends "connected" vs "disconnected" and correlate
+        // with the WebSocket transport state.
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'device_connection_notification',
+          message:
+              'device connection notification: isConnected=${connectionStatus.isConnected}',
+          payload: {
+            'isConnected': connectionStatus.isConnected,
+            'prevIsDeviceConnected': prev,
+            'transportConnected': _transport.isConnected,
+            'deviceId': _device?.deviceId,
+          },
+        );
     }
   }
 
@@ -200,9 +220,19 @@ class FF1WifiControl {
     _log.info('Connection state changed: $isConnected');
 
     if (!isConnected) {
-      // if disconnected from transport
-      // update connection status
-      // Clear state on disconnect
+      // Transport dropped — clear all cached state and push a disconnected
+      // status so the UI reacts immediately. Device-level "connected" will
+      // only be restored once the device re-sends a connection notification
+      // after the WebSocket reconnects.
+      _slog.warning(
+        category: LogCategory.wifi,
+        event: 'transport_disconnected',
+        message: 'transport disconnected — clearing device-connected state',
+        payload: {
+          'prevIsDeviceConnected': _isDeviceConnected,
+          'deviceId': _device?.deviceId,
+        },
+      );
       _currentPlayerStatus = null;
       _currentDeviceStatus = null;
       _isDeviceConnected = false;
@@ -210,15 +240,57 @@ class FF1WifiControl {
         FF1ConnectionStatus(isConnected: isConnected),
       );
     } else {
-      // device connected to transport
-      // connection status is already updated by _handleNotification
-      // nothing to do
+      // Transport (WebSocket) reconnected. Device-level "connected" flag is
+      // NOT updated here — it will only change once the device sends a
+      // FF1NotificationType.connection notification. This gap (transport up,
+      // device-level still false) is the root cause of the false "Device not
+      // connected" display after reconnect and is tracked by
+      // ff1ConnectionDiscrepancyWatcherProvider.
+      _slog.info(
+        category: LogCategory.wifi,
+        event: 'transport_connected',
+        message:
+            'transport connected — waiting for device connection notification',
+        payload: {
+          'isDeviceConnected': _isDeviceConnected,
+          'deviceId': _device?.deviceId,
+        },
+      );
     }
   }
 
   /// Handle transport error
   void _handleTransportError(FF1WifiTransportError error) {
     _log.warning('Transport error: $error');
+    unawaited(_reportTransportErrorToSentry(error));
+  }
+
+  /// Sends transport errors to Sentry. Network errors use a warning event to
+  /// limit noise from transient WebSocket failures.
+  Future<void> _reportTransportErrorToSentry(FF1WifiTransportError error) async {
+    if (error is FF1WifiNetworkError) {
+      await Sentry.captureEvent(
+        SentryEvent(
+          message: SentryMessage(error.message),
+          level: SentryLevel.warning,
+          tags: const {
+            'component': 'ff1_wifi_transport',
+            'error_kind': 'network',
+          },
+        ),
+      );
+      return;
+    }
+
+    await Sentry.captureException(
+      error,
+      stackTrace: StackTrace.current,
+      withScope: (scope) {
+        scope
+          ..setTag('component', 'ff1_wifi_transport')
+          ..setTag('error_kind', error.runtimeType.toString());
+      },
+    );
   }
 
   /// Reconnect to device (using cached connection params)
@@ -232,7 +304,16 @@ class FF1WifiControl {
       return;
     }
 
-    _log.info('Reconnecting to ${_device!.deviceId}');
+    _slog.info(
+      category: LogCategory.wifi,
+      event: 'reconnect_start',
+      message: 'reconnecting to device',
+      payload: {
+        'deviceId': _device!.deviceId,
+        'isDeviceConnected': _isDeviceConnected,
+        'isTransportConnected': _transport.isConnected,
+      },
+    );
 
     try {
       await _transport.connect(
@@ -241,8 +322,23 @@ class FF1WifiControl {
         apiKey: _apiKey!,
         forceReconnect: true,
       );
+      _slog.info(
+        category: LogCategory.wifi,
+        event: 'reconnect_transport_ok',
+        message: 'transport reconnected — waiting for device connection notification',
+        payload: {
+          'deviceId': _device?.deviceId,
+          'isDeviceConnected': _isDeviceConnected,
+        },
+      );
     } catch (e) {
-      _log.warning('Reconnect failed: $e');
+      _slog.warning(
+        category: LogCategory.wifi,
+        event: 'reconnect_failed',
+        message: 'reconnect failed',
+        payload: {'deviceId': _device?.deviceId, 'error': e.toString()},
+        error: e,
+      );
       rethrow;
     }
   }
@@ -251,6 +347,16 @@ class FF1WifiControl {
   ///
   /// Closes WebSocket but preserves connection params for [reconnect] on resume.
   void pauseConnection() {
+    _slog.info(
+      category: LogCategory.wifi,
+      event: 'connection_paused',
+      message: 'pausing connection for background',
+      payload: {
+        'isDeviceConnected': _isDeviceConnected,
+        'isTransportConnected': _transport.isConnected,
+        'deviceId': _device?.deviceId,
+      },
+    );
     _transport.pauseConnection();
 
     // Clear current state but preserve _device, _userId, _apiKey for reconnect

--- a/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
+++ b/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
@@ -20,6 +20,7 @@ import 'dart:isolate';
 import 'package:app/domain/models/ff1_device.dart';
 import 'package:app/infra/ff1/wifi_protocol/ff1_wifi_messages.dart';
 import 'package:app/infra/ff1/wifi_transport/ff1_wifi_transport.dart';
+import 'package:app/infra/logging/structured_logger.dart';
 import 'package:logging/logging.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -41,10 +42,16 @@ class FF1RelayerTransport implements FF1WifiTransport {
     required String relayerUrl,
     Logger? logger,
   }) : _relayerUrl = relayerUrl,
-       _log = logger ?? Logger('FF1RelayerTransport');
+       _log = logger ?? Logger('FF1RelayerTransport') {
+    _slog = AppStructuredLog.forLogger(
+      _log,
+      context: {'component': 'ff1_relayer_transport'},
+    );
+  }
 
   final String _relayerUrl;
   final Logger _log;
+  late final StructuredLogger _slog;
 
   // Connection state
   bool _isConnected = false;
@@ -299,12 +306,27 @@ class FF1RelayerTransport implements FF1WifiTransport {
         _lastError = null;
         _reconnectAttempts = 0;
         _connectionStateController.add(true);
-        _log.info('Connected to relayer');
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'ws_connected',
+          message: 'WebSocket connected to relayer',
+          payload: {'deviceId': _device?.deviceId, 'topicId': _device?.topicId},
+        );
 
       case _RelayerEventType.disconnected:
         _isConnected = false;
         _connectionStateController.add(false);
-        _log.warning('Disconnected from relayer');
+        _slog.warning(
+          category: LogCategory.wifi,
+          event: 'ws_disconnected',
+          message: 'WebSocket disconnected from relayer',
+          payload: {
+            'deviceId': _device?.deviceId,
+            'pausedForBackground': _pausedForBackground,
+            'reconnectAttempts': _reconnectAttempts,
+            'lastError': _lastError,
+          },
+        );
         if (!_pausedForBackground) {
           _scheduleReconnect();
         }
@@ -312,7 +334,12 @@ class FF1RelayerTransport implements FF1WifiTransport {
       case _RelayerEventType.error:
         final errorMsg = event.data?['error'] as String? ?? 'Unknown error';
         _lastError = errorMsg;
-        _log.warning('WebSocket error: $errorMsg');
+        _slog.warning(
+          category: LogCategory.wifi,
+          event: 'ws_error',
+          message: 'WebSocket error: $errorMsg',
+          payload: {'deviceId': _device?.deviceId, 'error': errorMsg},
+        );
         final error = FF1WifiNetworkError(errorMsg);
         _errorController.add(error);
 
@@ -339,7 +366,14 @@ class FF1RelayerTransport implements FF1WifiTransport {
   /// Schedule auto-reconnect with exponential backoff.
   void _scheduleReconnect() {
     if (_reconnectAttempts >= _maxReconnectAttempts) {
-      _log.severe('Max reconnect attempts reached, giving up');
+      _slog.error(
+        event: 'ws_reconnect_exhausted',
+        message: 'max reconnect attempts reached — giving up',
+        payload: {
+          'deviceId': _device?.deviceId,
+          'maxAttempts': _maxReconnectAttempts,
+        },
+      );
       const error = FF1WifiConnectionError(
         'Failed to reconnect after $_maxReconnectAttempts attempts',
       );
@@ -358,9 +392,18 @@ class FF1RelayerTransport implements FF1WifiTransport {
     final delay = _baseReconnectDelay * (1 << _reconnectAttempts);
     _reconnectAttempts++;
 
-    _log.info(
-      'Scheduling reconnect in ${delay.inSeconds}s '
-      '(attempt $_reconnectAttempts/$_maxReconnectAttempts)',
+    _slog.info(
+      category: LogCategory.wifi,
+      event: 'ws_reconnect_scheduled',
+      message:
+          'reconnect scheduled in ${delay.inSeconds}s '
+          '(attempt $_reconnectAttempts/$_maxReconnectAttempts)',
+      payload: {
+        'deviceId': _device?.deviceId,
+        'delaySeconds': delay.inSeconds,
+        'attempt': _reconnectAttempts,
+        'maxAttempts': _maxReconnectAttempts,
+      },
     );
 
     _reconnectTimer = Timer(delay, () async {
@@ -368,11 +411,25 @@ class FF1RelayerTransport implements FF1WifiTransport {
         return;
       }
 
-      _log.info('Attempting reconnect...');
+      _slog.info(
+        category: LogCategory.wifi,
+        event: 'ws_reconnect_attempt',
+        message: 'attempting reconnect',
+        payload: {
+          'deviceId': _device?.deviceId,
+          'attempt': _reconnectAttempts,
+        },
+      );
       try {
         await _connectInternal();
       } catch (e) {
-        _log.warning('Reconnect failed: $e');
+        _slog.warning(
+          category: LogCategory.wifi,
+          event: 'ws_reconnect_attempt_failed',
+          message: 'reconnect attempt failed',
+          payload: {'deviceId': _device?.deviceId, 'error': e.toString()},
+          error: e,
+        );
         // Will schedule another reconnect via disconnect event
       }
     });

--- a/lib/infra/logging/structured_logger.dart
+++ b/lib/infra/logging/structured_logger.dart
@@ -22,6 +22,9 @@ enum LogCategory {
   /// BLE transport and lifecycle events.
   ble,
 
+  /// WiFi/relayer transport and connection lifecycle events.
+  wifi,
+
   /// Domain/service events.
   domain,
 


### PR DESCRIPTION
- Add LogCategory.wifi and structured logs in control, relayer transport, and app lifecycle for connect/disconnect/reconnect paths
- Add FF1ConnectionDiscrepancyNotifier to report transport-vs-device gap to Sentry after threshold; wire in bootstrap
- Capture Sentry on wifi_connect/wifi_reconnect failures and transport errors (network errors as warning events to limit noise)

Made-with: Cursor