### PR TITLE
fix(database): heal malformed playlist rows on open

### DIFF
--- a/lib/infra/database/app_database.dart
+++ b/lib/infra/database/app_database.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:app/domain/models/channel.dart';
 import 'package:app/domain/models/playlist.dart';
 import 'package:app/infra/database/seed_database_gate.dart';
 import 'package:app/infra/database/tables.dart';
@@ -77,6 +78,7 @@ class AppDatabase extends _$AppDatabase {
         // Repair DBs where user_version already advanced but `signatures_json`
         // remains (failed migration, copied file, or pre-release builds).
         await _migratePlaylistsSignaturesJsonIfNeeded();
+        await _repairMalformedPlaylistRowsIfNeeded();
         await _createIndexes();
         await _createFtsInfrastructure();
         if (details.wasCreated || details.hadUpgrade) {
@@ -190,6 +192,209 @@ class AppDatabase extends _$AppDatabase {
         );
       }
     }
+  }
+
+  /// Repairs malformed playlist rows before Drift maps them into
+  /// `PlaylistData`.
+  ///
+  /// Why this exists:
+  /// - Older copied DBs and partially-migrated local files can still contain
+  ///   playlist rows where required columns are null or enum values drifted.
+  /// - Drift's generated row mapper force-unwraps those required fields, so one
+  ///   bad row can crash startup bootstrap and every playlist list/watch query.
+  ///
+  /// We heal rows on open instead of scattering defensive fallback logic across
+  /// providers and services. This preserves the offline-first contract: the app
+  /// should repair readable local state and keep going when the damage is local
+  /// to a few playlist rows.
+  Future<void> _repairMalformedPlaylistRowsIfNeeded() async {
+    final cols = await _playlistTableColumnNames();
+    const requiredCols = {
+      'id',
+      'channel_id',
+      'type',
+      'title',
+      'created_at_us',
+      'updated_at_us',
+      'signatures',
+      'sort_mode',
+      'item_count',
+      'owner_address',
+    };
+    if (!requiredCols.every(cols.contains)) {
+      return;
+    }
+
+    final rows = await customSelect(
+      '''
+      SELECT id, channel_id, type, title, created_at_us, updated_at_us,
+             signatures, owner_address, sort_mode, item_count
+      FROM playlists
+      WHERE type IS NULL
+         OR title IS NULL
+         OR created_at_us IS NULL
+         OR updated_at_us IS NULL
+         OR signatures IS NULL
+         OR sort_mode IS NULL
+         OR item_count IS NULL
+         OR type NOT IN (0, 1, 2)
+         OR sort_mode NOT IN (0, 1)
+         OR item_count < 0
+      ''',
+      readsFrom: {playlists},
+    ).get();
+
+    if (rows.isEmpty) {
+      return;
+    }
+
+    final nowUs = DateTime.now().microsecondsSinceEpoch;
+    await transaction(() async {
+      for (final row in rows) {
+        final id = row.read<String>('id');
+        final channelId = _repairPlaylistChannelId(
+          id: id,
+          rawChannelId: row.read<String?>('channel_id'),
+        );
+        final ownerAddress = row.read<String?>('owner_address');
+        final typeValue = _repairPlaylistTypeValue(
+          id: id,
+          ownerAddress: ownerAddress,
+          rawType: row.read<int?>('type'),
+        );
+        final rawCreatedAtUs = row.read<int?>('created_at_us');
+        final rawUpdatedAtUs = row.read<int?>('updated_at_us');
+        final createdAtUs = rawCreatedAtUs ?? rawUpdatedAtUs ?? nowUs;
+        final updatedAtUs = rawUpdatedAtUs ?? createdAtUs;
+        final title = _repairPlaylistTitle(
+          id: id,
+          ownerAddress: ownerAddress,
+          typeValue: typeValue,
+          rawTitle: row.read<String?>('title'),
+        );
+        final signatures = _repairPlaylistSignaturesJson(
+          row.read<String?>('signatures'),
+        );
+        final sortMode = _repairPlaylistSortModeValue(
+          rawSortMode: row.read<int?>('sort_mode'),
+          typeValue: typeValue,
+        );
+        final itemCount = _repairPlaylistItemCount(
+          row.read<int?>('item_count'),
+        );
+
+        await customStatement(
+          '''
+          UPDATE playlists
+          SET channel_id = ?,
+              type = ?,
+              title = ?,
+              created_at_us = ?,
+              updated_at_us = ?,
+              signatures = ?,
+              sort_mode = ?,
+              item_count = ?
+          WHERE id = ?
+          ''',
+          <Object?>[
+            channelId,
+            typeValue,
+            title,
+            createdAtUs,
+            updatedAtUs,
+            signatures,
+            sortMode,
+            itemCount,
+            id,
+          ],
+        );
+      }
+    });
+
+    _log.warning(
+      'Repaired ${rows.length} malformed playlist row(s) before startup reads',
+    );
+  }
+
+  int _repairPlaylistTypeValue({
+    required String id,
+    required String? ownerAddress,
+    required int? rawType,
+  }) {
+    if (rawType != null && PlaylistType.values.any((t) => t.value == rawType)) {
+      return rawType;
+    }
+    if (id == Playlist.favoriteId) {
+      return PlaylistType.favorite.value;
+    }
+    if (ownerAddress != null && ownerAddress.trim().isNotEmpty) {
+      return PlaylistType.addressBased.value;
+    }
+    return PlaylistType.dp1.value;
+  }
+
+  String? _repairPlaylistChannelId({
+    required String id,
+    required String? rawChannelId,
+  }) {
+    if (id == Playlist.favoriteId) {
+      return Channel.myCollectionId;
+    }
+    return rawChannelId;
+  }
+
+  String _repairPlaylistTitle({
+    required String id,
+    required String? ownerAddress,
+    required int typeValue,
+    required String? rawTitle,
+  }) {
+    final trimmedTitle = rawTitle?.trim();
+    if (trimmedTitle != null && trimmedTitle.isNotEmpty) {
+      return trimmedTitle;
+    }
+    if (id == Playlist.favoriteId) {
+      return 'Favorites';
+    }
+    if (typeValue == PlaylistType.addressBased.value &&
+        ownerAddress != null &&
+        ownerAddress.trim().isNotEmpty) {
+      return ownerAddress.trim();
+    }
+    return id;
+  }
+
+  String _repairPlaylistSignaturesJson(String? rawSignatures) {
+    final trimmed = rawSignatures?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return '[]';
+    }
+    return trimmed;
+  }
+
+  int _repairPlaylistSortModeValue({
+    required int? rawSortMode,
+    required int typeValue,
+  }) {
+    if (rawSortMode != null &&
+        PlaylistSortMode.values.any((m) => m.index == rawSortMode)) {
+      return rawSortMode;
+    }
+    switch (typeValue) {
+      case 1:
+      case 2:
+        return PlaylistSortMode.provenance.index;
+      case 0:
+      default:
+        return PlaylistSortMode.position.index;
+    }
+  }
+
+  int _repairPlaylistItemCount(int? rawItemCount) {
+    if (rawItemCount == null || rawItemCount < 0) {
+      return 0;
+    }
+    return rawItemCount;
   }
 
   /// Creates performance indexes.

