### PR TITLE
fix(now-displaying): full-row tap target for expanded playlist items

### DIFF
--- a/lib/widgets/now_displaying_bar/display_item.dart
+++ b/lib/widgets/now_displaying_bar/display_item.dart
@@ -32,69 +32,75 @@ class NowDisplayingDisplayItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final opacity = isPlaying ? 1.0 : 0.5;
 
+    // Transparent fill matches e.g. [WorkGridCard]: full-bounds hit target so
+    // taps register outside text/thumbnail (Row flex padding).
     return GestureDetector(
       onTap: onTap,
       child: Opacity(
         opacity: opacity,
-        child: Row(
-          crossAxisAlignment: isInExpandedView
-              ? CrossAxisAlignment.center
-              : CrossAxisAlignment.start,
-          children: [
-            _Thumbnail(url: item.thumbnailUrl),
-            SizedBox(width: LayoutConstants.nowDisplayingDisplayItemGap),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  if (deviceName != null)
-                    Text(
-                      deviceName!.toUpperCase(),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: AppTypography.displayItemDeviceName(context).white,
-                    ),
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
+        child: ColoredBox(
+          color: Colors.transparent,
+          child: Row(
+            crossAxisAlignment: isInExpandedView
+                ? CrossAxisAlignment.center
+                : CrossAxisAlignment.start,
+            children: [
+              _Thumbnail(url: item.thumbnailUrl),
+              SizedBox(width: LayoutConstants.nowDisplayingDisplayItemGap),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    if (deviceName != null)
                       Text(
-                        item.artistName,
+                        deviceName!.toUpperCase(),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: ContentRhythm.supporting(
-                          context,
-                        ).copyWith(color: Colors.white),
+                        style:
+                            AppTypography.displayItemDeviceName(context).white,
                       ),
-                      Transform.translate(
-                        offset: const Offset(
-                          0,
-                          LayoutConstants
-                              .nowDisplayingDisplayItemTextArtworkGap,
-                        ),
-                        child: Text(
-                          item.title ?? 'Unknown title',
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          item.artistName,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style: isInExpandedView
-                              ? ContentRhythm.supporting(
-                                  context,
-                                ).copyWith(
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w700,
-                                  fontStyle: FontStyle.italic,
-                                )
-                              : ContentRhythm.supporting(
-                                  context,
-                                ).copyWith(color: Colors.white),
+                          style: ContentRhythm.supporting(
+                            context,
+                          ).copyWith(color: Colors.white),
                         ),
-                      ),
-                    ],
-                  ),
-                ],
+                        Transform.translate(
+                          offset: const Offset(
+                            0,
+                            LayoutConstants
+                                .nowDisplayingDisplayItemTextArtworkGap,
+                          ),
+                          child: Text(
+                            item.title ?? 'Unknown title',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: isInExpandedView
+                                ? ContentRhythm.supporting(
+                                    context,
+                                  ).copyWith(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.w700,
+                                    fontStyle: FontStyle.italic,
+                                  )
+                                : ContentRhythm.supporting(
+                                    context,
+                                  ).copyWith(color: Colors.white),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/test/unit/widgets/now_displaying/display_item_widget_test.dart
+++ b/test/unit/widgets/now_displaying/display_item_widget_test.dart
@@ -1,0 +1,45 @@
+import 'package:app/domain/models/dp1/dp1_manifest.dart';
+import 'package:app/domain/models/playlist_item.dart';
+import 'package:app/widgets/now_displaying_bar/display_item.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'expanded row tap counts in padding above thumbnail (transparent hit fill)',
+    (tester) async {
+      var tapCount = 0;
+      const item = PlaylistItem(
+        id: 'id',
+        kind: PlaylistItemKind.indexerToken,
+        title: 'Short',
+        artists: [DP1Artist(name: 'Artist', id: '1')],
+        thumbnailUrl: null,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: SizedBox(
+              width: 360,
+              child: NowDisplayingDisplayItem(
+                item: item,
+                isPlaying: false,
+                isInExpandedView: true,
+                onTap: () => tapCount++,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final rect = tester.getRect(find.byType(NowDisplayingDisplayItem));
+      // Row can be taller than the thumbnail; centered thumbnail leaves a
+      // vertical strip above the image that deferToChild would not hit.
+      await tester.tapAt(Offset(rect.left + 12, rect.top + 1));
+      await tester.pump();
+      expect(tapCount, 1);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
When the Now Displaying bar is expanded, taps on empty flex padding (outside thumbnail and text) did not navigate to the artwork.

## Changes
- Wrap the display `Row` in `ColoredBox(color: Colors.transparent)` so the full row bounds participate in hit testing (same idea as WorkGridCard).
- Add a widget test that taps the padding strip above the thumbnail and expects `onTap`.

Fixes #349

Made with [Cursor](https://cursor.com)