### PR TITLE
fix: use previous page title for back label

### DIFF
--- a/lib/app/routing/previous_page_title_extra.dart
+++ b/lib/app/routing/previous_page_title_extra.dart
@@ -1,0 +1,27 @@
+/// Payload passed with route `push` so the next screen can label the back
+/// control with the title of the screen the user is leaving.
+final class PreviousPageTitleExtra {
+  /// Creates extra with the prior screen’s visible title.
+  const PreviousPageTitleExtra(this.title);
+
+  /// Title shown on the previous screen (tab label, channel name, etc.).
+  final String title;
+}
+
+const _genericIndexTitle = 'Index';
+
+/// Returns the wrapped title when [extra] is [PreviousPageTitleExtra];
+/// otherwise null.
+String? previousPageTitleFromExtra(Object? extra) {
+  if (extra is! PreviousPageTitleExtra) return null;
+
+  final normalizedTitle = extra.title.trim();
+  if (normalizedTitle.isEmpty || normalizedTitle == _genericIndexTitle) {
+    // "Index" is the shell page title, not the user-visible sub-surface the
+    // user navigated from. Treat it as missing so route-specific fallbacks like
+    // "Playlists" or "Channels" can provide the correct back label.
+    return null;
+  }
+
+  return normalizedTitle;
+}

--- a/test/unit/app/routing/previous_page_title_extra_test.dart
+++ b/test/unit/app/routing/previous_page_title_extra_test.dart
@@ -1,0 +1,33 @@
+import 'package:app/app/routing/previous_page_title_extra.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('previousPageTitleFromExtra', () {
+    test('returns title for PreviousPageTitleExtra', () {
+      expect(
+        previousPageTitleFromExtra(const PreviousPageTitleExtra('Channels')),
+        'Channels',
+      );
+    });
+
+    test('returns null for other extra types', () {
+      expect(previousPageTitleFromExtra(null), isNull);
+      expect(previousPageTitleFromExtra('string'), isNull);
+      expect(previousPageTitleFromExtra(42), isNull);
+    });
+
+    test('treats generic Index title as missing', () {
+      expect(
+        previousPageTitleFromExtra(const PreviousPageTitleExtra('Index')),
+        isNull,
+      );
+    });
+
+    test('trims surrounding whitespace from titles', () {
+      expect(
+        previousPageTitleFromExtra(const PreviousPageTitleExtra(' Playlists ')),
+        'Playlists',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- ignore the generic home shell title `Index` when deriving a previous-page back label
- let destination screens fall back to their route-specific titles such as `Playlists` and `Channels`
- add regression coverage for the `Index` case and whitespace normalization

## Verification
- flutter test test/unit/app/routing/previous_page_title_extra_test.dart
- flutter test test/unit/app/routing/all_playlists_route_test.dart
- scripts/agent-helpers/post-implementation-checks HEAD

## Review
- Reviewer sub-agent verdict: accept