### PR TITLE
fix(onboarding): prevent RenderEditable crash on add-address / add-alias

### DIFF
--- a/lib/app/utils/safe_focus_request.dart
+++ b/lib/app/utils/safe_focus_request.dart
@@ -1,0 +1,80 @@
+//
+//  SPDX-License-Identifier: BSD-2-Clause-Patent
+//  Copyright © 2024 Bitmark. All rights reserved.
+//  Use of this source code is governed by the BSD-2-Clause Plus Patent License
+//  that can be found in the LICENSE file.
+//
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+/// Upper bound on deferred focus attempts to avoid unbounded frame callbacks if
+/// layout never settles (e.g. widget removed).
+const _kMaxFocusLayoutAttempts = 16;
+
+/// Requests [focusNode] focus only when the owning route is current and the
+/// focus target has a laid-out [RenderBox].
+///
+/// A single post-frame [FocusNode.requestFocus] can run during route or app
+/// lifecycle churn before [RenderEditable] finishes layout, which crashes
+/// when the IME reads size/transform (see issue #357 / FF-APP-6J).
+void scheduleRequestFocusWhenLaidOut({
+  required FocusNode focusNode,
+  required BuildContext ownerContext,
+}) {
+  var attempts = 0;
+
+  void tryFocus() {
+    attempts++;
+    if (attempts > _kMaxFocusLayoutAttempts) {
+      return;
+    }
+    if (!ownerContext.mounted) {
+      return;
+    }
+    if (!focusNode.canRequestFocus) {
+      return;
+    }
+
+    final route = ModalRoute.of(ownerContext);
+    if (route != null && !route.isCurrent) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => tryFocus());
+      return;
+    }
+
+    final focusContext = focusNode.context;
+    if (focusContext == null || !focusContext.mounted) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => tryFocus());
+      return;
+    }
+
+    final renderObject = focusContext.findRenderObject();
+    if (renderObject is RenderBox &&
+        renderObject.attached &&
+        renderObject.hasSize) {
+      focusNode.requestFocus();
+      return;
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) => tryFocus());
+  }
+
+  // Call from a post-frame callback after [State.context] is valid (e.g.
+  // `addPostFrameCallback` from `initState`).
+  tryFocus();
+}
+
+/// Runs [action] on the next frame if [context] is still mounted.
+///
+/// Defers `go_router` navigation triggered from Riverpod listeners so it does
+/// not interleave with focus or route transition work in the same frame.
+void schedulePostFrameIfMounted(
+  BuildContext context,
+  VoidCallback action,
+) {
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    if (context.mounted) {
+      action();
+    }
+  });
+}

--- a/lib/app/utils/safe_focus_request.dart
+++ b/lib/app/utils/safe_focus_request.dart
@@ -64,17 +64,25 @@ void scheduleRequestFocusWhenLaidOut({
   tryFocus();
 }
 
-/// Runs [action] on the next frame if [context] is still mounted.
+/// Runs [action] on the next frame if [context] is still mounted and the
+/// nearest [ModalRoute] is still [ModalRoute.isCurrent].
 ///
-/// Defers `go_router` navigation triggered from Riverpod listeners so it does
-/// not interleave with focus or route transition work in the same frame.
+/// Matches [scheduleRequestFocusWhenLaidOut] so deferred `go_router`
+/// navigation from Riverpod listeners does not run after the user has left the
+/// screen (another route on top, or route replaced) while still interleaving
+/// safely with layout/focus work in the originating frame.
 void schedulePostFrameIfMounted(
   BuildContext context,
   VoidCallback action,
 ) {
   WidgetsBinding.instance.addPostFrameCallback((_) {
-    if (context.mounted) {
-      action();
+    if (!context.mounted) {
+      return;
     }
+    final route = ModalRoute.of(context);
+    if (route != null && !route.isCurrent) {
+      return;
+    }
+    action();
   });
 }

--- a/lib/ui/screens/add_address_screen.dart
+++ b/lib/ui/screens/add_address_screen.dart
@@ -12,6 +12,7 @@ import 'package:app/app/providers/add_address_provider.dart';
 import 'package:app/app/providers/now_displaying_visibility_provider.dart';
 import 'package:app/app/providers/scan_qr_provider.dart';
 import 'package:app/app/routing/routes.dart';
+import 'package:app/app/utils/safe_focus_request.dart';
 import 'package:app/design/app_typography.dart';
 import 'package:app/design/build/primitives.dart';
 import 'package:app/design/layout_constants.dart';
@@ -54,7 +55,10 @@ class _AddAddressInputScreenState extends ConsumerState<AddAddressScreen> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      _addressFocusNode.requestFocus();
+      scheduleRequestFocusWhenLaidOut(
+        focusNode: _addressFocusNode,
+        ownerContext: context,
+      );
     });
   }
 
