### PR TITLE
feat(ci): separate gold-path smoke vs endurance evidence (EV-03)

### DIFF
--- a/.github/actions/gold-path-patrol/action.yml
+++ b/.github/actions/gold-path-patrol/action.yml
@@ -1,0 +1,384 @@
+# Reusable steps for Patrol gold path (smoke vs endurance) — see gold-path-ui.yml.
+name: Gold Path Patrol
+description: Run Patrol gold path test on iOS or Android simulator/emulator
+inputs:
+  platform:
+    description: ios or android
+    required: true
+  soak_minutes:
+    description: GOLD_PATH_SOAK_MINUTES passed to the test
+    required: true
+  artifact_prefix:
+    description: Prefix for uploaded iOS xcresult (e.g. gold-path-smoke)
+    required: true
+  simulator_device:
+    required: true
+  android_avd_name:
+    required: false
+    default: ""
+  canary_channel_title:
+    required: true
+  env_vars_secret:
+    description: Optional repository secret ENV_VARS (pass secrets.ENV_VARS from the workflow)
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Use host Flutter/Android SDK
+      shell: bash
+      run: |
+        echo "FLUTTER_ROOT=/Users/ffci/flutter" >> "$GITHUB_ENV"
+        echo "/Users/ffci/flutter/bin" >> "$GITHUB_PATH"
+        echo "ANDROID_SDK_ROOT=/Users/ffci/.android/sdk" >> "$GITHUB_ENV"
+        echo "ANDROID_HOME=/Users/ffci/.android/sdk" >> "$GITHUB_ENV"
+        echo "/Users/ffci/.android/sdk/platform-tools" >> "$GITHUB_PATH"
+        echo "/Users/ffci/.android/sdk/emulator" >> "$GITHUB_PATH"
+        echo "/Users/ffci/.android/sdk/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
+
+    - name: Configure Android SDK environment
+      if: ${{ inputs.platform == 'android' }}
+      shell: bash
+      run: |
+        echo "ANDROID_HOME=$ANDROID_SDK_ROOT" >> "$GITHUB_ENV"
+        echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT" >> "$GITHUB_ENV"
+        echo "ANDROID_USER_HOME=$ANDROID_USER_HOME" >> "$GITHUB_ENV"
+        echo "ANDROID_EMULATOR_HOME=$ANDROID_EMULATOR_HOME" >> "$GITHUB_ENV"
+        echo "ANDROID_AVD_HOME=$ANDROID_AVD_HOME" >> "$GITHUB_ENV"
+        echo "$ANDROID_SDK_ROOT/platform-tools" >> "$GITHUB_PATH"
+        echo "$ANDROID_SDK_ROOT/emulator" >> "$GITHUB_PATH"
+        echo "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
+
+    - name: Install Android emulator dependencies
+      if: ${{ inputs.platform == 'android' }}
+      shell: bash
+      run: |
+        yes | sdkmanager --licenses >/dev/null
+        sdkmanager \
+          "platform-tools" \
+          "platforms;android-$ANDROID_API_LEVEL" \
+          "emulator" \
+          "$ANDROID_SYSTEM_IMAGE"
+
+    - name: Ensure Android AVD exists
+      if: ${{ inputs.platform == 'android' }}
+      shell: bash
+      run: |
+        export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$PATH"
+        mkdir -p "$ANDROID_USER_HOME" "$ANDROID_EMULATOR_HOME" "$ANDROID_AVD_HOME"
+
+        requested_avd="$ANDROID_AVD_NAME"
+        available_avds="$(emulator -list-avds)"
+
+        echo "Available Android AVDs before setup:"
+        if [ -n "$available_avds" ]; then
+          printf '%s\n' "$available_avds"
+        else
+          echo "<none>"
+        fi
+
+        selected_avd="$requested_avd"
+        if [ -n "$selected_avd" ] && ! printf '%s\n' "$available_avds" | grep -Fxq "$selected_avd"; then
+          echo "Requested Android AVD '$selected_avd' was not found. Creating it."
+          printf 'no\n' | avdmanager create avd \
+            --force \
+            --name "$selected_avd" \
+            --package "$ANDROID_SYSTEM_IMAGE" \
+            --abi "arm64-v8a"
+          available_avds="$(emulator -list-avds)"
+        fi
+
+        if [ -z "$selected_avd" ]; then
+          selected_avd="$(printf '%s\n' "$available_avds" | head -n 1)"
+        fi
+
+        if [ -z "$selected_avd" ]; then
+          selected_avd="ff-ci-api-$ANDROID_API_LEVEL"
+          echo "Creating Android AVD: $selected_avd"
+          printf 'no\n' | avdmanager create avd \
+            --force \
+            --name "$selected_avd" \
+            --package "$ANDROID_SYSTEM_IMAGE" \
+            --abi "arm64-v8a"
+        fi
+
+        rm -rf "$ANDROID_AVD_HOME/$selected_avd.avd" "$ANDROID_AVD_HOME/$selected_avd.ini"
+        echo "Creating fresh Android AVD: $selected_avd"
+        printf 'no\n' | avdmanager create avd \
+          --force \
+          --name "$selected_avd" \
+          --package "$ANDROID_SYSTEM_IMAGE" \
+          --abi "arm64-v8a"
+
+        echo "ANDROID_AVD_NAME=$selected_avd" >> "$GITHUB_ENV"
+
+    - name: Debug Android emulator paths
+      if: ${{ inputs.platform == 'android' }}
+      shell: bash
+      run: |
+        export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$PATH"
+        echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
+        echo "ANDROID_USER_HOME=$ANDROID_USER_HOME"
+        echo "ANDROID_EMULATOR_HOME=$ANDROID_EMULATOR_HOME"
+        echo "ANDROID_AVD_HOME=$ANDROID_AVD_HOME"
+        echo "Resolved emulator binary: $(command -v emulator)"
+        emulator -list-avds
+        avd_ini="$ANDROID_AVD_HOME/$ANDROID_AVD_NAME.ini"
+        if [ -f "$avd_ini" ]; then
+          echo "AVD ini:"
+          cat "$avd_ini"
+        fi
+
+    - name: Create env file
+      shell: bash
+      env:
+        ENV_VARS_SECRET: ${{ inputs.env_vars_secret }}
+      run: |
+        : > .env
+        if [ -n "${ENV_VARS_SECRET:-}" ]; then
+          echo -e "${ENV_VARS_SECRET}" | sed 's/\\n/\n/g' >> .env
+        fi
+
+        if [ -n "$FF1_TEST_DEVICE_ID" ] && ! grep -q '^FF1_TEST_DEVICE_ID=' .env; then
+          echo "FF1_TEST_DEVICE_ID=$FF1_TEST_DEVICE_ID" >> .env
+        fi
+        if [ -n "$FF1_TEST_TOPIC_ID" ] && ! grep -q '^FF1_TEST_TOPIC_ID=' .env; then
+          echo "FF1_TEST_TOPIC_ID=$FF1_TEST_TOPIC_ID" >> .env
+        fi
+
+    - name: Resolve shared FF1 identifiers
+      shell: bash
+      run: |
+        ff1_device_id="$FF1_TEST_DEVICE_ID"
+        ff1_topic_id="$FF1_TEST_TOPIC_ID"
+
+        if [ -z "$ff1_device_id" ]; then
+          ff1_device_id="$(awk -F= '$1 == "FF1_TEST_DEVICE_ID" { sub(/^[^=]*=/, "", $0); print; exit }' .env)"
+        fi
+        if [ -z "$ff1_topic_id" ]; then
+          ff1_topic_id="$(awk -F= '$1 == "FF1_TEST_TOPIC_ID" { sub(/^[^=]*=/, "", $0); print; exit }' .env)"
+        fi
+
+        test -n "$ff1_device_id" || {
+          echo "Missing FF1_TEST_DEVICE_ID. Set it in repository secrets or ENV_VARS."
+          exit 1
+        }
+        test -n "$ff1_topic_id" || {
+          echo "Missing FF1_TEST_TOPIC_ID. Set it in repository secrets or ENV_VARS."
+          exit 1
+        }
+
+        echo "FF1_TEST_DEVICE_ID=$ff1_device_id" >> "$GITHUB_ENV"
+        echo "FF1_TEST_TOPIC_ID=$ff1_topic_id" >> "$GITHUB_ENV"
+
+    - name: Reset generated artifacts
+      shell: bash
+      run: |
+        flutter clean
+        rm -rf build .dart_tool patrol_test/test_bundle.dart
+        rm -rf ios/Pods ios/Podfile.lock ios/.symlinks ios/Flutter/ephemeral
+
+    - name: Install dependencies
+      shell: bash
+      run: flutter pub get
+
+    - name: Install CocoaPods
+      if: ${{ inputs.platform == 'ios' }}
+      shell: bash
+      run: |
+        cd ios
+        pod install --repo-update
+
+    - name: Install Patrol CLI
+      shell: bash
+      run: dart pub global activate patrol_cli
+
+    - name: Boot iOS simulator
+      if: ${{ inputs.platform == 'ios' }}
+      shell: bash
+      run: |
+        xcrun simctl boot "$SIMULATOR_DEVICE" || true
+        open -a Simulator
+        xcrun simctl bootstatus "$SIMULATOR_DEVICE" -b
+
+    - name: Boot Android emulator
+      if: ${{ inputs.platform == 'android' }}
+      shell: bash
+      run: |
+        set -eu
+        export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$PATH"
+
+        adb start-server
+        selected_avd="$ANDROID_AVD_NAME"
+
+        echo "Using Android AVD: $selected_avd"
+        rm -f /tmp/android-emulator.log
+        nohup "$ANDROID_SDK_ROOT/emulator/emulator" \
+          -avd "$selected_avd" \
+          -no-snapshot \
+          -no-audio \
+          -no-boot-anim \
+          -no-window \
+          -gpu swiftshader_indirect \
+          >/tmp/android-emulator.log 2>&1 &
+
+        emulator_pid=$!
+        echo "Android emulator PID: $emulator_pid"
+        sleep 10
+
+        if ! kill -0 "$emulator_pid" 2>/dev/null; then
+          echo "Android emulator exited before boot completed."
+          cat /tmp/android-emulator.log
+          exit 1
+        fi
+
+        python3 - <<PY
+        import pathlib
+        import subprocess
+        import time
+
+        emulator_pid = $emulator_pid
+        deadline = time.time() + 300
+        log_path = pathlib.Path("/tmp/android-emulator.log")
+
+        def emulator_alive() -> bool:
+            return subprocess.run(
+                ["kill", "-0", str(emulator_pid)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ).returncode == 0
+
+        while True:
+            if not emulator_alive():
+                print("Android emulator process exited while waiting for adb.")
+                if log_path.exists():
+                    print(log_path.read_text())
+                raise SystemExit(1)
+
+            devices = subprocess.run(
+                ["adb", "devices"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.splitlines()
+            if any(line.startswith("emulator-") and "\tdevice" in line for line in devices):
+                break
+
+            if time.time() >= deadline:
+                print("Timed out waiting for adb to detect the Android emulator.")
+                if log_path.exists():
+                    print(log_path.read_text())
+                raise SystemExit(1)
+
+            time.sleep(2)
+
+        while True:
+            if not emulator_alive():
+                print("Android emulator process exited before sys.boot_completed.")
+                if log_path.exists():
+                    print(log_path.read_text())
+                raise SystemExit(1)
+
+            boot_completed = subprocess.run(
+                ["adb", "shell", "getprop", "sys.boot_completed"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).stdout.strip()
+            if boot_completed == "1":
+                break
+
+            if time.time() >= deadline:
+                print("Timed out waiting for Android sys.boot_completed.")
+                if log_path.exists():
+                    print(log_path.read_text())
+                raise SystemExit(1)
+
+            time.sleep(2)
+        PY
+
+        adb shell input keyevent 82 || true
+        adb devices
+        tail -n 50 /tmp/android-emulator.log || true
+
+    - name: Resolve Android emulator device id
+      if: ${{ inputs.platform == 'android' }}
+      shell: bash
+      run: |
+        echo "adb devices output:"
+        adb devices
+        device_id="$(adb devices | awk '$1 ~ /^emulator-[0-9]+$/ && $2 == "device" { print $1; exit }')"
+        test -n "$device_id" || {
+          echo "No booted Android emulator device found."
+          adb devices
+          exit 1
+        }
+        echo "ANDROID_DEVICE_ID=$device_id" >> "$GITHUB_ENV"
+
+    - name: Run gold path Patrol test
+      shell: bash
+      env:
+        GOLD_PATH_SOAK_MINUTES: ${{ inputs.soak_minutes }}
+        GOLD_PATH_CANARY_CHANNEL_TITLE: ${{ inputs.canary_channel_title }}
+      run: |
+        export PATH="$PATH:$HOME/.pub-cache/bin"
+        if [ "${{ inputs.platform }}" = "ios" ]; then
+          patrol test \
+            --target patrol_test/gold_path_test.dart \
+            --flavor development \
+            --device "$SIMULATOR_DEVICE" \
+            --bundle-id com.feralfile.app \
+            --dart-define FF1_TEST_DEVICE_ID="$FF1_TEST_DEVICE_ID" \
+            --dart-define FF1_TEST_TOPIC_ID="$FF1_TEST_TOPIC_ID" \
+            --dart-define GOLD_PATH_CANARY_CHANNEL_TITLE="$GOLD_PATH_CANARY_CHANNEL_TITLE" \
+            --dart-define GOLD_PATH_SOAK_MINUTES="$GOLD_PATH_SOAK_MINUTES" \
+            --show-flutter-logs \
+            --verbose
+        else
+          patrol test \
+            --target patrol_test/gold_path_test.dart \
+            --flavor development \
+            --device "$ANDROID_DEVICE_ID" \
+            --dart-define FF1_TEST_DEVICE_ID="$FF1_TEST_DEVICE_ID" \
+            --dart-define FF1_TEST_TOPIC_ID="$FF1_TEST_TOPIC_ID" \
+            --dart-define GOLD_PATH_CANARY_CHANNEL_TITLE="$GOLD_PATH_CANARY_CHANNEL_TITLE" \
+            --dart-define GOLD_PATH_SOAK_MINUTES="$GOLD_PATH_SOAK_MINUTES" \
+            --show-flutter-logs
+        fi
+
+    - name: Shut down iOS Simulator
+      if: ${{ always() && inputs.platform == 'ios' }}
+      shell: bash
+      run: |
+        xcrun simctl shutdown "$SIMULATOR_DEVICE" || true
+        osascript -e 'quit app "Simulator"' || true
+
+    - name: Shut down Android emulator
+      if: ${{ always() && inputs.platform == 'android' }}
+      shell: bash
+      run: |
+        if [ -n "${ANDROID_DEVICE_ID:-}" ]; then
+          adb -s "$ANDROID_DEVICE_ID" emu kill || true
+        fi
+
+    - name: Capture latest xcresult path
+      if: ${{ always() && inputs.platform == 'ios' }}
+      id: xcresult
+      shell: bash
+      run: |
+        LATEST_XCRESULT="$(find build -maxdepth 1 -name 'ios_results_*.xcresult' -print | sort | tail -n 1)"
+        echo "path=$LATEST_XCRESULT" >> "$GITHUB_OUTPUT"
+        if [ -n "$LATEST_XCRESULT" ]; then
+          echo "Found xcresult at $LATEST_XCRESULT"
+        else
+          echo "No xcresult bundle found"
+        fi
+
+    - name: Upload xcresult artifact
+      if: ${{ always() && inputs.platform == 'ios' && steps.xcresult.outputs.path != '' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact_prefix }}-ios-xcresult
+        path: ${{ steps.xcresult.outputs.path }}
+        if-no-files-found: error

--- a/.github/workflows/gold-path-ui.yml
+++ b/.github/workflows/gold-path-ui.yml
@@ -1,3 +1,5 @@
+# Smoke (PR + optional manual): short soak — endurance (nightly + manual): long soak.
+# Nightly schedule matches `.github/workflows/nightly-integration.yml` (09:00 UTC).
 name: Gold Path UI Test
 
 on:
@@ -10,9 +12,20 @@ on:
       - "ios/**"
       - "android/**"
       - ".github/workflows/gold-path-ui.yml"
+      - ".github/actions/gold-path-patrol/**"
       - pubspec.yaml
+  schedule:
+    - cron: "0 9 * * *"
   workflow_dispatch:
     inputs:
+      run_profile:
+        description: smoke (short soak) or endurance (long soak)
+        required: true
+        default: smoke
+        type: choice
+        options:
+          - smoke
+          - endurance
       simulator_device:
         description: iOS Simulator device name
         required: true
@@ -29,13 +42,14 @@ on:
         default: Social Codes
         type: string
       soak_minutes:
-        description: Optional soak duration in minutes
-        required: true
-        default: "1"
+        description: Soak duration in minutes (endurance profile only; smoke always uses 1)
+        required: false
+        default: "240"
         type: string
 
 jobs:
-  gold-path-ui:
+  gold-path-smoke:
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.run_profile == 'smoke')
     strategy:
       fail-fast: false
       matrix:
@@ -52,343 +66,54 @@ jobs:
       ANDROID_EMULATOR_HOME: /tmp/android-emulator-home
       ANDROID_AVD_HOME: /tmp/android-avd
       GOLD_PATH_CANARY_CHANNEL_TITLE: ${{ inputs.canary_channel_title || 'Social Codes' }}
-      GOLD_PATH_SOAK_MINUTES: ${{ inputs.soak_minutes || '1' }}
       FF1_TEST_DEVICE_ID: ${{ secrets.FF1_TEST_DEVICE_ID }}
       FF1_TEST_TOPIC_ID: ${{ secrets.FF1_TEST_TOPIC_ID }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Use host Flutter/Android SDK
-        run: |
-          echo "FLUTTER_ROOT=/Users/ffci/flutter" >> "$GITHUB_ENV"
-          echo "/Users/ffci/flutter/bin" >> "$GITHUB_PATH"
-          echo "ANDROID_SDK_ROOT=/Users/ffci/.android/sdk" >> "$GITHUB_ENV"
-          echo "ANDROID_HOME=/Users/ffci/.android/sdk" >> "$GITHUB_ENV"
-          echo "/Users/ffci/.android/sdk/platform-tools" >> "$GITHUB_PATH"
-          echo "/Users/ffci/.android/sdk/emulator" >> "$GITHUB_PATH"
-          echo "/Users/ffci/.android/sdk/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
-
-      - name: Configure Android SDK environment
-        if: matrix.platform == 'android'
-        run: |
-          echo "ANDROID_HOME=$ANDROID_SDK_ROOT" >> "$GITHUB_ENV"
-          echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT" >> "$GITHUB_ENV"
-          echo "ANDROID_USER_HOME=$ANDROID_USER_HOME" >> "$GITHUB_ENV"
-          echo "ANDROID_EMULATOR_HOME=$ANDROID_EMULATOR_HOME" >> "$GITHUB_ENV"
-          echo "ANDROID_AVD_HOME=$ANDROID_AVD_HOME" >> "$GITHUB_ENV"
-          echo "$ANDROID_SDK_ROOT/platform-tools" >> "$GITHUB_PATH"
-          echo "$ANDROID_SDK_ROOT/emulator" >> "$GITHUB_PATH"
-          echo "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
-
-      - name: Install Android emulator dependencies
-        if: matrix.platform == 'android'
-        run: |
-          yes | sdkmanager --licenses >/dev/null
-          sdkmanager \
-            "platform-tools" \
-            "platforms;android-$ANDROID_API_LEVEL" \
-            "emulator" \
-            "$ANDROID_SYSTEM_IMAGE"
-
-      - name: Ensure Android AVD exists
-        if: matrix.platform == 'android'
-        run: |
-          export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$PATH"
-          mkdir -p "$ANDROID_USER_HOME" "$ANDROID_EMULATOR_HOME" "$ANDROID_AVD_HOME"
-
-          requested_avd="$ANDROID_AVD_NAME"
-          available_avds="$(emulator -list-avds)"
-
-          echo "Available Android AVDs before setup:"
-          if [ -n "$available_avds" ]; then
-            printf '%s\n' "$available_avds"
-          else
-            echo "<none>"
-          fi
-
-          selected_avd="$requested_avd"
-          if [ -n "$selected_avd" ] && ! printf '%s\n' "$available_avds" | grep -Fxq "$selected_avd"; then
-            echo "Requested Android AVD '$selected_avd' was not found. Creating it."
-            printf 'no\n' | avdmanager create avd \
-              --force \
-              --name "$selected_avd" \
-              --package "$ANDROID_SYSTEM_IMAGE" \
-              --abi "arm64-v8a"
-            available_avds="$(emulator -list-avds)"
-          fi
-
-          if [ -z "$selected_avd" ]; then
-            selected_avd="$(printf '%s\n' "$available_avds" | head -n 1)"
-          fi
-
-          if [ -z "$selected_avd" ]; then
-            selected_avd="ff-ci-api-$ANDROID_API_LEVEL"
-            echo "Creating Android AVD: $selected_avd"
-            printf 'no\n' | avdmanager create avd \
-              --force \
-              --name "$selected_avd" \
-              --package "$ANDROID_SYSTEM_IMAGE" \
-              --abi "arm64-v8a"
-          fi
-
-          rm -rf "$ANDROID_AVD_HOME/$selected_avd.avd" "$ANDROID_AVD_HOME/$selected_avd.ini"
-          echo "Creating fresh Android AVD: $selected_avd"
-          printf 'no\n' | avdmanager create avd \
-            --force \
-            --name "$selected_avd" \
-            --package "$ANDROID_SYSTEM_IMAGE" \
-            --abi "arm64-v8a"
-
-          echo "ANDROID_AVD_NAME=$selected_avd" >> "$GITHUB_ENV"
-
-      - name: Debug Android emulator paths
-        if: matrix.platform == 'android'
-        run: |
-          export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$PATH"
-          echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
-          echo "ANDROID_USER_HOME=$ANDROID_USER_HOME"
-          echo "ANDROID_EMULATOR_HOME=$ANDROID_EMULATOR_HOME"
-          echo "ANDROID_AVD_HOME=$ANDROID_AVD_HOME"
-          echo "Resolved emulator binary: $(command -v emulator)"
-          emulator -list-avds
-          avd_ini="$ANDROID_AVD_HOME/$ANDROID_AVD_NAME.ini"
-          if [ -f "$avd_ini" ]; then
-            echo "AVD ini:"
-            cat "$avd_ini"
-          fi
-
-      - name: Create env file
-        run: |
-          : > .env
-          if [ -n "${{ secrets.ENV_VARS }}" ]; then
-            echo -e "${{ secrets.ENV_VARS }}" | sed 's/\\n/\n/g' >> .env
-          fi
-
-          if [ -n "$FF1_TEST_DEVICE_ID" ] && ! grep -q '^FF1_TEST_DEVICE_ID=' .env; then
-            echo "FF1_TEST_DEVICE_ID=$FF1_TEST_DEVICE_ID" >> .env
-          fi
-          if [ -n "$FF1_TEST_TOPIC_ID" ] && ! grep -q '^FF1_TEST_TOPIC_ID=' .env; then
-            echo "FF1_TEST_TOPIC_ID=$FF1_TEST_TOPIC_ID" >> .env
-          fi
-
-      - name: Resolve shared FF1 identifiers
-        run: |
-          ff1_device_id="$FF1_TEST_DEVICE_ID"
-          ff1_topic_id="$FF1_TEST_TOPIC_ID"
-
-          if [ -z "$ff1_device_id" ]; then
-            ff1_device_id="$(awk -F= '$1 == "FF1_TEST_DEVICE_ID" { sub(/^[^=]*=/, "", $0); print; exit }' .env)"
-          fi
-          if [ -z "$ff1_topic_id" ]; then
-            ff1_topic_id="$(awk -F= '$1 == "FF1_TEST_TOPIC_ID" { sub(/^[^=]*=/, "", $0); print; exit }' .env)"
-          fi
-
-          test -n "$ff1_device_id" || {
-            echo "Missing FF1_TEST_DEVICE_ID. Set it in repository secrets or ENV_VARS."
-            exit 1
-          }
-          test -n "$ff1_topic_id" || {
-            echo "Missing FF1_TEST_TOPIC_ID. Set it in repository secrets or ENV_VARS."
-            exit 1
-          }
-
-          echo "FF1_TEST_DEVICE_ID=$ff1_device_id" >> "$GITHUB_ENV"
-          echo "FF1_TEST_TOPIC_ID=$ff1_topic_id" >> "$GITHUB_ENV"
-
-      - name: Reset generated artifacts
-        run: |
-          flutter clean
-          rm -rf build .dart_tool patrol_test/test_bundle.dart
-          rm -rf ios/Pods ios/Podfile.lock ios/.symlinks ios/Flutter/ephemeral
-
-      - name: Install dependencies
-        run: flutter pub get
-
-      - name: Install CocoaPods
-        if: matrix.platform == 'ios'
-        run: |
-          cd ios
-          pod install --repo-update
-
-      - name: Install Patrol CLI
-        run: dart pub global activate patrol_cli
-
-      - name: Boot iOS simulator
-        if: matrix.platform == 'ios'
-        run: |
-          xcrun simctl boot "$SIMULATOR_DEVICE" || true
-          open -a Simulator
-          xcrun simctl bootstatus "$SIMULATOR_DEVICE" -b
-
-      - name: Boot Android emulator
-        if: matrix.platform == 'android'
-        run: |
-          set -eu
-          export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$PATH"
-
-          adb start-server
-          selected_avd="$ANDROID_AVD_NAME"
-
-          echo "Using Android AVD: $selected_avd"
-          rm -f /tmp/android-emulator.log
-          nohup "$ANDROID_SDK_ROOT/emulator/emulator" \
-            -avd "$selected_avd" \
-            -no-snapshot \
-            -no-audio \
-            -no-boot-anim \
-            -no-window \
-            -gpu swiftshader_indirect \
-            >/tmp/android-emulator.log 2>&1 &
-
-          emulator_pid=$!
-          echo "Android emulator PID: $emulator_pid"
-          sleep 10
-
-          if ! kill -0 "$emulator_pid" 2>/dev/null; then
-            echo "Android emulator exited before boot completed."
-            cat /tmp/android-emulator.log
-            exit 1
-          fi
-
-          python3 - <<PY
-          import pathlib
-          import subprocess
-          import time
-
-          emulator_pid = $emulator_pid
-          deadline = time.time() + 300
-          log_path = pathlib.Path("/tmp/android-emulator.log")
-
-          def emulator_alive() -> bool:
-              return subprocess.run(
-                  ["kill", "-0", str(emulator_pid)],
-                  stdout=subprocess.DEVNULL,
-                  stderr=subprocess.DEVNULL,
-              ).returncode == 0
-
-          while True:
-              if not emulator_alive():
-                  print("Android emulator process exited while waiting for adb.")
-                  if log_path.exists():
-                      print(log_path.read_text())
-                  raise SystemExit(1)
-
-              devices = subprocess.run(
-                  ["adb", "devices"],
-                  check=True,
-                  capture_output=True,
-                  text=True,
-              ).stdout.splitlines()
-              if any(line.startswith("emulator-") and "\tdevice" in line for line in devices):
-                  break
-
-              if time.time() >= deadline:
-                  print("Timed out waiting for adb to detect the Android emulator.")
-                  if log_path.exists():
-                      print(log_path.read_text())
-                  raise SystemExit(1)
-
-              time.sleep(2)
-
-          while True:
-              if not emulator_alive():
-                  print("Android emulator process exited before sys.boot_completed.")
-                  if log_path.exists():
-                      print(log_path.read_text())
-                  raise SystemExit(1)
-
-              boot_completed = subprocess.run(
-                  ["adb", "shell", "getprop", "sys.boot_completed"],
-                  stdout=subprocess.PIPE,
-                  stderr=subprocess.DEVNULL,
-                  text=True,
-              ).stdout.strip()
-              if boot_completed == "1":
-                  break
-
-              if time.time() >= deadline:
-                  print("Timed out waiting for Android sys.boot_completed.")
-                  if log_path.exists():
-                      print(log_path.read_text())
-                  raise SystemExit(1)
-
-              time.sleep(2)
-          PY
-
-          adb shell input keyevent 82 || true
-          adb devices
-          tail -n 50 /tmp/android-emulator.log || true
-
-      - name: Resolve Android emulator device id
-        if: matrix.platform == 'android'
-        run: |
-          echo "adb devices output:"
-          adb devices
-          device_id="$(adb devices | awk '$1 ~ /^emulator-[0-9]+$/ && $2 == "device" { print $1; exit }')"
-          test -n "$device_id" || {
-            echo "No booted Android emulator device found."
-            adb devices
-            exit 1
-          }
-          echo "ANDROID_DEVICE_ID=$device_id" >> "$GITHUB_ENV"
-
-      - name: Run gold path Patrol test
-        run: |
-          export PATH="$PATH:$HOME/.pub-cache/bin"
-          if [ "${{ matrix.platform }}" = "ios" ]; then
-            patrol test \
-              --target patrol_test/gold_path_test.dart \
-              --flavor development \
-              --device "$SIMULATOR_DEVICE" \
-              --bundle-id com.feralfile.app \
-              --dart-define FF1_TEST_DEVICE_ID="$FF1_TEST_DEVICE_ID" \
-              --dart-define FF1_TEST_TOPIC_ID="$FF1_TEST_TOPIC_ID" \
-              --dart-define GOLD_PATH_CANARY_CHANNEL_TITLE="$GOLD_PATH_CANARY_CHANNEL_TITLE" \
-              --dart-define GOLD_PATH_SOAK_MINUTES="$GOLD_PATH_SOAK_MINUTES" \
-              --show-flutter-logs \
-              --verbose
-          else
-            patrol test \
-              --target patrol_test/gold_path_test.dart \
-              --flavor development \
-              --device "$ANDROID_DEVICE_ID" \
-              --dart-define FF1_TEST_DEVICE_ID="$FF1_TEST_DEVICE_ID" \
-              --dart-define FF1_TEST_TOPIC_ID="$FF1_TEST_TOPIC_ID" \
-              --dart-define GOLD_PATH_CANARY_CHANNEL_TITLE="$GOLD_PATH_CANARY_CHANNEL_TITLE" \
-              --dart-define GOLD_PATH_SOAK_MINUTES="$GOLD_PATH_SOAK_MINUTES" \
-              --show-flutter-logs
-          fi
-
-      - name: Shut down iOS Simulator
-        if: always() && matrix.platform == 'ios'
-        run: |
-          xcrun simctl shutdown "$SIMULATOR_DEVICE" || true
-          osascript -e 'quit app "Simulator"' || true
-
-      - name: Shut down Android emulator
-        if: always() && matrix.platform == 'android'
-        run: |
-          if [ -n "${ANDROID_DEVICE_ID:-}" ]; then
-            adb -s "$ANDROID_DEVICE_ID" emu kill || true
-          fi
-
-      - name: Capture latest xcresult path
-        if: always() && matrix.platform == 'ios'
-        id: xcresult
-        run: |
-          LATEST_XCRESULT="$(find build -maxdepth 1 -name 'ios_results_*.xcresult' -print | sort | tail -n 1)"
-          echo "path=$LATEST_XCRESULT" >> "$GITHUB_OUTPUT"
-          if [ -n "$LATEST_XCRESULT" ]; then
-            echo "Found xcresult at $LATEST_XCRESULT"
-          else
-            echo "No xcresult bundle found"
-          fi
-
-      - name: Upload xcresult artifact
-        if: always() && matrix.platform == 'ios' && steps.xcresult.outputs.path != ''
-        uses: actions/upload-artifact@v4
+      - name: Run Patrol (smoke)
+        uses: ./.github/actions/gold-path-patrol
         with:
-          name: gold-path-ios-xcresult
-          path: ${{ steps.xcresult.outputs.path }}
-          if-no-files-found: error
+          platform: ${{ matrix.platform }}
+          soak_minutes: "1"
+          artifact_prefix: gold-path-smoke
+          simulator_device: ${{ inputs.simulator_device || 'iPhone 16e' }}
+          android_avd_name: ${{ inputs.android_avd_name || '' }}
+          canary_channel_title: ${{ inputs.canary_channel_title || 'Social Codes' }}
+          env_vars_secret: ${{ secrets.ENV_VARS }}
+
+  gold-path-endurance:
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_profile == 'endurance')
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ios, android]
+    runs-on: [self-hosted, macOS]
+    permissions:
+      contents: read
+    env:
+      SIMULATOR_DEVICE: ${{ inputs.simulator_device || 'iPhone 16e' }}
+      ANDROID_AVD_NAME: ${{ inputs.android_avd_name || '' }}
+      ANDROID_API_LEVEL: "35"
+      ANDROID_SYSTEM_IMAGE: system-images;android-35;google_apis;arm64-v8a
+      ANDROID_USER_HOME: /tmp/android-user-home
+      ANDROID_EMULATOR_HOME: /tmp/android-emulator-home
+      ANDROID_AVD_HOME: /tmp/android-avd
+      GOLD_PATH_CANARY_CHANNEL_TITLE: ${{ inputs.canary_channel_title || 'Social Codes' }}
+      FF1_TEST_DEVICE_ID: ${{ secrets.FF1_TEST_DEVICE_ID }}
+      FF1_TEST_TOPIC_ID: ${{ secrets.FF1_TEST_TOPIC_ID }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Patrol (endurance)
+        uses: ./.github/actions/gold-path-patrol
+        with:
+          platform: ${{ matrix.platform }}
+          soak_minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.soak_minutes || '240' }}
+          artifact_prefix: gold-path-endurance
+          simulator_device: ${{ inputs.simulator_device || 'iPhone 16e' }}
+          android_avd_name: ${{ inputs.android_avd_name || '' }}
+          canary_channel_title: ${{ inputs.canary_channel_title || 'Social Codes' }}
+          env_vars_secret: ${{ secrets.ENV_VARS }}

--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ What it enforces:
 - minimum playlist/item thresholds are met
 - reproducible report file includes required evidence checklist for the >=4h soak run
 
+### Gold Path UI (CI): smoke vs endurance
+
+The GitHub Actions workflow **Gold Path UI Test** keeps two separate evidence streams:
+
+- **Smoke** (`gold-path-smoke` job): runs on pull requests (and optional manual dispatch with profile `smoke`). Uses a **1 minute** soak. iOS xcresult artifacts are named `gold-path-smoke-ios-xcresult`.
+- **Endurance** (`gold-path-endurance` job): runs on the **same nightly schedule** as [Nightly integration tests](.github/workflows/nightly-integration.yml) (`0 9 * * *`, 09:00 UTC) and on manual dispatch with profile `endurance`. Default soak is **240 minutes** (override via workflow input). Artifacts: `gold-path-endurance-ios-xcresult`.
+
+Shared steps live in [.github/actions/gold-path-patrol](.github/actions/gold-path-patrol/action.yml).
+
 ---
 
 ## Contributing

--- a/docs/plans/gold_path_patrol_test.md
+++ b/docs/plans/gold_path_patrol_test.md
@@ -6,6 +6,7 @@ Automate the gold path as a Patrol-based UI test:
 
 - Steps 1–6: Fresh sync → canary present in Curated surface → open Channel/Playlist → Play on FF1 → FF1 cast initiated
 - Step 7: 4+ hour soak treated as configurable (short for CI, full for nightly) or separate run
+- CI: `.github/workflows/gold-path-ui.yml` runs **smoke** on PR (1 min soak) and **endurance** on the same nightly cron as `nightly-integration.yml` (default 240 min soak); see `.github/actions/gold-path-patrol/action.yml`.
 
 ## FF1 Device Injection (Bypass BLE Pairing)
 

--- a/docs/vision_execution_gap.md
+++ b/docs/vision_execution_gap.md
@@ -51,6 +51,16 @@
   deferred recovery) with typed status events for UI/test observability.
 
 ## Completed items
