### PR TITLE
ci: add Sentry release steps to mobile release workflows

### DIFF
--- a/.github/workflows/release-android-playstore.yaml
+++ b/.github/workflows/release-android-playstore.yaml
@@ -101,6 +101,13 @@ jobs:
           echo "FLUTTER_VERSION_CODE=${{ steps.fetch_build_number.outputs.build_number }}" >> $GITHUB_ENV
           echo "NAME_SUFFIX=main-${{ steps.fetch_build_number.outputs.build_number }}" >> $GITHUB_ENV
 
+      - name: Prepare Sentry release metadata
+        run: |
+          # Keep the workflow-created release identical to the shipped app
+          # version so Sentry can match uploaded DIFs to production crashes.
+          echo "SENTRY_RELEASE=com.feralfile.app@${{ steps.fetch_build_number.outputs.version_name }}+${{ steps.fetch_build_number.outputs.build_number }}" >> "$GITHUB_ENV"
+          echo "SENTRY_DIST=${{ steps.fetch_build_number.outputs.build_number }}" >> "$GITHUB_ENV"
+
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
@@ -137,20 +144,21 @@ jobs:
       - name: Build appbundle
         run: flutter build appbundle --flavor production --release --build-name "${{ env.FLUTTER_VERSION_NAME }}" --build-number "${{ env.FLUTTER_VERSION_CODE }}"
 
-      # - name: Install sentry-cli & create Sentry release and upload Android debug symbols
-      #   env:
-      #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      #     SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-      #     SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-      #   run: |
-      #     curl -sL https://sentry.io/get-cli/ | bash
-      #     sentry-cli --version
-      #     RELEASE="com.feralfile.app@${FLUTTER_VERSION_NAME}+${FLUTTER_VERSION_CODE}"
-      #     echo "Sentry release: $RELEASE"
-      #     sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases new "$RELEASE"
-      #     sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases set-commits "$RELEASE" --auto || true
-      #     sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" debug-files upload --include-sources --wait build/app/intermediates/merged_native_libs/productionRelease/mergeProductionReleaseNativeLibs/out/lib
-      #     sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases finalize "$RELEASE"
+      - name: Create Sentry release and upload Android debug symbols
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          echo "Sentry release: $SENTRY_RELEASE"
+          sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases new "$SENTRY_RELEASE" || \
+            sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases info "$SENTRY_RELEASE"
+          sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases set-commits "$SENTRY_RELEASE" --auto || true
+          sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" debug-files upload \
+            --include-sources \
+            --wait \
+            build/app/intermediates/merged_native_libs/productionRelease/mergeProductionReleaseNativeLibs/out/lib
+          sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases finalize "$SENTRY_RELEASE"
 
       - name: Release notes
         run: |

--- a/.github/workflows/release-ios-testflight.yaml
+++ b/.github/workflows/release-ios-testflight.yaml
@@ -227,6 +227,8 @@ jobs:
             archive
 
           echo "ARCHIVE_PATH=$ARCHIVE_PATH" >> "$GITHUB_ENV"
+          echo "SENTRY_RELEASE=com.feralfile.app@$BUILD_NAME+$BUILD_NUMBER" >> "$GITHUB_ENV"
+          echo "SENTRY_DIST=$BUILD_NUMBER" >> "$GITHUB_ENV"
 
       - name: Export IPA
         run: |
@@ -268,20 +270,24 @@ jobs:
           IPA_PATH="$(ls "$EXPORT_PATH"/*.ipa | head -1)"
           echo "IOS_IPA_PATH=$IPA_PATH" >> "$GITHUB_ENV"
 
-      # - name: Install sentry-cli & create Sentry release and upload iOS debug symbols
-      #   env:
-      #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      #     SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-      #     SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-      #   run: |
-      #     curl -sL https://sentry.io/get-cli/ | bash
-      #     sentry-cli --version
-      #     RELEASE="com.feralfile.app@${IOS_BUILD_NAME}+${IOS_BUILD_NUMBER}"
-      #     echo "Sentry release: $RELEASE"
-      #     sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases new "$RELEASE"
-      #     sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases set-commits "$RELEASE" --auto || true
-      #     sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" debug-files upload --include-sources --wait "$ARCHIVE_PATH/dSYMs"
-      #     sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases finalize "$RELEASE"
+      - name: Create Sentry release and upload iOS debug symbols
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          echo "Sentry release: $SENTRY_RELEASE"
+          sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases new "$SENTRY_RELEASE" || \
+            sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases info "$SENTRY_RELEASE"
+          sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases set-commits "$SENTRY_RELEASE" --auto || true
+          SYMBOL_UPLOAD_ARGS=(--include-sources --wait --type dsym)
+          if [[ -d "$ARCHIVE_PATH/BCSymbolMaps" ]]; then
+            SYMBOL_UPLOAD_ARGS+=(--symbol-maps "$ARCHIVE_PATH/BCSymbolMaps")
+          fi
+          sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" debug-files upload \
+            "${SYMBOL_UPLOAD_ARGS[@]}" \
+            "$ARCHIVE_PATH/dSYMs"
+          sentry-cli --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" releases finalize "$SENTRY_RELEASE"
 
       - name: Upload to TestFlight
         uses: apple-actions/upload-testflight-build@v3


### PR DESCRIPTION
## Problem
The Android Play Store and iOS TestFlight release workflows build and upload production artifacts, but they do not create matching Sentry releases or upload native debug symbols during the release pipeline.

## Why it matters
Without a release created from the shipped version/build and the matching native symbols uploaded at release time, production mobile crashes are harder to symbolicate and correlate back to the exact app version that was shipped.

## Acceptance checks
- Android release workflow creates a Sentry release named from the shipped app version/build and uploads Android native debug files before the Play upload.
- iOS release workflow creates the matching Sentry release and uploads dSYMs, including BCSymbolMaps when present, before the TestFlight upload.
- Both workflows remain valid YAML and keep the release naming aligned with the app version/build used for the actual store submission.