@@ -103,20 +107,18 @@ class _AddAddressInputScreenState extends ConsumerState<AddAddressScreen> {
             :final address,
             :final domain,
           )) {
-            if (context.mounted) {
+            schedulePostFrameIfMounted(context, () {
               final payload = AddAliasScreenPayload(
                 address: address,
                 domain: domain,
               );
               unawaited(context.push(Routes.addAliasPage, extra: payload));
-            }
+            });
             return;
           }
 
           if (value is AddAddressFlowCompleted) {
-            if (context.mounted) {
-              context.pop();
-            }
+            schedulePostFrameIfMounted(context, () => context.pop());
           }
         }
       },

--- a/lib/ui/screens/add_alias_screen.dart
+++ b/lib/ui/screens/add_alias_screen.dart
@@ -10,6 +10,7 @@ import 'dart:async';
 import 'package:app/app/patrol/gold_path_patrol_keys.dart';
 import 'package:app/app/providers/add_address_provider.dart';
 import 'package:app/app/providers/now_displaying_visibility_provider.dart';
+import 'package:app/app/utils/safe_focus_request.dart';
 import 'package:app/design/app_typography.dart';
 import 'package:app/design/build/primitives.dart';
 import 'package:app/design/layout_constants.dart';
@@ -60,11 +61,12 @@ class _AddAliasScreenState extends ConsumerState<AddAliasScreen> {
   void initState() {
     super.initState();
     _inputController = TextEditingController();
-    // Auto focus on input field
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        _aliasFocusNode.requestFocus();
-      }
+      if (!mounted) return;
+      scheduleRequestFocusWhenLaidOut(
+        focusNode: _aliasFocusNode,
+        ownerContext: context,
+      );
     });
   }
 
