### PR TITLE
fix: bump wkwebview plugin for iOS teardown crash

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,9 +107,9 @@ dependencies:
   mobile_scanner:
   package_info_plus: 9.0.0
   permission_handler: 12.0.1
-  webview_flutter: ^4.13.0
-  webview_flutter_android: ^4.10.13
-  webview_flutter_wkwebview: ^3.23.8
+  webview_flutter: ^4.13.1
+  webview_flutter_android: ^4.10.15
+  webview_flutter_wkwebview: ^3.24.2
 dev_dependencies:
   # Code generation
   build_runner: ^2.12.2


### PR DESCRIPTION
## Problem
Issue #338 reports an iOS SIGABRT on `/keyboard-control` after relayer disconnect / teardown, with the crash signature pointing into `webview_flutter_wkwebview`'s native codec path.

## Why It Matters
This crash interrupts an active FF1 interaction flow and can terminate the app during a high-value device-control journey. Because the failure happens in native WKWebView teardown rather than app Dart logic, it is both user-visible and hard to recover from once triggered.

## Solution
This PR upgrades the webview packages to the current resolvable safe line, most importantly bumping `webview_flutter_wkwebview` from `^3.23.8` to `^3.24.2`. That version line includes the iOS platform-view lifecycle fix that replaces the risky teardown reference path implicated by this crash class.

## Acceptance Checks
- `flutter test`
- `scripts/agent-helpers/post-implementation-checks.sh HEAD`
- Manually verify iOS no longer crashes when reproducing the `/keyboard-control` disconnect / lifecycle race from [#338](https://github.com/feral-file/ff-app/issues/338)

Closes #338

Note: per user direction, this PR skips the repo's usual sub-agent review loop.
