### PR TITLE
fix(ui): show Favorite row on work detail only when work is favorited

### DIFF
--- a/lib/domain/utils/work_detail_favorite_playlist_row.dart
+++ b/lib/domain/utils/work_detail_favorite_playlist_row.dart
@@ -1,0 +1,8 @@
+/// Whether the Favorite playlist row appears on work detail below the preview.
+///
+/// The row should reflect that **this** work is in Favorites, not merely that
+/// the Favorite playlist has other items.
+bool shouldShowFavoritePlaylistRowOnWorkDetail({
+  required bool isFullScreen,
+  required bool isCurrentWorkInFavorite,
+}) => !isFullScreen && isCurrentWorkInFavorite;

--- a/lib/ui/screens/work_detail_back_layer.dart
+++ b/lib/ui/screens/work_detail_back_layer.dart
@@ -6,8 +6,8 @@
 
 import 'dart:math';
 
+import 'package:app/app/providers/me_section_playlists_provider.dart';
 import 'package:app/app/providers/now_displaying_provider.dart';
-import 'package:app/app/providers/playlist_details_provider.dart';
 import 'package:app/app/routing/navigation_extensions.dart';
 import 'package:app/app/routing/routes.dart';
 import 'package:app/design/layout_constants.dart';
@@ -15,6 +15,7 @@ import 'package:app/domain/extensions/playlist_item_ext.dart';
 import 'package:app/domain/models/now_displaying_object.dart';
 import 'package:app/domain/models/playlist.dart';
 import 'package:app/domain/models/playlist_item.dart';
+import 'package:app/domain/utils/work_detail_favorite_playlist_row.dart';
 import 'package:app/nft_rendering/audio_rendering_widget.dart';
 import 'package:app/nft_rendering/gif_rendering_widget.dart';
 import 'package:app/nft_rendering/image_rendering_widget.dart';
@@ -75,15 +76,14 @@ class WorkDetailBackLayer extends ConsumerWidget {
 
     final isPlayingOnFF1 = playingObject != null;
 
-    final favoriteDetailsAsync = ref.watch(
-      playlistDetailsProvider(Playlist.favoriteId),
+    final isWorkFavoriteAsync = ref.watch(
+      isWorkInFavoriteProvider(item.id),
     );
-    final showFavoriteRow =
-        !isFullScreen &&
-        (favoriteDetailsAsync.whenOrNull(
-              data: (state) => state.items.isNotEmpty,
-            ) ??
-            false);
+    final showFavoriteRow = shouldShowFavoritePlaylistRowOnWorkDetail(
+      isFullScreen: isFullScreen,
+      isCurrentWorkInFavorite:
+          isWorkFavoriteAsync.whenOrNull(data: (v) => v) ?? false,
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -128,7 +128,8 @@ class WorkDetailBackLayer extends ConsumerWidget {
           ),
         ),
         // SizedBox(height: LayoutConstants.space4),
-        // Favorite playlist row (same UI as Playlist tab). Only when not empty.
+        // Favorite playlist row (same UI as Playlist tab). Only when this work
+        // is in Favorites (not merely when Favorite has other items).
         if (showFavoriteRow) ...[
           PlaylistRowItem(
             playlist: Playlist.favorite(),

--- a/test/unit/domain/utils/work_detail_favorite_playlist_row_test.dart
+++ b/test/unit/domain/utils/work_detail_favorite_playlist_row_test.dart
@@ -1,0 +1,36 @@
+import 'package:app/domain/utils/work_detail_favorite_playlist_row.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('shouldShowFavoritePlaylistRowOnWorkDetail', () {
+    test('shows when not full screen and this work is favorited', () {
+      expect(
+        shouldShowFavoritePlaylistRowOnWorkDetail(
+          isFullScreen: false,
+          isCurrentWorkInFavorite: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('hides when full screen even if favorited', () {
+      expect(
+        shouldShowFavoritePlaylistRowOnWorkDetail(
+          isFullScreen: true,
+          isCurrentWorkInFavorite: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('hides when this work is not favorited', () {
+      expect(
+        shouldShowFavoritePlaylistRowOnWorkDetail(
+          isFullScreen: false,
+          isCurrentWorkInFavorite: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
On the work detail screen, the Favorite playlist row was shown whenever the Favorite playlist had any items. It now appears only when **this** work is in Favorites (same source as the favorite control in the app bar).

## Changes
- Watch `isWorkInFavoriteProvider(item.id)` instead of non-empty `playlistDetailsProvider(Playlist.favoriteId)`.
- Extract `shouldShowFavoritePlaylistRowOnWorkDetail` in domain with unit tests.

## Issue
Fixes https://github.com/feral-file/ff-app/issues/326

## Verification
- `scripts/agent-helpers/post-implementation-checks.sh HEAD` clean
- Unit tests for the visibility helper

Made with [Cursor](https://cursor.com)