@@ -99,13 +101,12 @@ class _AddAliasScreenState extends ConsumerState<AddAliasScreen> {
     ref.listen<AsyncValue<void>>(
       addAliasProvider,
       (previous, next) {
-        // When address is successfully added, pop
         if (next is AsyncData<void>) {
-          if (context.mounted) {
+          schedulePostFrameIfMounted(context, () {
             context
               ..pop()
               ..pop();
-          }
+          });
         }
       },
     );

--- a/test/unit/app/utils/safe_focus_request_test.dart
+++ b/test/unit/app/utils/safe_focus_request_test.dart
@@ -3,55 +3,121 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('scheduleRequestFocusWhenLaidOut focuses TextField after layout',
-      (tester) async {
-    final focusNode = FocusNode();
-    addTearDown(focusNode.dispose);
+  testWidgets(
+    'scheduleRequestFocusWhenLaidOut focuses TextField after layout',
+    (tester) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: _AutoFocusHarness(
-          focusNode: focusNode,
-          child: TextField(
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _AutoFocusHarness(
             focusNode: focusNode,
-            autofocus: false,
+            child: TextField(
+              focusNode: focusNode,
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    await tester.pumpAndSettle();
-    expect(focusNode.hasFocus, isTrue);
-  });
+      await tester.pumpAndSettle();
+      expect(focusNode.hasFocus, isTrue);
+    },
+  );
 
-  testWidgets('schedulePostFrameIfMounted runs action on next frame', (
-    tester,
-  ) async {
-    var ran = false;
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Builder(
-          builder: (context) {
-            return Scaffold(
-              body: TextButton(
-                onPressed: () {
-                  schedulePostFrameIfMounted(context, () {
-                    ran = true;
-                  });
-                },
-                child: const Text('go'),
-              ),
-            );
-          },
+  testWidgets(
+    'schedulePostFrameIfMounted runs action on next frame when route current',
+    (tester) async {
+      var ran = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: TextButton(
+                  onPressed: () {
+                    schedulePostFrameIfMounted(context, () {
+                      ran = true;
+                    });
+                  },
+                  child: const Text('go'),
+                ),
+              );
+            },
+          ),
         ),
-      ),
-    );
+      );
 
-    await tester.tap(find.text('go'));
-    expect(ran, isFalse);
-    await tester.pump();
-    expect(ran, isTrue);
-  });
+      await tester.tap(find.text('go'));
+      expect(ran, isFalse);
+      await tester.pump();
+      expect(ran, isTrue);
+    },
+  );
+
+  testWidgets(
+    'schedulePostFrameIfMounted skips action when route no longer current',
+    (tester) async {
+      var ran = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: TextButton(
+                  onPressed: () {
+                    schedulePostFrameIfMounted(context, () {
+                      ran = true;
+                    });
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const Scaffold(
+                          body: Text('second'),
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('go'),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('go'));
+      expect(ran, isFalse);
+      await tester.pump();
+      expect(ran, isFalse);
+    },
+  );
+
+  testWidgets(
+    'schedulePostFrameIfMounted skips when context unmounted before callback',
+    (tester) async {
+      var ran = false;
+      late BuildContext captured;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              captured = context;
+              return const Scaffold(
+                body: Text('home'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      schedulePostFrameIfMounted(captured, () {
+        ran = true;
+      });
+      await tester.pump();
+      expect(ran, isFalse);
+    },
+  );
 }
 
 class _AutoFocusHarness extends StatefulWidget {

--- a/test/unit/app/utils/safe_focus_request_test.dart
+++ b/test/unit/app/utils/safe_focus_request_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app/app/utils/safe_focus_request.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -69,10 +71,12 @@ void main() {
                     schedulePostFrameIfMounted(context, () {
                       ran = true;
                     });
-                    Navigator.of(context).push(
-                      MaterialPageRoute<void>(
-                        builder: (_) => const Scaffold(
-                          body: Text('second'),
+                    unawaited(
+                      Navigator.of(context).push<void>(
+                        MaterialPageRoute<void>(
+                          builder: (_) => const Scaffold(
+                            body: Text('second'),
+                          ),
                         ),
                       ),
                     );

--- a/test/unit/app/utils/safe_focus_request_test.dart
+++ b/test/unit/app/utils/safe_focus_request_test.dart
@@ -1,0 +1,87 @@
+import 'package:app/app/utils/safe_focus_request.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('scheduleRequestFocusWhenLaidOut focuses TextField after layout',
+      (tester) async {
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: _AutoFocusHarness(
+          focusNode: focusNode,
+          child: TextField(
+            focusNode: focusNode,
+            autofocus: false,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isTrue);
+  });
+
+  testWidgets('schedulePostFrameIfMounted runs action on next frame', (
+    tester,
+  ) async {
+    var ran = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: TextButton(
+                onPressed: () {
+                  schedulePostFrameIfMounted(context, () {
+                    ran = true;
+                  });
+                },
+                child: const Text('go'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('go'));
+    expect(ran, isFalse);
+    await tester.pump();
+    expect(ran, isTrue);
+  });
+}
+
+class _AutoFocusHarness extends StatefulWidget {
+  const _AutoFocusHarness({
+    required this.focusNode,
+    required this.child,
+  });
+
+  final FocusNode focusNode;
+  final Widget child;
+
+  @override
+  State<_AutoFocusHarness> createState() => _AutoFocusHarnessState();
+}
+
+class _AutoFocusHarnessState extends State<_AutoFocusHarness> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      scheduleRequestFocusWhenLaidOut(
+        focusNode: widget.focusNode,
+        ownerContext: context,
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: widget.child);
+  }
+}

--- a/test/unit/app/utils/safe_focus_request_test.dart
+++ b/test/unit/app/utils/safe_focus_request_test.dart
@@ -28,6 +28,23 @@ void main() {
   );
 
   testWidgets(
+    'scheduleRequestFocusWhenLaidOut retries when TextField not laid out yet',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: _LateTextFieldHarness(),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).focusNode!.hasFocus,
+        isTrue,
+      );
+    },
+  );
+
+  testWidgets(
     'schedulePostFrameIfMounted runs action on next frame when route current',
     (tester) async {
       var ran = false;
@@ -153,5 +170,50 @@ class _AutoFocusHarnessState extends State<_AutoFocusHarness> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(body: widget.child);
+  }
+}
+
+/// First frame has no [TextField], so the first focus attempt sees no layout;
+/// the field is inserted in the same post-frame callback after scheduling
+/// focus — exercising the retry path used for FF-APP-6J / issue #357.
+class _LateTextFieldHarness extends StatefulWidget {
+  const _LateTextFieldHarness();
+
+  @override
+  State<_LateTextFieldHarness> createState() => _LateTextFieldHarnessState();
+}
+
+class _LateTextFieldHarnessState extends State<_LateTextFieldHarness> {
+  final FocusNode _focusNode = FocusNode();
+  bool _insertField = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      scheduleRequestFocusWhenLaidOut(
+        focusNode: _focusNode,
+        ownerContext: context,
+      );
+      setState(() => _insertField = true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _insertField
+          ? TextField(
+              focusNode: _focusNode,
+            )
+          : const SizedBox.shrink(),
+    );
   }
 }

--- a/test/unit/ui/screens/add_address/add_address_screen_widget_test.dart
+++ b/test/unit/ui/screens/add_address/add_address_screen_widget_test.dart
@@ -152,8 +152,7 @@ void main() {
                   builder: (context, state) => Scaffold(
                     body: Center(
                       child: TextButton(
-                        onPressed: () =>
-                            context.push(Routes.addAddressPage),
+                        onPressed: () => context.push(Routes.addAddressPage),
                         child: const Text('Open'),
                       ),
                     ),

--- a/test/unit/ui/screens/add_address/add_address_screen_widget_test.dart
+++ b/test/unit/ui/screens/add_address/add_address_screen_widget_test.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:app/app/providers/add_address_provider.dart';
 import 'package:app/app/providers/now_displaying_visibility_provider.dart';
+import 'package:app/app/routing/routes.dart';
 import 'package:app/ui/screens/add_address_screen.dart';
+import 'package:app/ui/screens/add_alias_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -129,6 +131,88 @@ void main() {
     expect(observer.popCount, 1);
     expect(find.text('Open'), findsOneWidget);
   });
+
+  testWidgets(
+    'add-address to add-alias flow completes on skip without error',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            nowDisplayingShouldShowProvider.overrideWithValue(false),
+            addAddressFlowProvider.overrideWith(
+              _NeedsAliasOnSubmitNotifier.new,
+            ),
+            addAliasProvider.overrideWith(_ImmediateAliasCompleteNotifier.new),
+          ],
+          child: MaterialApp.router(
+            routerConfig: GoRouter(
+              routes: [
+                GoRoute(
+                  path: Routes.home,
+                  builder: (context, state) => Scaffold(
+                    body: Center(
+                      child: TextButton(
+                        onPressed: () =>
+                            context.push(Routes.addAddressPage),
+                        child: const Text('Open'),
+                      ),
+                    ),
+                  ),
+                ),
+                GoRoute(
+                  path: Routes.addAddressPage,
+                  builder: (context, state) => const AddAddressScreen(),
+                ),
+                GoRoute(
+                  path: Routes.addAliasPage,
+                  builder: (context, state) {
+                    final extra = state.extra! as AddAliasScreenPayload;
+                    return AddAliasScreen(payload: extra);
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '0xabc');
+      await tester.tap(find.text('Submit'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Alias (optional)'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+
+      await tester.tap(find.text('Skip'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Open'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+}
+
+class _NeedsAliasOnSubmitNotifier extends AddAddressFlowNotifier {
+  @override
+  Future<void> submit(String addressOrDomain) async {
+    state = const AsyncValue.loading();
+    state = const AsyncValue.data(
+      AddAddressFlowNeedsAlias(
+        address: '0x1234567890123456789012345678901234567890',
+      ),
+    );
+  }
+}
+
+class _ImmediateAliasCompleteNotifier extends AddAliasNotifier {
+  @override
+  Future<void> add(String address, String? alias) async {
+    state = const AsyncValue.loading();
+    state = const AsyncValue.data(null);
+  }
 }
 
 class _ErrorAddAddressFlowNotifier extends AddAddressFlowNotifier {

--- a/test/unit/ui/screens/add_alias/add_alias_screen_widget_test.dart
+++ b/test/unit/ui/screens/add_alias/add_alias_screen_widget_test.dart
@@ -1,5 +1,6 @@
 import 'package:app/app/providers/add_address_provider.dart';
 import 'package:app/app/providers/now_displaying_visibility_provider.dart';
+import 'package:app/app/routing/routes.dart';
 import 'package:app/design/build/primitives.dart';
 import 'package:app/ui/screens/add_alias_screen.dart';
 import 'package:app/widgets/buttons/outline_button.dart';
@@ -7,6 +8,7 @@ import 'package:app/widgets/buttons/primary_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 
 void main() {
   testWidgets(
@@ -127,6 +129,156 @@ void main() {
     expect(calls.single.address, '0xabc');
     expect(calls.single.alias, 'Alice');
   });
+
+  testWidgets(
+    'GoRouter: AddAliasScreen auto-focuses alias field after push',
+    (tester) async {
+      const payload = AddAliasScreenPayload(
+        address: '0x1234567890123456789012345678901234567890',
+        domain: 'ff.example',
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            nowDisplayingShouldShowProvider.overrideWithValue(false),
+            addAliasProvider.overrideWith(_StallAliasNotifier.new),
+          ],
+          child: MaterialApp.router(
+            routerConfig: GoRouter(
+              routes: [
+                GoRoute(
+                  path: Routes.home,
+                  builder: (context, state) => Scaffold(
+                    body: Center(
+                      child: TextButton(
+                        onPressed: () => context.push(
+                          Routes.addAliasPage,
+                          extra: payload,
+                        ),
+                        child: const Text('Open'),
+                      ),
+                    ),
+                  ),
+                ),
+                GoRoute(
+                  path: Routes.addAliasPage,
+                  builder: (context, state) {
+                    final extra = state.extra! as AddAliasScreenPayload;
+                    return AddAliasScreen(payload: extra);
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.focusNode, isNotNull);
+      expect(field.focusNode!.hasFocus, isTrue);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'GoRouter: Skip completes flow and pops twice (three-level stack)',
+    (tester) async {
+      final observer = _RecordingNavigatorObserver();
+      const payload = AddAliasScreenPayload(
+        address: '0x1234567890123456789012345678901234567890',
+        domain: 'ff.example',
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            nowDisplayingShouldShowProvider.overrideWithValue(false),
+            addAliasProvider.overrideWith(_ImmediateAliasSuccessNotifier.new),
+          ],
+          child: MaterialApp.router(
+            routerConfig: GoRouter(
+              observers: [observer],
+              routes: [
+                GoRoute(
+                  path: Routes.home,
+                  builder: (context, state) => Scaffold(
+                    body: Center(
+                      child: TextButton(
+                        onPressed: () => context.push('/mid'),
+                        child: const Text('Open'),
+                      ),
+                    ),
+                  ),
+                ),
+                GoRoute(
+                  path: '/mid',
+                  builder: (context, state) => Scaffold(
+                    body: Center(
+                      child: TextButton(
+                        onPressed: () => context.push(
+                          Routes.addAliasPage,
+                          extra: payload,
+                        ),
+                        child: const Text('To alias'),
+                      ),
+                    ),
+                  ),
+                ),
+                GoRoute(
+                  path: Routes.addAliasPage,
+                  builder: (context, state) {
+                    final extra = state.extra! as AddAliasScreenPayload;
+                    return AddAliasScreen(payload: extra);
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('To alias'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Skip'));
+      await tester.pumpAndSettle();
+
+      expect(observer.popCount, 2);
+      expect(find.text('Open'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+}
+
+class _StallAliasNotifier extends AddAliasNotifier {
+  @override
+  Future<void> add(String address, String? alias) async {
+    state = const AsyncValue.loading();
+  }
+}
+
+class _ImmediateAliasSuccessNotifier extends AddAliasNotifier {
+  @override
+  Future<void> add(String address, String? alias) async {
+    state = const AsyncValue.loading();
+    state = const AsyncValue.data(null);
+  }
+}
+
+class _RecordingNavigatorObserver extends NavigatorObserver {
+  int popCount = 0;
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    popCount++;
+    super.didPop(route, previousRoute);
+  }
 }
 
 class _AddAliasCall {


### PR DESCRIPTION
## Summary
Addresses Sentry **FF-APP-6J** / GitHub **#357**: `RenderBox was not laid out: RenderEditable` when focusing the address or alias field during onboarding route or lifecycle churn.

## Changes
- Add `scheduleRequestFocusWhenLaidOut` (`lib/app/utils/safe_focus_request.dart`) to request focus only after the route is current and the focus target has a laid-out `RenderBox`, with a bounded retry.
- Defer `go_router` `push` / `pop` from Riverpod listeners via `schedulePostFrameIfMounted` so navigation does not interleave with the same frame as focus/layout work.
- Apply on `AddAddressScreen` and `AddAliasScreen`.
- Add widget tests for the new helpers.

Fixes #357

Made with [Cursor](https://cursor.com)