### PR TITLE
fix(wifi): hide connecting UI when Wi‑Fi credential send fails

### DIFF
--- a/lib/ui/screens/send_wifi_credentials_screen.dart
+++ b/lib/ui/screens/send_wifi_credentials_screen.dart
@@ -26,6 +26,25 @@ import 'package:logging/logging.dart';
 
 final _log = Logger('EnterWiFiPasswordScreen');
 
+/// Whether the enter Wi‑Fi password screen should show the loading
+/// ("Connecting…") view.
+///
+/// [localProcessingFlag] is set when the user taps Submit; the Wi‑Fi notifier
+/// may transition to [WiFiConnectionStatus.error] before the dialog effect
+/// clears that flag — do not keep showing loading after a failed send.
+bool isWifiPasswordSubmitBusy({
+  required bool localProcessingFlag,
+  required WiFiConnectionStatus status,
+}) {
+  if (status == WiFiConnectionStatus.error) {
+    return false;
+  }
+  return localProcessingFlag ||
+      (status != WiFiConnectionStatus.selectingNetwork &&
+          status != WiFiConnectionStatus.idle &&
+          status != WiFiConnectionStatus.success);
+}
+
 /// Payload for the enter wifi password page
 class EnterWifiPasswordPagePayload {
   /// Constructor
@@ -66,6 +85,7 @@ class _EnterWiFiPasswordScreenState
   bool _isProcessing = false;
   String _passwordText = '';
   ProviderSubscription<FF1SetupState>? _setupSub;
+  ProviderSubscription<WiFiConnectionState>? _wifiErrorSub;
 
   /// Parse SSID from networkSsid (may contain "ssid|security" format)
   String _parseSSID(String ssid) {
@@ -118,6 +138,18 @@ class _EnterWiFiPasswordScreenState
       fireImmediately: true,
     );
 
+    // Clear submit flag when Wi‑Fi flow reports failure.
+    _wifiErrorSub = ref.listenManual<WiFiConnectionState>(
+      connectWiFiProvider,
+      (previous, next) {
+        if (next.status == WiFiConnectionStatus.error && mounted) {
+          setState(() {
+            _isProcessing = false;
+          });
+        }
+      },
+    );
+
     final isOpen = _isOpenNetwork(widget.payload.wifiAccessPoint.ssid);
     if (isOpen) {
       // Auto-submit for open networks
@@ -137,6 +169,7 @@ class _EnterWiFiPasswordScreenState
     _passwordController.dispose();
     _passwordFocusNode.dispose();
     _setupSub?.close();
+    _wifiErrorSub?.close();
     super.dispose();
   }
 
@@ -236,12 +269,10 @@ class _EnterWiFiPasswordScreenState
     final shouldReserveNowDisplayingBar = ref.watch(
       nowDisplayingShouldShowProvider,
     );
-    final isProcessing =
-        _isProcessing ||
-        (connectionState.status != WiFiConnectionStatus.selectingNetwork &&
-            connectionState.status != WiFiConnectionStatus.idle &&
-            connectionState.status != WiFiConnectionStatus.error &&
-            connectionState.status != WiFiConnectionStatus.success);
+    final isProcessing = isWifiPasswordSubmitBusy(
+      localProcessingFlag: _isProcessing,
+      status: connectionState.status,
+    );
     final isOpen = _isOpenNetwork(widget.payload.wifiAccessPoint.ssid);
     final parsedSsid = _parseSSID(widget.payload.wifiAccessPoint.ssid);
     // Open networks don't need a password; closed networks require one.

--- a/test/unit/ui/screens/send_wifi_credentials_busy_test.dart
+++ b/test/unit/ui/screens/send_wifi_credentials_busy_test.dart
@@ -1,0 +1,47 @@
+import 'package:app/app/providers/connect_wifi_provider.dart';
+import 'package:app/ui/screens/send_wifi_credentials_screen.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('isWifiPasswordSubmitBusy', () {
+    test('returns false when status is error even if local flag is true', () {
+      expect(
+        isWifiPasswordSubmitBusy(
+          localProcessingFlag: true,
+          status: WiFiConnectionStatus.error,
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns true when local flag is true and status is selectingNetwork', () {
+      expect(
+        isWifiPasswordSubmitBusy(
+          localProcessingFlag: true,
+          status: WiFiConnectionStatus.selectingNetwork,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns true for sendingCredentials without local flag', () {
+      expect(
+        isWifiPasswordSubmitBusy(
+          localProcessingFlag: false,
+          status: WiFiConnectionStatus.sendingCredentials,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for idle without local flag', () {
+      expect(
+        isWifiPasswordSubmitBusy(
+          localProcessingFlag: false,
+          status: WiFiConnectionStatus.idle,
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
When sending Wi‑Fi credentials failed, the enter-password screen could stay on the "Connecting…" loading state because local processing was not cleared when `connectWiFiProvider` transitioned to `error`.

## Changes
- Clear the local busy flag when Wi‑Fi flow reports `WiFiConnectionStatus.error`.
- Add `isWifiPasswordSubmitBusy` helper so loading ends as soon as the notifier is in error (covers races where error arrives before dialog handling).
- Unit tests for the busy helper.

## Testing
- Added `send_wifi_credentials_busy_test.dart` for `isWifiPasswordSubmitBusy`.

Made with [Cursor](https://cursor.com)