### PR TITLE
fix(routing): use matchedLocation for smartPush and popUntil

### DIFF
--- a/lib/app/routing/navigation_extensions.dart
+++ b/lib/app/routing/navigation_extensions.dart
@@ -19,7 +19,12 @@ extension NavigationExtensions on BuildContext {
   /// ```
   void popUntil(String targetRoute) {
     final router = GoRouter.of(this);
-    final currentLocation = router.routerDelegate.currentConfiguration.uri.path;
+    String matchedPath() {
+      final p = router.routerDelegate.state.matchedLocation;
+      return p.isEmpty ? '/' : p;
+    }
+
+    final currentLocation = matchedPath();
 
     // If we're already at the target route, do nothing
     if (currentLocation == targetRoute) {
@@ -29,8 +34,7 @@ extension NavigationExtensions on BuildContext {
     // Try to pop routes until we reach the target
     // We'll pop while we can and check if we've reached the target
     while (router.canPop()) {
-      final locationBeforePop =
-          router.routerDelegate.currentConfiguration.uri.path;
+      final locationBeforePop = matchedPath();
 
       // If we're at the target, stop
       if (locationBeforePop == targetRoute) {
@@ -41,8 +45,7 @@ extension NavigationExtensions on BuildContext {
       router.pop();
 
       // Check if we're now at the target after popping
-      final locationAfterPop =
-          router.routerDelegate.currentConfiguration.uri.path;
+      final locationAfterPop = matchedPath();
       if (locationAfterPop == targetRoute) {
         return;
       }

--- a/lib/app/routing/router_extensions.dart
+++ b/lib/app/routing/router_extensions.dart
@@ -17,7 +17,11 @@ extension SmartNavigation on GoRouter {
   /// - Currently on `/works/item-123`, call `smartPush('/works/item-123')`
   ///   → No-op (already on same work)
   void smartPush(String location) {
-    final currentUri = routerDelegate.currentConfiguration.uri.path;
+    // matchedLocation reflects the full matched path (e.g. /works/id).
+    // currentConfiguration.uri.path is often "/" with nested navigators / shell
+    // layouts, which breaks same-route-family detection.
+    final path = routerDelegate.state.matchedLocation;
+    final currentUri = path.isEmpty ? '/' : path;
     
     // Extract the base route (e.g., '/works' from '/works/item-123')
     final currentBase = _extractBaseRoute(currentUri);


### PR DESCRIPTION
Fixes #299

## Summary
- `smartPush`: read current path via `routerDelegate.state.matchedLocation` instead of `currentConfiguration.uri.path`, which stayed `/` on nested routes (e.g. work detail).
- `popUntil`: same path resolution for consistent behavior.

Aligns with `AppRouteObserver`, which already documented this limitation.

Made with [Cursor](https://cursor.com)