--- a/test/unit/infra/database/app_database_playlist_repair_test.dart
+++ b/test/unit/infra/database/app_database_playlist_repair_test.dart
@@ -1,0 +1,269 @@
+import 'dart:io';
+
+import 'package:app/domain/models/channel.dart';
+import 'package:app/domain/models/playlist.dart';
+import 'package:app/infra/database/app_database.dart';
+import 'package:app/infra/database/database_service.dart';
+import 'package:app/infra/services/bootstrap_service.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+void main() {
+  group('AppDatabase malformed playlist repair', () {
+    test('repairs malformed favorite row before bootstrap reads it', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'ff_playlist_repair_',
+      );
+      final dbFile = File(p.join(tempDir.path, 'favorite-malformed.sqlite'));
+
+      try {
+        _createMalformedPlaylistDatabase(
+          file: dbFile,
+          rows: const [
+            _RawPlaylistRow(
+              id: Playlist.favoriteId,
+              title: null,
+              type: null,
+              createdAtUs: null,
+              updatedAtUs: null,
+              signatures: null,
+              sortMode: null,
+              itemCount: null,
+            ),
+          ],
+        );
+
+        final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+        final service = DatabaseService(db);
+
+        try {
+          await BootstrapService(databaseService: service).bootstrap();
+
+          final favorite = await service.getPlaylistById(Playlist.favoriteId);
+          expect(favorite, isNotNull);
+          expect(favorite!.name, 'Favorites');
+          expect(favorite.type, PlaylistType.favorite);
+          expect(favorite.sortMode, PlaylistSortMode.provenance);
+          expect(favorite.itemCount, 0);
+          expect(favorite.channelId, Channel.myCollectionId);
+        } finally {
+          await db.close();
+        }
+      } finally {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test(
+      'repairs malformed address playlists before list queries map rows',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(p.join(tempDir.path, 'address-malformed.sqlite'));
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_addr',
+                ownerAddress: '0xABCDEF',
+                title: null,
+                type: 9,
+                createdAtUs: null,
+                updatedAtUs: 55,
+                signatures: '',
+                sortMode: 99,
+                itemCount: -4,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_addr');
+            expect(playlists.single.name, '0xABCDEF');
+            expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.sortMode, PlaylistSortMode.provenance);
+            expect(playlists.single.itemCount, 0);
+            expect(playlists.single.createdAt!.microsecondsSinceEpoch, 55);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+  });
+}
+
+class _RawPlaylistRow {
+  const _RawPlaylistRow({
+    required this.id,
+    this.channelId,
+    this.type,
+    this.baseUrl,
+    this.dpVersion,
+    this.slug,
+    this.title,
+    this.createdAtUs,
+    this.updatedAtUs,
+    this.signature,
+    this.signatures,
+    this.defaultsJson,
+    this.dynamicQueriesJson,
+    this.ownerAddress,
+    this.ownerChain,
+    this.sortMode,
+    this.itemCount,
+  });
+
+  final String id;
+  final String? channelId;
+  final int? type;
+  final String? baseUrl;
+  final String? dpVersion;
+  final String? slug;
+  final String? title;
+  final int? createdAtUs;
+  final int? updatedAtUs;
+  final String? signature;
+  final String? signatures;
+  final String? defaultsJson;
+  final String? dynamicQueriesJson;
+  final String? ownerAddress;
+  final String? ownerChain;
+  final int? sortMode;
+  final int? itemCount;
+}
+
+void _createMalformedPlaylistDatabase({
+  required File file,
+  required List<_RawPlaylistRow> rows,
+}) {
+  final db = sqlite3.sqlite3.open(file.path);
+  try {
+    db.execute('PRAGMA foreign_keys = ON;');
+    db.execute('PRAGMA user_version = 3;');
+
+    db.execute('''
+      CREATE TABLE publishers (
+        id INTEGER PRIMARY KEY,
+        title TEXT NOT NULL,
+        created_at_us INTEGER NOT NULL,
+        updated_at_us INTEGER NOT NULL
+      )
+    ''');
+
+    db.execute('''
+      CREATE TABLE channels (
+        id TEXT PRIMARY KEY,
+        type INTEGER NOT NULL,
+        base_url TEXT,
+        slug TEXT,
+        publisher_id INTEGER,
+        title TEXT NOT NULL,
+        curator TEXT,
+        summary TEXT,
+        cover_image_uri TEXT,
+        created_at_us INTEGER NOT NULL,
+        updated_at_us INTEGER NOT NULL,
+        sort_order INTEGER
+      )
+    ''');
+
+    db.execute('''
+      CREATE TABLE playlists (
+        id TEXT PRIMARY KEY,
+        channel_id TEXT,
+        type INTEGER,
+        base_url TEXT,
+        dp_version TEXT,
+        slug TEXT,
+        title TEXT,
+        created_at_us INTEGER,
+        updated_at_us INTEGER,
+        signature TEXT,
+        signatures TEXT,
+        defaults_json TEXT,
+        dynamic_queries_json TEXT,
+        owner_address TEXT,
+        owner_chain TEXT,
+        sort_mode INTEGER,
+        item_count INTEGER
+      )
+    ''');
+
+    db.execute('''
+      CREATE TABLE items (
+        id TEXT PRIMARY KEY,
+        kind INTEGER NOT NULL,
+        title TEXT,
+        thumbnail_uri TEXT,
+        duration_sec INTEGER,
+        provenance_json TEXT,
+        source_uri TEXT,
+        ref_uri TEXT,
+        license TEXT,
+        repro_json TEXT,
+        override_json TEXT,
+        display_json TEXT,
+        list_artist_json TEXT,
+        enrichment_status INTEGER NOT NULL DEFAULT 0,
+        updated_at_us INTEGER NOT NULL
+      )
+    ''');
+
+    db.execute('''
+      CREATE TABLE playlist_entries (
+        playlist_id TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        position INTEGER,
+        sort_key_us INTEGER NOT NULL,
+        updated_at_us INTEGER NOT NULL
+      )
+    ''');
+
+    for (final row in rows) {
+      db.execute(
+        '''
+        INSERT INTO playlists (
+          id, channel_id, type, base_url, dp_version, slug, title,
+          created_at_us, updated_at_us, signature, signatures,
+          defaults_json, dynamic_queries_json, owner_address, owner_chain,
+          sort_mode, item_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''',
+        <Object?>[
+          row.id,
+          row.channelId,
+          row.type,
+          row.baseUrl,
+          row.dpVersion,
+          row.slug,
+          row.title,
+          row.createdAtUs,
+          row.updatedAtUs,
+          row.signature,
+          row.signatures,
+          row.defaultsJson,
+          row.dynamicQueriesJson,
+          row.ownerAddress,
+          row.ownerChain,
+          row.sortMode,
+          row.itemCount,
+        ],
+      );
+    }
+  } finally {
+    db.dispose();
+  }
+}


### PR DESCRIPTION
## Problem
A malformed local `playlists` row can still crash startup bootstrap and playlist list/watch queries before the app reaches any domain-level fallback. Drift force-unwraps required playlist columns, so one bad row can take down `/` during `_ensureFavoritePlaylists` and poison later playlist loads.

## Why It Matters
This is an offline-first app, so a partially migrated or copied local DB should be repaired and kept readable instead of hard-failing bootstrap. A single damaged playlist row should not block home load, favorites bootstrap, or Me/playlist provider reads.

## Acceptance Checks
- Startup bootstrap no longer crashes when the local DB contains a malformed favorite playlist row.
- Playlist list queries recover malformed playlist rows on DB open instead of throwing during Drift mapping.
- Regression coverage proves malformed favorite and address-based playlist rows become readable again.

Closes #354