### PR TITLE
chore(gitignore): ignore symlinked local Cursor rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,8 @@ old_ff_app
 
 # Cursor
 .cursor/codebase-rule.mdc
+# Symlinked personal Cursor rules (machine-local)
+.cursor/local-rules/
 
 # Database snapshot
 scripts/ff_feed_indexer_seed.sqlite


### PR DESCRIPTION
## Summary

Adds `.cursor/local-rules/` to `.gitignore` so machine-local symlinked Cursor rules are not tracked.

## Changes

- Ignore the `.cursor/local-rules/` directory (personal Cursor rules symlinked from elsewhere).

## Verification

- No app code changes; gitignore only.

Made with [Cursor](https://cursor.com)