+- EV-03 (Orbit 2): Gold-path CI separates **smoke** vs **endurance** evidence.
+  - Smoke: PR job `gold-path-smoke`, fixed short soak (1 minute), artifact prefix
+    `gold-path-smoke-ios-xcresult`.
+  - Endurance: job `gold-path-endurance`, nightly schedule aligned with
+    `nightly-integration.yml` (09:00 UTC), default long soak (240 minutes,
+    overridable on `workflow_dispatch`), artifact prefix
+    `gold-path-endurance-ios-xcresult`.
+  - Shared implementation: `.github/actions/gold-path-patrol/action.yml`;
+    workflow: `.github/workflows/gold-path-ui.yml`.
+  - Manual dispatch uses input `run_profile` (`smoke` | `endurance`).
 - EV-02 (Orbit 2): Trust boundary for DP-1 playlist signatures is explicit;
   wire parsing for `signature` vs `signatures[]` is locked and regression-tested.
   - Trust boundary:


### PR DESCRIPTION
## Summary

Implement **EV-03 (Orbit 2)** — separate gold-path CI evidence for smoke vs endurance testing.

- **Smoke**: runs on PR with 1 min soak; artifacts `gold-path-smoke-ios-xcresult`
- **Endurance**: runs nightly (09:00 UTC, aligned with `nightly-integration.yml`) with 240 min soak; artifacts `gold-path-endurance-ios-xcresult`

Refactored via composite action (`.github/actions/gold-path-patrol/`) to reduce YAML duplication from 397 → 120 LOC.

Manual dispatch now supports `run_profile` input (`smoke` | `endurance`).

## Changes

- `.github/workflows/gold-path-ui.yml` — two jobs with conditional triggers + schedule
- `.github/actions/gold-path-patrol/action.yml` — shared Patrol steps (NEW)
- `README.md` — new section "Gold Path UI (CI): smoke vs endurance"
- `docs/vision_execution_gap.md` — EV-03 marked completed with evidence
- `docs/plans/gold_path_patrol_test.md` — reference to workflow

## Evidence

Closes #264 (EV-03: Separate smoke vs endurance gold-path evidence)

## Test plan

- [ ] PR trigger: \`gold-path-smoke\` job runs with 1 min soak
- [ ] Manual dispatch with \`run_profile=smoke\`: 1 min soak, artifact prefix correct
- [ ] Manual dispatch with \`run_profile=endurance\`: 240 min soak (or override), artifact prefix correct
- [ ] Nightly 09:00 UTC: \`gold-path-endurance\` job runs (inspect next nightly run)
- [ ] No regression: other workflows unaffected (lint, unit-test, nightly-integration)

Made with [Cursor](https://cursor.com)