### PR TITLE
fix(routing): avoid cold-start deeplink replacement crash

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -219,11 +219,15 @@ class _AppStartupBootstrapState extends ConsumerState<_AppStartupBootstrap>
       } else {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (!mounted) return;
-          unawaited(
-            widget.router.pushReplacement(
-              Routes.startSetupFf1,
-              extra: StartSetupFf1PagePayload(deeplink: action.link),
-            ),
+          _log.info(
+            'Handling deeplink go to Routes.startSetupFf1',
+          );
+          // Use go() instead of pushReplacement() because Android cold start
+          // can deliver an app link before GoRouter has an active top route.
+          // pushReplacement requires an existing route to replace.
+          widget.router.go(
+            Routes.startSetupFf1,
+            extra: StartSetupFf1PagePayload(deeplink: action.link),
           );
         });
       }


### PR DESCRIPTION
## Summary
- Replace `pushReplacement` with `go` when handling app-link `device_connect` deeplinks during startup.
- Prevent `Bad state: No element` from GoRouter when there is no active route to replace on cold start.
- Keep deeplink payload flow intact for navigation to `Routes.startSetupFf1`.

## Test plan
- [x] Run `flutter test test/unit/app/routing/deeplink_handler_test.dart test/unit/app/routing/router_provider_test.dart`
- [x] Check lints for touched files (`lib/app/app.dart`, `lib/app/routing/router_provider.dart`)
- [x] Manual verify Android cold start via QR deeplink (`device_connect`)
- [x] Manual verify iOS cold start via QR deeplink (`device_connect`)

Made with [Cursor](https://cursor.com)