### PR TITLE
fix(ff1): debounce inactive relayer pause and serialize reconnect

### DIFF
--- a/docs/app_flows.md
+++ b/docs/app_flows.md
@@ -37,6 +37,18 @@
 - key screens involved: config error screen (fallback), Home, Onboarding
 - key modules/services involved: `lib/main.dart`, `lib/app/app.dart`, `seed_database_*`, `bootstrap_provider`, `legacy_data_migration_service`, `app_state_service`
 
+## Flow: App lifecycle and FF1 relayer Wi‑Fi
+
+- goal: pause the FF1 relayer WebSocket when the app is not active, without tearing it down on every transient `inactive`, and restore it after real backgrounding
+- start point: `AppLifecycleNotifier` (`app_lifecycle_provider.dart`) handling `WidgetsBindingObserver` lifecycle updates
+- steps:
+  - `inactive`: schedule a debounced relayer pause; `resumed` cancels only the pending timer (no reconnect if the relayer was never paused)
+  - `paused` / `hidden` / `detached`: cancel any debounce and pause relayer Wi‑Fi immediately
+  - `resumed`: resume indexer token sync; call `FF1WifiConnectionNotifier.reconnect` only when lifecycle actually paused the relayer in this cycle (immediate pause or debounced inactive pause)
+- success state: relayer socket matches whether the app backgrounded; short inactive-only flicker does not force reconnect
+- failure/edge states: reconnect failures are logged; connection notifier clears stale connecting flags when pause races with an in-flight connect
+- key modules: `app_lifecycle_provider.dart`, `inactive_wifi_pause_schedule.dart`, `ff1_wifi_providers.dart` (`FF1WifiConnectionNotifier`)
+
 ## Flow: Onboarding (No Deeplink)
 
 - goal: orient new users and optionally set up personal collection + FF1

--- a/docs/app_flows.md
+++ b/docs/app_flows.md
@@ -214,7 +214,7 @@
 - route / entry point: `/add-address`
 - important actions: submit input, scan QR, continue to alias or complete
 - dependencies: `addAddressFlowProvider`, `scanQrProvider`, address/domain services
-- notes / caveats: duplicate and invalid-input errors are explicit and distinct
+- notes / caveats: duplicate and invalid-input errors are explicit and distinct; focus and post-frame work use `scheduleRequestFocusWhenLaidOut` / `schedulePostFrameIfMounted` so navigation after layout does not assert on disposed `BuildContext`
 
 ## Screen: AddAliasScreen
 
@@ -222,7 +222,7 @@
 - route / entry point: `/add-alias` (requires payload)
 - important actions: submit alias or skip
 - dependencies: `addAliasProvider`, `addressService`
-- notes / caveats: successful completion pops both alias and add-address routes
+- notes / caveats: successful completion pops both alias and add-address routes; same deferred focus / post-frame helpers as Add Address when requesting focus after route transitions
 
 ## Screen: PlaylistDetailScreen
 

--- a/docs/app_flows.md
+++ b/docs/app_flows.md
@@ -45,6 +45,7 @@
   - `inactive`: schedule a debounced relayer pause; `resumed` cancels only the pending timer (no reconnect if the relayer was never paused)
   - `paused` / `hidden` / `detached`: cancel any debounce and pause relayer Wi‑Fi immediately
   - `resumed`: resume indexer token sync; call `FF1WifiConnectionNotifier.reconnect` only when lifecycle actually paused the relayer in this cycle (immediate pause or debounced inactive pause)
+  - the first successful relayer session for a device triggers the required-device-version check, including the later resume reconnect path after a suppressed initial connect
 - success state: relayer socket matches whether the app backgrounded; short inactive-only flicker does not force reconnect
 - failure/edge states: reconnect failures are logged; connection notifier clears stale connecting flags when pause races with an in-flight connect
 - key modules: `app_lifecycle_provider.dart`, `inactive_wifi_pause_schedule.dart`, `ff1_wifi_providers.dart` (`FF1WifiConnectionNotifier`)

--- a/docs/project_spec.md
+++ b/docs/project_spec.md
@@ -59,6 +59,15 @@
     on-disk DB; gate completion follows normal sync outcome (see seed services).
   - legacy data exists: onboarding is marked seen and migration runs in background
 
+### Flow: FF1 relayer Wi‑Fi and app lifecycle
+
+- Trigger: OS lifecycle transitions (`inactive`, `paused`, `hidden`, `detached`, `resumed`).
+- Key steps:
+  - `inactive` is debounced before closing the relayer WebSocket; very short inactive-only transitions (for example system overlays) do not pause the relayer.
+  - `paused`, `hidden`, and `detached` pause relayer Wi‑Fi immediately.
+  - On `resumed`, a forced relayer reconnect runs only when the relayer was paused during this background or foreground cycle; otherwise the existing session is left as-is to avoid unnecessary socket churn.
+- Outcome: the relayer stays connected when the app never truly backgrounded; after real backgrounding, the app restores relayer connectivity on resume.
+
 ### Flow: Onboarding and first-use setup
 
 - Trigger: user without onboarding completion (or forced reset path).

--- a/docs/project_spec.md
+++ b/docs/project_spec.md
@@ -66,6 +66,7 @@
   - `inactive` is debounced before closing the relayer WebSocket; very short inactive-only transitions (for example system overlays) do not pause the relayer.
   - `paused`, `hidden`, and `detached` pause relayer Wi‑Fi immediately.
   - On `resumed`, a forced relayer reconnect runs only when the relayer was paused during this background or foreground cycle; otherwise the existing session is left as-is to avoid unnecessary socket churn.
+  - The required-device-version gate is scheduled on the first successful relayer session for a device, including the resume reconnect path after a suppressed initial connect.
 - Outcome: the relayer stays connected when the app never truly backgrounded; after real backgrounding, the app restores relayer connectivity on resume.
 
 ### Flow: Onboarding and first-use setup

--- a/lib/app/lifecycle/inactive_wifi_pause_schedule.dart
+++ b/lib/app/lifecycle/inactive_wifi_pause_schedule.dart
@@ -74,9 +74,11 @@ class InactiveRelayerWifiPauseCoordinator {
     switch (action) {
       case WifiPauseDebouncerAction.cancelTimerOnly:
         _cancelPendingTimer(reason: 'lifecycle_${state.name}');
+        return;
       case WifiPauseDebouncerAction.cancelTimerAndPauseWifiNow:
         _cancelPendingTimer(reason: 'lifecycle_${state.name}_immediate_pause');
         pauseRelayerWifi();
+        return;
       case WifiPauseDebouncerAction.scheduleInactiveTimerIfNone:
         if (_timer != null) {
           structuredLog.info(
@@ -119,6 +121,7 @@ class InactiveRelayerWifiPauseCoordinator {
           );
           pauseRelayerWifi();
         });
+        return;
     }
   }
 

--- a/lib/app/lifecycle/inactive_wifi_pause_schedule.dart
+++ b/lib/app/lifecycle/inactive_wifi_pause_schedule.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+
+import 'package:app/infra/logging/structured_logger.dart';
+import 'package:flutter/widgets.dart';
+
+/// Debounce duration for [AppLifecycleState.inactive] before pausing the FF1
+/// relayer Wi‑Fi session. iOS emits `inactive` for transient overlays (Control
+/// Center, notification shade), not only real backgrounding.
+const kInactiveRelayerWifiPauseDebounce = Duration(milliseconds: 350);
+
+/// What to do for relayer Wi‑Fi pause when the app lifecycle changes.
+enum WifiPauseDebouncerAction {
+  /// Cancel any pending inactive debounce timer only.
+  cancelTimerOnly,
+
+  /// Cancel timer and pause relayer Wi‑Fi immediately.
+  cancelTimerAndPauseWifiNow,
+
+  /// Start the inactive debounce timer if none is running.
+  scheduleInactiveTimerIfNone,
+}
+
+/// Maps lifecycle state to debouncer action (pure; easy to unit test).
+WifiPauseDebouncerAction wifiPauseDebouncerActionFor(AppLifecycleState state) {
+  switch (state) {
+    case AppLifecycleState.resumed:
+      return WifiPauseDebouncerAction.cancelTimerOnly;
+    case AppLifecycleState.inactive:
+      return WifiPauseDebouncerAction.scheduleInactiveTimerIfNone;
+    case AppLifecycleState.paused:
+    case AppLifecycleState.detached:
+    case AppLifecycleState.hidden:
+      return WifiPauseDebouncerAction.cancelTimerAndPauseWifiNow;
+  }
+}
+
+/// When the inactive debounce timer fires, run relayer pause only if the app
+/// is not back in the foreground. Primary guard: **never** pause from this
+/// timer while [AppLifecycleState.resumed].
+bool shouldRunDebouncedInactiveWifiPause(AppLifecycleState lifecycleNow) {
+  return lifecycleNow != AppLifecycleState.resumed;
+}
+
+/// Coordinates debounced relayer pause on `inactive` vs immediate pause on
+/// real background transitions.
+class InactiveRelayerWifiPauseCoordinator {
+  /// Creates a coordinator.
+  InactiveRelayerWifiPauseCoordinator({
+    required this.debounce,
+    required this.structuredLog,
+  });
+
+  /// Debounce length for [AppLifecycleState.inactive].
+  final Duration debounce;
+
+  /// Logger with `component: app_lifecycle` (or similar).
+  final StructuredLogger structuredLog;
+
+  Timer? _timer;
+
+  /// Clears any pending timer (e.g. on provider dispose).
+  void dispose() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  /// Handles one lifecycle transition for relayer Wi‑Fi pause policy.
+  void onLifecycle({
+    required AppLifecycleState state,
+    required AppLifecycleState Function() readLifecycle,
+    required void Function() pauseRelayerWifi,
+  }) {
+    final action = wifiPauseDebouncerActionFor(state);
+    switch (action) {
+      case WifiPauseDebouncerAction.cancelTimerOnly:
+        _cancelPendingTimer(reason: 'lifecycle_${state.name}');
+      case WifiPauseDebouncerAction.cancelTimerAndPauseWifiNow:
+        _cancelPendingTimer(reason: 'lifecycle_${state.name}_immediate_pause');
+        pauseRelayerWifi();
+      case WifiPauseDebouncerAction.scheduleInactiveTimerIfNone:
+        if (_timer != null) {
+          structuredLog.info(
+            category: LogCategory.wifi,
+            event: 'inactive_wifi_pause_debounce_ignored_duplicate',
+            message:
+                'inactive received while debounce timer already pending — '
+                'not rescheduling',
+            payload: {'lifecycleState': state.name},
+          );
+          return;
+        }
+        structuredLog.info(
+          category: LogCategory.wifi,
+          event: 'inactive_wifi_pause_debounce_scheduled',
+          message: 'scheduling debounced relayer pause for inactive',
+          payload: {
+            'lifecycleState': state.name,
+            'debounceMs': debounce.inMilliseconds,
+          },
+        );
+        _timer = Timer(debounce, () {
+          _timer = null;
+          final now = readLifecycle();
+          if (!shouldRunDebouncedInactiveWifiPause(now)) {
+            structuredLog.info(
+              category: LogCategory.wifi,
+              event: 'inactive_wifi_pause_debounce_fire_skipped',
+              message:
+                  'debounced inactive pause skipped — app is foreground again',
+              payload: {'lifecycleStateNow': now.name},
+            );
+            return;
+          }
+          structuredLog.info(
+            category: LogCategory.wifi,
+            event: 'inactive_wifi_pause_debounce_fired',
+            message: 'debounced inactive pause firing — pausing relayer Wi‑Fi',
+            payload: {'lifecycleStateNow': now.name},
+          );
+          pauseRelayerWifi();
+        });
+    }
+  }
+
+  void _cancelPendingTimer({required String reason}) {
+    if (_timer == null) {
+      return;
+    }
+    _timer!.cancel();
+    _timer = null;
+    structuredLog.info(
+      category: LogCategory.wifi,
+      event: 'inactive_wifi_pause_debounce_canceled',
+      message: 'canceled debounced inactive relayer pause',
+      payload: {'reason': reason},
+    );
+  }
+}

--- a/lib/app/providers/app_lifecycle_provider.dart
+++ b/lib/app/providers/app_lifecycle_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:app/app/lifecycle/inactive_wifi_pause_schedule.dart';
 import 'package:app/app/providers/ff1_wifi_providers.dart';
 import 'package:app/app/providers/indexer_tokens_provider.dart';
 import 'package:app/infra/logging/structured_logger.dart';
@@ -17,6 +18,7 @@ class AppLifecycleNotifier extends Notifier<AppLifecycleState> {
   late final Logger _log;
   late final StructuredLogger _slog;
   late final _Observer _observer;
+  late final InactiveRelayerWifiPauseCoordinator _inactiveRelayerWifiPause;
 
   @override
   AppLifecycleState build() {
@@ -25,10 +27,15 @@ class AppLifecycleNotifier extends Notifier<AppLifecycleState> {
       _log,
       context: {'component': 'app_lifecycle'},
     );
+    _inactiveRelayerWifiPause = InactiveRelayerWifiPauseCoordinator(
+      debounce: kInactiveRelayerWifiPauseDebounce,
+      structuredLog: _slog,
+    );
     _observer = _Observer(_onLifecycleChanged);
     WidgetsBinding.instance.addObserver(_observer);
 
     ref.onDispose(() {
+      _inactiveRelayerWifiPause.dispose();
       WidgetsBinding.instance.removeObserver(_observer);
     });
 
@@ -53,6 +60,11 @@ class AppLifecycleNotifier extends Notifier<AppLifecycleState> {
     final deviceId = wifiConnectionState.device?.deviceId;
 
     if (state == AppLifecycleState.resumed) {
+      _inactiveRelayerWifiPause.onLifecycle(
+        state: state,
+        readLifecycle: () => this.state,
+        pauseRelayerWifi: wifiConnectionNotifier.pauseConnection,
+      );
       unawaited(coordinator.syncAllTrackedAddresses());
       coordinator.startSyncCollectionPolling();
       // Reconnect relayer WebSocket when app resumes; Timer-based reconnect
@@ -70,18 +82,13 @@ class AppLifecycleNotifier extends Notifier<AppLifecycleState> {
         },
       );
       unawaited(_reconnectRelayerAfterResume(wifiConnectionNotifier, deviceId));
-    } else if (state == AppLifecycleState.paused ||
-        state == AppLifecycleState.inactive ||
-        state == AppLifecycleState.detached) {
+    } else {
       coordinator.pauseSyncCollectionPolling();
-      // Pause relayer WebSocket to free resources; reconnect on resume.
-      // Note: `inactive` fires frequently on iOS (notification shade, control
-      // centre) so it also triggers pause/resume cycles — tracked as
-      // lifecycle_paused events to help diagnose false "Device not connected".
       _slog.info(
         category: LogCategory.wifi,
-        event: 'lifecycle_paused',
-        message: 'app lifecycle: $state — pausing relayer connection',
+        event: 'lifecycle_background',
+        message: 'app not resumed — pausing token sync; '
+            'relayer Wi‑Fi debounced on inactive only',
         payload: {
           'previousLifecycleState': previous.name,
           'lifecycleState': state.name,
@@ -90,7 +97,22 @@ class AppLifecycleNotifier extends Notifier<AppLifecycleState> {
           'deviceId': deviceId,
         },
       );
-      wifiConnectionNotifier.pauseConnection();
+      _inactiveRelayerWifiPause.onLifecycle(
+        state: state,
+        readLifecycle: () => this.state,
+        pauseRelayerWifi: () {
+          _slog.info(
+            category: LogCategory.wifi,
+            event: 'lifecycle_immediate_relayer_pause',
+            message: 'pausing relayer Wi‑Fi (non-inactive or debounce fired)',
+            payload: {
+              'lifecycleState': this.state.name,
+              'deviceId': deviceId,
+            },
+          );
+          wifiConnectionNotifier.pauseConnection();
+        },
+      );
     }
   }
 

--- a/lib/app/providers/app_lifecycle_provider.dart
+++ b/lib/app/providers/app_lifecycle_provider.dart
@@ -20,6 +20,11 @@ class AppLifecycleNotifier extends Notifier<AppLifecycleState> {
   late final _Observer _observer;
   late final InactiveRelayerWifiPauseCoordinator _inactiveRelayerWifiPause;
 
+  /// Set when `FF1WifiConnectionNotifier.pauseConnection` runs from lifecycle
+  /// (immediate pause or debounced inactive). Used so `resumed` does not force
+  /// a relayer reconnect after a no-op inactive→resumed flicker.
+  bool _relayerPausedByLifecycleSinceLastResume = false;
+
   @override
   AppLifecycleState build() {
     _log = Logger('AppLifecycleNotifier');
@@ -67,21 +72,42 @@ class AppLifecycleNotifier extends Notifier<AppLifecycleState> {
       );
       unawaited(coordinator.syncAllTrackedAddresses());
       coordinator.startSyncCollectionPolling();
-      // Reconnect relayer WebSocket when app resumes; Timer-based reconnect
-      // does not fire while app is suspended.
-      _slog.info(
-        category: LogCategory.wifi,
-        event: 'lifecycle_resumed',
-        message: 'app resumed — triggering relayer reconnect',
-        payload: {
-          'previousLifecycleState': previous.name,
-          'lifecycleState': state.name,
-          'wifiStateConnected': wifiConnectionState.isConnected,
-          'wifiStateConnecting': wifiConnectionState.isConnecting,
-          'deviceId': deviceId,
-        },
-      );
-      unawaited(_reconnectRelayerAfterResume(wifiConnectionNotifier, deviceId));
+
+      final shouldReconnectRelayer = _relayerPausedByLifecycleSinceLastResume;
+      _relayerPausedByLifecycleSinceLastResume = false;
+
+      if (shouldReconnectRelayer) {
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'lifecycle_resumed',
+          message:
+              'app resumed after relayer pause — triggering relayer reconnect',
+          payload: {
+            'previousLifecycleState': previous.name,
+            'lifecycleState': state.name,
+            'wifiStateConnected': wifiConnectionState.isConnected,
+            'wifiStateConnecting': wifiConnectionState.isConnecting,
+            'deviceId': deviceId,
+          },
+        );
+        unawaited(
+          _reconnectRelayerAfterResume(wifiConnectionNotifier, deviceId),
+        );
+      } else {
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'lifecycle_resumed_skip_relayer_reconnect',
+          message: 'app resumed without lifecycle relayer pause — '
+              'skipping forced reconnect',
+          payload: {
+            'previousLifecycleState': previous.name,
+            'lifecycleState': state.name,
+            'wifiStateConnected': wifiConnectionState.isConnected,
+            'wifiStateConnecting': wifiConnectionState.isConnecting,
+            'deviceId': deviceId,
+          },
+        );
+      }
     } else {
       coordinator.pauseSyncCollectionPolling();
       _slog.info(
@@ -101,6 +127,7 @@ class AppLifecycleNotifier extends Notifier<AppLifecycleState> {
         state: state,
         readLifecycle: () => this.state,
         pauseRelayerWifi: () {
+          _relayerPausedByLifecycleSinceLastResume = true;
           _slog.info(
             category: LogCategory.wifi,
             event: 'lifecycle_immediate_relayer_pause',

--- a/lib/app/providers/ff1_wifi_providers.dart
+++ b/lib/app/providers/ff1_wifi_providers.dart
@@ -195,7 +195,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
     _connectingEpoch = epoch;
 
     try {
-      await _control.connect(
+      final ok = await _control.connect(
         device: device,
         userId: userId,
         apiKey: apiKey,
@@ -206,6 +206,22 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
           category: LogCategory.wifi,
           event: 'connection_notifier_connect_canceled',
           message: 'connect completed after a newer connection request',
+          payload: {'deviceId': device.deviceId, 'topicId': device.topicId},
+        );
+        return;
+      }
+
+      if (!ok) {
+        state = state.copyWith(
+          isConnected: false,
+          isConnecting: false,
+          device: device,
+        );
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'connection_notifier_connect_not_applied',
+          message:
+              'connect did not dispatch (suppressed or superseded at transport)',
           payload: {'deviceId': device.deviceId, 'topicId': device.topicId},
         );
         return;
@@ -788,11 +804,16 @@ final ff1WifiConnectOperationProvider = FutureProvider.autoDispose
       (ref, params) async {
         final control = ref.watch(ff1WifiControlProvider);
 
-        await control.connect(
+        final ok = await control.connect(
           device: params.device,
           userId: params.userId,
           apiKey: params.apiKey,
         );
+        if (!ok) {
+          throw StateError(
+            'FF1 Wi-Fi connect did not dispatch to the relayer (suppressed).',
+          );
+        }
       },
     );
 

--- a/lib/app/providers/ff1_wifi_providers.dart
+++ b/lib/app/providers/ff1_wifi_providers.dart
@@ -148,6 +148,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
   FF1WifiControl get _control => ref.read(ff1WifiControlProvider);
   late final StructuredLogger _slog;
   int _connectEpoch = 0;
+  int? _connectingEpoch;
 
   @override
   FF1WifiConnectionState build() {
@@ -191,6 +192,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
     }
 
     state = state.copyWith(device: device, isConnecting: true);
+    _connectingEpoch = epoch;
 
     try {
       await _control.connect(
@@ -248,7 +250,11 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
       );
       rethrow;
     } finally {
-      if (epoch == _connectEpoch && state.isConnecting) {
+      // Only the connect attempt that still owns the spinner may clear it.
+      // Pause/disconnect already clear `isConnecting`, while a newer connect
+      // must keep the UI in "connecting" until that replacement attempt ends.
+      if (_connectingEpoch == epoch && state.isConnecting) {
+        _connectingEpoch = null;
         state = state.copyWith(isConnecting: false);
       }
     }
@@ -262,6 +268,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
   /// reconnect() on resume would use the stale cached device.
   Future<void> disconnect() async {
     _connectEpoch++;
+    _connectingEpoch = null;
     _slog.info(
       category: LogCategory.wifi,
       event: 'connection_notifier_disconnect_requested',
@@ -294,6 +301,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
   /// Closes WebSocket but preserves [state.device] for [reconnect] on resume.
   void pauseConnection() {
     _connectEpoch++;
+    _connectingEpoch = null;
     _slog.info(
       category: LogCategory.wifi,
       event: 'connection_notifier_pause_requested',
@@ -305,7 +313,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
       },
     );
     _control.pauseConnection();
-    state = state.copyWith(isConnected: false);
+    state = state.copyWith(isConnected: false, isConnecting: false);
     _slog.info(
       category: LogCategory.wifi,
       event: 'connection_notifier_pause_completed',
@@ -319,9 +327,10 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
 
   /// Reconnect to device (using cached params)
   ///
-  /// Does not set [isConnecting]; "Connecting" status is shown only for
-  /// initial connect, not for background reconnects (app resume, etc.).
+  /// Does not set [isConnecting] to true; "Connecting" is reserved for the
+  /// initial [connect] path, not background reconnects (app resume, etc.).
   Future<void> reconnect() async {
+    _connectingEpoch = null;
     _slog.info(
       category: LogCategory.wifi,
       event: 'connection_notifier_reconnect_requested',
@@ -356,7 +365,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
       }
 
       if (!ok) {
-        state = state.copyWith(isConnected: false);
+        state = state.copyWith(isConnected: false, isConnecting: false);
         _slog.info(
           category: LogCategory.wifi,
           event: 'connection_notifier_reconnect_not_applied',
@@ -367,7 +376,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
         return;
       }
 
-      state = state.copyWith(isConnected: true);
+      state = state.copyWith(isConnected: true, isConnecting: false);
       _slog.info(
         category: LogCategory.wifi,
         event: 'connection_notifier_reconnect_completed',
@@ -392,6 +401,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
       }
       state = state.copyWith(
         isConnected: false,
+        isConnecting: false,
         error: e,
       );
       _slog.warning(

--- a/lib/app/providers/ff1_wifi_providers.dart
+++ b/lib/app/providers/ff1_wifi_providers.dart
@@ -164,7 +164,11 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
   /// [device] - FF1 device with topicId
   /// [userId] - user identifier for authentication
   /// [apiKey] - API key for authentication
-  Future<void> connect({
+  ///
+  /// Returns `false` when the session was not established (superseded,
+  /// suppressed transport dispatch, etc.). Callers such as the auto-connect
+  /// watcher use this to avoid follow-up work (e.g. version checks).
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -188,7 +192,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
         message: 'connect skipped because notifier is already connected',
         payload: {'deviceId': device.deviceId, 'topicId': device.topicId},
       );
-      return;
+      return true;
     }
 
     state = state.copyWith(device: device, isConnecting: true);
@@ -208,7 +212,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
           message: 'connect completed after a newer connection request',
           payload: {'deviceId': device.deviceId, 'topicId': device.topicId},
         );
-        return;
+        return false;
       }
 
       if (!ok) {
@@ -224,7 +228,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
               'connect did not dispatch (suppressed or superseded at transport)',
           payload: {'deviceId': device.deviceId, 'topicId': device.topicId},
         );
-        return;
+        return false;
       }
 
       state = state.copyWith(
@@ -238,6 +242,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
         message: 'connect completed in notifier',
         payload: {'deviceId': device.deviceId, 'topicId': device.topicId},
       );
+      return true;
     } on Exception catch (e) {
       if (epoch != _connectEpoch) {
         _slog.info(
@@ -250,7 +255,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
             'error': e.toString(),
           },
         );
-        return;
+        return false;
       }
       state = state.copyWith(
         isConnected: false,
@@ -730,18 +735,20 @@ final ff1AutoConnectWatcherProvider = Provider<void>((ref) {
             logger.info(
               'Active device changed: ${device.toJson()}, connecting...',
             );
-            await connectionNotifier.connect(
+            final connectedOk = await connectionNotifier.connect(
               device: device,
               userId: 'user_id',
               apiKey: AppConfig.ff1RelayerApiKey,
             );
-            unawaited(
-              _scheduleRequiredDeviceVersionCheck(
-                ref: ref,
-                logger: logger,
-                device: device,
-              ),
-            );
+            if (connectedOk) {
+              unawaited(
+                _scheduleRequiredDeviceVersionCheck(
+                  ref: ref,
+                  logger: logger,
+                  device: device,
+                ),
+              );
+            }
           } else {
             logger.info('No active device, disconnecting...');
             await connectionNotifier.disconnect();
@@ -809,10 +816,10 @@ final ff1WifiConnectOperationProvider = FutureProvider.autoDispose
           userId: params.userId,
           apiKey: params.apiKey,
         );
+        // Suppressed/no-dispatch (e.g. lifecycle pause) is a controlled no-op,
+        // not a hard failure — avoid retry storms that would churn transport.
         if (!ok) {
-          throw StateError(
-            'FF1 Wi-Fi connect did not dispatch to the relayer (suppressed).',
-          );
+          return;
         }
       },
     );

--- a/lib/app/providers/ff1_wifi_providers.dart
+++ b/lib/app/providers/ff1_wifi_providers.dart
@@ -146,17 +146,49 @@ class FF1WifiConnectionState {
 /// Manages connection lifecycle and state for a single device.
 class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
   FF1WifiControl get _control => ref.read(ff1WifiControlProvider);
+  late final Logger _log;
   late final StructuredLogger _slog;
   int _connectEpoch = 0;
   int? _connectingEpoch;
+  String? _requiredDeviceVersionCheckCompletedForDeviceId;
+  String? _requiredDeviceVersionCheckInFlightForDeviceId;
 
   @override
   FF1WifiConnectionState build() {
+    _log = Logger('FF1WifiConnectionNotifier');
     _slog = AppStructuredLog.forLogger(
-      Logger('FF1WifiConnectionNotifier'),
+      _log,
       context: {'component': 'ff1_wifi_connection_notifier'},
     );
     return const FF1WifiConnectionState(isConnected: false);
+  }
+
+  void _scheduleRequiredDeviceVersionCheckIfNeeded(FF1Device device) {
+    if (_requiredDeviceVersionCheckCompletedForDeviceId == device.deviceId) {
+      return;
+    }
+    if (_requiredDeviceVersionCheckInFlightForDeviceId == device.deviceId) {
+      return;
+    }
+
+    // The first session that actually observes a version-bearing device
+    // status owns the required-version gate. If the session is paused before
+    // that status arrives, the gate must be allowed to re-arm on resume.
+    _requiredDeviceVersionCheckInFlightForDeviceId = device.deviceId;
+    unawaited(
+      _scheduleRequiredDeviceVersionCheck(
+        ref: ref,
+        logger: _log,
+        device: device,
+      ).then((completed) {
+        if (_requiredDeviceVersionCheckInFlightForDeviceId == device.deviceId) {
+          _requiredDeviceVersionCheckInFlightForDeviceId = null;
+        }
+        if (completed) {
+          _requiredDeviceVersionCheckCompletedForDeviceId = device.deviceId;
+        }
+      }),
+    );
   }
 
   /// Connect to device over WiFi
@@ -186,6 +218,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
       },
     );
     if (state.isConnected && state.device?.topicId == device.topicId) {
+      _scheduleRequiredDeviceVersionCheckIfNeeded(device);
       _slog.info(
         category: LogCategory.wifi,
         event: 'connection_notifier_connect_skipped',
@@ -193,6 +226,11 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
         payload: {'deviceId': device.deviceId, 'topicId': device.topicId},
       );
       return true;
+    }
+
+    if (state.device?.deviceId != device.deviceId) {
+      _requiredDeviceVersionCheckCompletedForDeviceId = null;
+      _requiredDeviceVersionCheckInFlightForDeviceId = null;
     }
 
     state = state.copyWith(device: device, isConnecting: true);
@@ -236,6 +274,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
         isConnecting: false,
         device: device,
       );
+      _scheduleRequiredDeviceVersionCheckIfNeeded(device);
       _slog.info(
         category: LogCategory.wifi,
         event: 'connection_notifier_connect_completed',
@@ -290,6 +329,8 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
   Future<void> disconnect() async {
     _connectEpoch++;
     _connectingEpoch = null;
+    _requiredDeviceVersionCheckCompletedForDeviceId = null;
+    _requiredDeviceVersionCheckInFlightForDeviceId = null;
     _slog.info(
       category: LogCategory.wifi,
       event: 'connection_notifier_disconnect_requested',
@@ -323,6 +364,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
   void pauseConnection() {
     _connectEpoch++;
     _connectingEpoch = null;
+    _requiredDeviceVersionCheckInFlightForDeviceId = null;
     _slog.info(
       category: LogCategory.wifi,
       event: 'connection_notifier_pause_requested',
@@ -398,6 +440,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
       }
 
       state = state.copyWith(isConnected: true, isConnecting: false);
+      _scheduleRequiredDeviceVersionCheckIfNeeded(state.device!);
       _slog.info(
         category: LogCategory.wifi,
         event: 'connection_notifier_reconnect_completed',
@@ -617,7 +660,7 @@ Future<void> _runRequiredDeviceVersionCheck({
       );
 }
 
-Future<void> _scheduleRequiredDeviceVersionCheck({
+Future<bool> _scheduleRequiredDeviceVersionCheck({
   required Ref ref,
   required Logger logger,
   required FF1Device device,
@@ -629,14 +672,14 @@ Future<void> _scheduleRequiredDeviceVersionCheck({
   // the future with null automatically on teardown / device switch.
   final deviceStatus = await control.freshDeviceVersionFuture();
   if (!ref.mounted) {
-    return;
+    return false;
   }
   if (deviceStatus == null) {
     logger.warning(
       'Skipping device version compatibility check: '
       'fresh device status unavailable for this session',
     );
-    return;
+    return false;
   }
   final activeDevice = ref
       .read(activeFF1BluetoothDeviceProvider)
@@ -650,7 +693,7 @@ Future<void> _scheduleRequiredDeviceVersionCheck({
       'Skipping device version compatibility check for '
       '${device.deviceId}: active device changed before status arrived',
     );
-    return;
+    return false;
   }
   try {
     await _runRequiredDeviceVersionCheck(
@@ -659,6 +702,7 @@ Future<void> _scheduleRequiredDeviceVersionCheck({
       device: device,
       deviceStatus: deviceStatus,
     );
+    return true;
   } on Object catch (error, stack) {
     logger.severe(
       'Failed required device version compatibility check for '
@@ -666,6 +710,7 @@ Future<void> _scheduleRequiredDeviceVersionCheck({
       error,
       stack,
     );
+    return false;
   }
 }
 
@@ -735,20 +780,11 @@ final ff1AutoConnectWatcherProvider = Provider<void>((ref) {
             logger.info(
               'Active device changed: ${device.toJson()}, connecting...',
             );
-            final connectedOk = await connectionNotifier.connect(
+            await connectionNotifier.connect(
               device: device,
               userId: 'user_id',
               apiKey: AppConfig.ff1RelayerApiKey,
             );
-            if (connectedOk) {
-              unawaited(
-                _scheduleRequiredDeviceVersionCheck(
-                  ref: ref,
-                  logger: logger,
-                  device: device,
-                ),
-              );
-            }
           } else {
             logger.info('No active device, disconnecting...');
             await connectionNotifier.disconnect();

--- a/lib/app/providers/ff1_wifi_providers.dart
+++ b/lib/app/providers/ff1_wifi_providers.dart
@@ -1,14 +1,7 @@
-// This provider file still contains legacy analyzer noise that is outside the
-// firmware-update flow; keep the ignore local so this PR can be gated on the
-// new prompt/update behavior instead of a broader cleanup pass.
-// ignore_for_file: implementation_imports, lines_longer_than_80_chars, comment_references, discarded_futures, unawaited_futures, public_member_api_docs, avoid_equals_and_hash_code_on_mutable_classes
+// This provider file still contains legacy analyzer noise outside narrow fixes.
+// ignore_for_file: lines_longer_than_80_chars, comment_references, public_member_api_docs, avoid_equals_and_hash_code_on_mutable_classes
 
 import 'dart:async';
-
-// This provider layer already carries lint debt unrelated to the stale-status
-// bug. The current change is intentionally narrow: keep live status aligned
-// with the current FF1 connection session without refactoring the whole file.
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes, cascade_invocations, comment_references, discarded_futures, implementation_imports, lines_longer_than_80_chars, public_member_api_docs, unawaited_futures
 
 import 'package:app/app/providers/ff1_bluetooth_device_providers.dart';
 import 'package:app/app/providers/version_provider.dart';
@@ -300,6 +293,7 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
   ///
   /// Closes WebSocket but preserves [state.device] for [reconnect] on resume.
   void pauseConnection() {
+    _connectEpoch++;
     _slog.info(
       category: LogCategory.wifi,
       event: 'connection_notifier_pause_requested',
@@ -347,8 +341,31 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
       return;
     }
 
+    final epoch = ++_connectEpoch;
     try {
-      await _control.reconnect();
+      final ok = await _control.reconnect();
+
+      if (epoch != _connectEpoch) {
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'connection_notifier_reconnect_canceled',
+          message: 'reconnect completed after a newer connection/pause request',
+          payload: {'deviceId': state.device?.deviceId},
+        );
+        return;
+      }
+
+      if (!ok) {
+        state = state.copyWith(isConnected: false);
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'connection_notifier_reconnect_not_applied',
+          message:
+              'reconnect did not apply (skipped, superseded, or transport error)',
+          payload: {'deviceId': state.device?.deviceId},
+        );
+        return;
+      }
 
       state = state.copyWith(isConnected: true);
       _slog.info(
@@ -361,6 +378,18 @@ class FF1WifiConnectionNotifier extends Notifier<FF1WifiConnectionState> {
         },
       );
     } on Exception catch (e) {
+      if (epoch != _connectEpoch) {
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'connection_notifier_reconnect_canceled_error',
+          message: 'reconnect failed after cancellation; ignoring stale error',
+          payload: {
+            'deviceId': state.device?.deviceId,
+            'error': e.toString(),
+          },
+        );
+        return;
+      }
       state = state.copyWith(
         isConnected: false,
         error: e,

--- a/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
+++ b/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
@@ -217,14 +217,17 @@ class FF1WifiControl {
         apiKey: apiKey,
       );
       if (connectOpGen != _wifiOpGeneration) {
+        // Do not call `_transport.pauseConnection()` here: a newer connect,
+        // reconnect, or pause already owns the transport. Pausing from this
+        // stale completion would tear down the winner's in-flight session.
         _slog.info(
           category: LogCategory.wifi,
           event: 'control_connect_superseded',
           message:
-              'connect completed after a newer Wi‑Fi operation — tearing down',
+              'connect completed after a newer Wi‑Fi operation — ignoring '
+              'stale result (no transport mutation)',
           payload: {'flowId': flowId, 'deviceId': device.deviceId},
         );
-        _transport.pauseConnection();
         return;
       }
       _slog.info(
@@ -649,11 +652,15 @@ class FF1WifiControl {
         forceReconnect: true,
       );
       if (opGen != _wifiOpGeneration) {
+        // Same rationale as [connect]: never pause transport from a stale
+        // completion — the newer operation (e.g. user connect, lifecycle pause)
+        // already decided transport fate.
         _slog.info(
           category: LogCategory.wifi,
           event: 'reconnect_superseded_after_await',
           message:
-              'reconnect completed after a newer Wi‑Fi operation — tearing down',
+              'reconnect completed after a newer Wi‑Fi operation — ignoring '
+              'stale result (no transport mutation)',
           payload: {
             'flowId': flowId,
             'deviceId': _device?.deviceId,
@@ -661,7 +668,6 @@ class FF1WifiControl {
             'currentGeneration': _wifiOpGeneration,
           },
         );
-        _transport.pauseConnection();
         return false;
       }
       _slog

--- a/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
+++ b/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
@@ -211,6 +211,9 @@ class FF1WifiControl {
 
     final connectOpGen = ++_wifiOpGeneration;
     try {
+      // Relayer: [FF1WifiTransport.connect] returns after dispatching to the
+      // isolate; superseding pause/disconnect is enforced in the relayer
+      // isolate (non-blocking connect handler), not only here (PR #361).
       await _transport.connect(
         device: device,
         userId: userId,

--- a/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
+++ b/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
@@ -266,7 +266,11 @@ class FF1WifiControl {
           event: 'control_connect_error_superseded',
           message:
               'connect failed after a newer Wi‑Fi operation — ignoring error',
-          payload: {'flowId': flowId, 'deviceId': device.deviceId, 'error': '$e'},
+          payload: {
+            'flowId': flowId,
+            'deviceId': device.deviceId,
+            'error': '$e',
+          },
         );
         return false;
       }
@@ -699,6 +703,13 @@ class FF1WifiControl {
         );
         return false;
       }
+
+      // Re-arm the session-scoped fresh-status waiters for the reconnecting
+      // session. Reconnect bypasses [connect], so it must recreate the futures
+      // that gate follow-up work like the required-version check.
+      _freshDeviceStatusCompleter = Completer<FF1DeviceStatus?>();
+      _freshDeviceVersionCompleter = Completer<FF1DeviceStatus?>();
+
       _slog
         ..info(
           category: LogCategory.wifi,

--- a/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
+++ b/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
@@ -140,7 +140,10 @@ class FF1WifiControl {
   /// [device] - FF1 device with topicId
   /// [userId] - user identifier for authentication
   /// [apiKey] - API key for authentication
-  Future<void> connect({
+  ///
+  /// Returns `false` when the transport did not dispatch a connect (suppressed
+  /// or superseded). Callers must not flip UI to connected on `false`.
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -214,7 +217,7 @@ class FF1WifiControl {
       // Relayer: [FF1WifiTransport.connect] returns after dispatching to the
       // isolate; superseding pause/disconnect is enforced in the relayer
       // isolate (non-blocking connect handler), not only here (PR #361).
-      await _transport.connect(
+      final dispatched = await _transport.connect(
         device: device,
         userId: userId,
         apiKey: apiKey,
@@ -231,7 +234,18 @@ class FF1WifiControl {
               'stale result (no transport mutation)',
           payload: {'flowId': flowId, 'deviceId': device.deviceId},
         );
-        return;
+        return false;
+      }
+      if (!dispatched) {
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'control_connect_transport_skipped',
+          message:
+              'transport connect returned without dispatch (e.g. suppressed '
+              'during isolate startup) — not treating as connected',
+          payload: {'flowId': flowId, 'deviceId': device.deviceId},
+        );
+        return false;
       }
       _slog.info(
         category: LogCategory.wifi,
@@ -244,6 +258,7 @@ class FF1WifiControl {
           'transportConnecting': _transport.isConnecting,
         },
       );
+      return true;
     } catch (e) {
       if (connectOpGen != _wifiOpGeneration) {
         _slog.info(
@@ -253,7 +268,7 @@ class FF1WifiControl {
               'connect failed after a newer Wi‑Fi operation — ignoring error',
           payload: {'flowId': flowId, 'deviceId': device.deviceId, 'error': '$e'},
         );
-        return;
+        return false;
       }
       _log.severe('Failed to connect: $e');
       _slog.warning(
@@ -648,7 +663,7 @@ class FF1WifiControl {
         message: 'calling transport.connect(forceReconnect: true)',
         payload: {'flowId': flowId, 'deviceId': _device?.deviceId},
       );
-      await _transport.connect(
+      final dispatched = await _transport.connect(
         device: _device!,
         userId: _userId!,
         apiKey: _apiKey!,
@@ -670,6 +685,17 @@ class FF1WifiControl {
             'expectedGeneration': opGen,
             'currentGeneration': _wifiOpGeneration,
           },
+        );
+        return false;
+      }
+      if (!dispatched) {
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'reconnect_transport_skipped',
+          message:
+              'transport reconnect returned without dispatch (e.g. suppressed '
+              'during isolate startup) — not treating as connected',
+          payload: {'flowId': flowId, 'deviceId': _device?.deviceId},
         );
         return false;
       }

--- a/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
+++ b/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
@@ -102,6 +102,10 @@ class FF1WifiControl {
   String? _apiKey;
   int _flowSequence = 0;
 
+  /// Invalidates in-flight connect/reconnect work after a newer pause,
+  /// disconnect, connect, or reconnect request.
+  int _wifiOpGeneration = 0;
+
   String _nextFlowId(String stage) => '$stage-${++_flowSequence}';
 
   /// Start listening to transport streams
@@ -205,12 +209,24 @@ class FF1WifiControl {
       },
     );
 
+    final connectOpGen = ++_wifiOpGeneration;
     try {
       await _transport.connect(
         device: device,
         userId: userId,
         apiKey: apiKey,
       );
+      if (connectOpGen != _wifiOpGeneration) {
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'control_connect_superseded',
+          message:
+              'connect completed after a newer Wi‑Fi operation — tearing down',
+          payload: {'flowId': flowId, 'deviceId': device.deviceId},
+        );
+        _transport.pauseConnection();
+        return;
+      }
       _slog.info(
         category: LogCategory.wifi,
         event: 'control_connect_dispatched',
@@ -223,6 +239,16 @@ class FF1WifiControl {
         },
       );
     } catch (e) {
+      if (connectOpGen != _wifiOpGeneration) {
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'control_connect_error_superseded',
+          message:
+              'connect failed after a newer Wi‑Fi operation — ignoring error',
+          payload: {'flowId': flowId, 'deviceId': device.deviceId, 'error': '$e'},
+        );
+        return;
+      }
       _log.severe('Failed to connect: $e');
       _slog.warning(
         category: LogCategory.wifi,
@@ -254,6 +280,7 @@ class FF1WifiControl {
   /// Disconnect from device
   Future<void> disconnect() async {
     final flowId = _nextFlowId('disconnect');
+    _wifiOpGeneration++;
     _log.info('Disconnecting');
     _slog.info(
       category: LogCategory.wifi,
@@ -575,7 +602,11 @@ class FF1WifiControl {
   /// Uses the `forceReconnect` flag to bypass the "already connected" check
   /// when the connection may be stale (e.g. the app was suspended and the
   /// timer-based reconnect did not fire).
-  Future<void> reconnect() async {
+  ///
+  /// Returns `false` if reconnect was skipped, superseded by a newer
+  /// operation, or failed after supersession (caller must not treat as
+  /// connected).
+  Future<bool> reconnect() async {
     final flowId = _nextFlowId('reconnect');
     if (_device == null || _userId == null || _apiKey == null) {
       _log.warning('Cannot reconnect: no cached connection params');
@@ -585,8 +616,10 @@ class FF1WifiControl {
         message: 'cannot reconnect due to missing cached params',
         payload: {'flowId': flowId, 'deviceId': _device?.deviceId},
       );
-      return;
+      return false;
     }
+
+    final opGen = ++_wifiOpGeneration;
 
     _slog.info(
       category: LogCategory.wifi,
@@ -595,6 +628,7 @@ class FF1WifiControl {
       payload: {
         'flowId': flowId,
         'deviceId': _device!.deviceId,
+        'wifiOpGeneration': opGen,
         'isDeviceConnected': _isDeviceConnected,
         'isTransportConnected': _transport.isConnected,
         'isTransportConnecting': _transport.isConnecting,
@@ -614,6 +648,22 @@ class FF1WifiControl {
         apiKey: _apiKey!,
         forceReconnect: true,
       );
+      if (opGen != _wifiOpGeneration) {
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'reconnect_superseded_after_await',
+          message:
+              'reconnect completed after a newer Wi‑Fi operation — tearing down',
+          payload: {
+            'flowId': flowId,
+            'deviceId': _device?.deviceId,
+            'expectedGeneration': opGen,
+            'currentGeneration': _wifiOpGeneration,
+          },
+        );
+        _transport.pauseConnection();
+        return false;
+      }
       _slog
         ..info(
           category: LogCategory.wifi,
@@ -637,7 +687,21 @@ transport reconnected — waiting for device connection notification''',
             'isDeviceConnected': _isDeviceConnected,
           },
         );
+      return true;
     } catch (e) {
+      if (opGen != _wifiOpGeneration) {
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'reconnect_failed_superseded',
+          message: 'reconnect failed after a newer Wi‑Fi operation — ignoring',
+          payload: {
+            'flowId': flowId,
+            'deviceId': _device?.deviceId,
+            'error': e.toString(),
+          },
+        );
+        return false;
+      }
       _slog.warning(
         category: LogCategory.wifi,
         event: 'reconnect_failed',
@@ -661,6 +725,7 @@ transport reconnected — waiting for device connection notification''',
       return;
     }
 
+    _wifiOpGeneration++;
     final flowId = _nextFlowId('pause');
     _slog.info(
       category: LogCategory.wifi,

--- a/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
+++ b/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
@@ -108,6 +108,16 @@ class FF1WifiControl {
 
   String _nextFlowId(String stage) => '$stage-${++_flowSequence}';
 
+  /// Arms the session-scoped waiters for the next fresh device-status update.
+  ///
+  /// Reconnect must do this before dispatching transport.connect(), because the
+  /// relayer can emit the first device status before the reconnect await
+  /// completes. Creating the futures afterward would miss that status.
+  void _resetFreshDeviceStatusWaiters() {
+    _freshDeviceStatusCompleter = Completer<FF1DeviceStatus?>();
+    _freshDeviceVersionCompleter = Completer<FF1DeviceStatus?>();
+  }
+
   /// Start listening to transport streams
   void _startListening() {
     // Listen to notification stream
@@ -191,8 +201,7 @@ class FF1WifiControl {
     _currentPlayerStatus = null;
     _currentDeviceStatus = null;
     _isDeviceConnected = false;
-    _freshDeviceStatusCompleter = Completer<FF1DeviceStatus?>();
-    _freshDeviceVersionCompleter = Completer<FF1DeviceStatus?>();
+    _resetFreshDeviceStatusWaiters();
     _connectionStatusController.add(
       const FF1ConnectionStatus(isConnected: false),
     );
@@ -645,6 +654,7 @@ class FF1WifiControl {
     }
 
     final opGen = ++_wifiOpGeneration;
+    _resetFreshDeviceStatusWaiters();
 
     _slog.info(
       category: LogCategory.wifi,
@@ -674,6 +684,10 @@ class FF1WifiControl {
         forceReconnect: true,
       );
       if (opGen != _wifiOpGeneration) {
+        _freshDeviceStatusCompleter?.complete(null);
+        _freshDeviceStatusCompleter = null;
+        _freshDeviceVersionCompleter?.complete(null);
+        _freshDeviceVersionCompleter = null;
         // Same rationale as [connect]: never pause transport from a stale
         // completion — the newer operation (e.g. user connect, lifecycle pause)
         // already decided transport fate.
@@ -693,6 +707,10 @@ class FF1WifiControl {
         return false;
       }
       if (!dispatched) {
+        _freshDeviceStatusCompleter?.complete(null);
+        _freshDeviceStatusCompleter = null;
+        _freshDeviceVersionCompleter?.complete(null);
+        _freshDeviceVersionCompleter = null;
         _slog.info(
           category: LogCategory.wifi,
           event: 'reconnect_transport_skipped',
@@ -703,12 +721,6 @@ class FF1WifiControl {
         );
         return false;
       }
-
-      // Re-arm the session-scoped fresh-status waiters for the reconnecting
-      // session. Reconnect bypasses [connect], so it must recreate the futures
-      // that gate follow-up work like the required-version check.
-      _freshDeviceStatusCompleter = Completer<FF1DeviceStatus?>();
-      _freshDeviceVersionCompleter = Completer<FF1DeviceStatus?>();
 
       _slog
         ..info(

--- a/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
+++ b/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
@@ -42,9 +42,10 @@ bool relayerDisconnectEventAppliesToSession({
     // Legacy events without generation: preserve previous apply-all behavior.
     return true;
   }
-  final pending = expectedConnectedGen != null &&
-      eventConnectGen == expectedConnectedGen;
-  final active = activeRelayerConnectGen != null &&
+  final pending =
+      expectedConnectedGen != null && eventConnectGen == expectedConnectedGen;
+  final active =
+      activeRelayerConnectGen != null &&
       eventConnectGen == activeRelayerConnectGen;
   return pending || active;
 }
@@ -199,14 +200,27 @@ class FF1RelayerTransport implements FF1WifiTransport {
     // review 4098243960).
     final teardownInFlight = _teardownCompleter;
     if (teardownInFlight != null) {
+      final pauseGenBeforeTeardown = _relayerPauseGeneration;
       _slog.info(
         category: LogCategory.wifi,
         event: 'transport_connect_waiting_teardown',
-        message: 'connect waiting for in-flight disconnect teardown before '
+        message:
+            'connect waiting for in-flight disconnect teardown before '
             'proceeding',
         payload: {'flowId': flowId, 'deviceId': device.deviceId},
       );
       await teardownInFlight.future;
+      if (_relayerPauseGeneration != pauseGenBeforeTeardown) {
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'transport_connect_aborted_pause_during_teardown',
+          message:
+              'connect aborted because relayer pause won while waiting for '
+              'disconnect teardown',
+          payload: {'flowId': flowId, 'deviceId': device.deviceId},
+        );
+        return false;
+      }
     }
 
     // Clear reconnect suppression on any connect. If only cleared on
@@ -672,7 +686,8 @@ disconnect requested while teardown in progress; waiting existing teardown''',
           _slog.info(
             category: LogCategory.wifi,
             event: 'ws_connected_ignored_stale',
-            message: 'ignoring connected event (stale vs pause/disconnect or '
+            message:
+                'ignoring connected event (stale vs pause/disconnect or '
                 'newer connect)',
             payload: {
               'deviceId': _device?.deviceId,
@@ -711,7 +726,8 @@ disconnect requested while teardown in progress; waiting existing teardown''',
           _slog.info(
             category: LogCategory.wifi,
             event: 'ws_disconnected_ignored_stale',
-            message: 'ignoring disconnected event (stale socket vs newer '
+            message:
+                'ignoring disconnected event (stale socket vs newer '
                 'session)',
             payload: {
               'deviceId': _device?.deviceId,

--- a/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
+++ b/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
@@ -42,8 +42,10 @@ class FF1RelayerTransport implements FF1WifiTransport {
   FF1RelayerTransport({
     required String relayerUrl,
     Logger? logger,
+    Future<void> Function()? debugBeforeConnectControlDispatch,
   }) : _relayerUrl = relayerUrl,
-       _log = logger ?? Logger('FF1RelayerTransport') {
+       _log = logger ?? Logger('FF1RelayerTransport'),
+       _debugBeforeConnectControlDispatch = debugBeforeConnectControlDispatch {
     _slog = AppStructuredLog.forLogger(
       _log,
       context: {'component': 'ff1_relayer_transport'},
@@ -53,6 +55,7 @@ class FF1RelayerTransport implements FF1WifiTransport {
   final String _relayerUrl;
   final Logger _log;
   late final StructuredLogger _slog;
+  final Future<void> Function()? _debugBeforeConnectControlDispatch;
 
   // Connection state
   bool _isConnected = false;
@@ -91,6 +94,14 @@ class FF1RelayerTransport implements FF1WifiTransport {
   // Single-flight teardown: shared completer ensures concurrent disconnect()
   // and dispose() calls do not race each other on stream adds/closes.
   Completer<void>? _teardownCompleter;
+
+  /// Monotonic id for each connect control sent (pairs with expected gen).
+  int _connectSeq = 0;
+
+  /// Set synchronously when connect control is sent; cleared on pause/disconnect.
+  /// Isolate echoes `connectGen` in the connected event; we ignore events that
+  /// do not match, or any event after pause cleared the expectation (PR #361).
+  int? _expectedConnectedGen;
 
   int _flowSequence = 0;
 
@@ -150,10 +161,10 @@ class FF1RelayerTransport implements FF1WifiTransport {
       throw error;
     }
 
-    // Clear reconnect suppression on any connect. If only cleared on forceReconnect,
-    // a manual connect after app was backgrounded (before any device connected)
-    // would leave _reconnectSuppressed stuck true, silently disabling
-    // auto-reconnect for the rest of the session.
+    // Clear reconnect suppression on any connect. If only cleared on
+    // forceReconnect, a manual connect after app was backgrounded (before any
+    // device connected) would leave _reconnectSuppressed stuck true, silently
+    // disabling auto-reconnect for the rest of the session.
     _reconnectSuppressed = false;
 
     // Already connected to same device (skip when forceReconnect)
@@ -262,10 +273,31 @@ class FF1RelayerTransport implements FF1WifiTransport {
       }
     }
 
-    // Send connect control message
+    if (_debugBeforeConnectControlDispatch != null) {
+      await _debugBeforeConnectControlDispatch();
+    }
+
+    if (_reconnectSuppressed) {
+      // App lifecycle pause/disconnect may win while connect is still waiting
+      // for isolate startup. In that case, do not dispatch a stale connect
+      // control after the background transition, or the isolate can open a
+      // socket that app state has already decided must stay down.
+      _slog.info(
+        category: LogCategory.wifi,
+        event: 'transport_connect_control_skipped_suppressed',
+        message: 'connect control skipped because transport is suppressed',
+        payload: {'flowId': flowId, 'deviceId': _device?.deviceId},
+      );
+      return;
+    }
+
+    // Send connect control message. wireGen is assigned here with no await
+    // after — see PR #361: pause() must not invalidate before this runs.
+    final wireGen = ++_connectSeq;
+    _expectedConnectedGen = wireGen;
     final control = _RelayerControlMessage(
       type: _RelayerControlType.connect,
-      data: {'wsUrl': wsUrl},
+      data: {'wsUrl': wsUrl, 'connectGen': wireGen},
     );
     _isolateSendPort?.send(control.toJson());
     _slog.info(
@@ -299,7 +331,8 @@ class FF1RelayerTransport implements FF1WifiTransport {
       },
     );
 
-    // Single-flight teardown: if already tearing down, wait for ongoing teardown
+    // Single-flight teardown: if already tearing down, wait for ongoing
+    // teardown
     if (_reconnectSuppressed && _teardownCompleter != null) {
       _slog.info(
         category: LogCategory.wifi,
@@ -319,6 +352,7 @@ disconnect requested while teardown in progress; waiting existing teardown''',
     }
 
     _reconnectSuppressed = true;
+    _expectedConnectedGen = null;
     _teardownCompleter ??= Completer<void>();
     final completer = _teardownCompleter!;
 
@@ -398,7 +432,8 @@ disconnect requested while teardown in progress; waiting existing teardown''',
       if (!completer.isCompleted) {
         completer.complete();
       }
-      // Clear completer after completion to allow fresh teardown cycle next time
+      // Clear completer after completion to allow fresh teardown cycle next
+      // time
       _teardownCompleter = null;
       _slog.info(
         category: LogCategory.wifi,
@@ -411,6 +446,7 @@ disconnect requested while teardown in progress; waiting existing teardown''',
 
   @override
   void pauseConnection() {
+    _expectedConnectedGen = null;
     final flowId = _nextFlowId('pause');
     _log.info('Pausing relayer connection (app background)');
     _slog.info(
@@ -425,9 +461,10 @@ disconnect requested while teardown in progress; waiting existing teardown''',
       },
     );
 
-    // Always cancel reconnect timers and set suppression flag, even when already
-    // disconnected. After a network drop, the transport can be !_isConnected
-    // but still have an active _reconnectTimer from _scheduleReconnect().
+    // Always cancel reconnect timers and set suppression flag, even when
+    // already disconnected. After a network drop, the transport can be
+    // !_isConnected but still have an active _reconnectTimer from
+    // _scheduleReconnect().
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     _reconnectSuppressed = true;
@@ -540,6 +577,24 @@ disconnect requested while teardown in progress; waiting existing teardown''',
         }
 
       case _RelayerEventType.connected:
+        final connectGen = event.data?['connectGen'] as int?;
+        if (connectGen == null ||
+            _expectedConnectedGen == null ||
+            connectGen != _expectedConnectedGen) {
+          _slog.info(
+            category: LogCategory.wifi,
+            event: 'ws_connected_ignored_stale',
+            message: 'ignoring connected event (stale vs pause/disconnect or '
+                'newer connect)',
+            payload: {
+              'deviceId': _device?.deviceId,
+              'eventConnectGen': connectGen,
+              'expectedConnectGen': _expectedConnectedGen,
+            },
+          );
+          break;
+        }
+        _expectedConnectedGen = null;
         _isConnected = true;
         _lastError = null;
         _reconnectAttempts = 0;
@@ -615,7 +670,7 @@ disconnect requested while teardown in progress; waiting existing teardown''',
             if (!_notificationController.isClosed) {
               _notificationController.add(notification);
             }
-          } catch (e) {
+          } on Object catch (e) {
             _log.warning('Failed to parse notification: $e');
             _slog.warning(
               category: LogCategory.wifi,
@@ -709,7 +764,7 @@ disconnect requested while teardown in progress; waiting existing teardown''',
       );
       try {
         await _connectInternal();
-      } catch (e) {
+      } on Object catch (e) {
         _slog.warning(
           category: LogCategory.wifi,
           event: 'ws_reconnect_attempt_failed',
@@ -722,6 +777,7 @@ disconnect requested while teardown in progress; waiting existing teardown''',
     });
   }
 
+  /// Last connection error string from the transport, if any.
   String? get lastError => _lastError;
 }
 
@@ -754,6 +810,11 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
   StreamSubscription<dynamic>? channelSub;
   String? wsUrl;
 
+  /// Bumped on each connect control and on disconnect/dispose. Deferred
+  /// [connect] work checks this so a pause/disconnect that arrives before the
+  /// microtask runs still suppresses the stale `connected` event (PR #361).
+  var connectGeneration = 0;
+
   Future<void> closeChannel() async {
     _relayerIsolateLog('close_channel_start', 'closing websocket channel');
     await channelSub?.cancel();
@@ -763,7 +824,14 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
     _relayerIsolateLog('close_channel_done', 'websocket channel closed');
   }
 
-  Future<void> connect() async {
+  Future<void> connect(int connectGen) async {
+    if (connectGen != connectGeneration) {
+      _relayerIsolateLog(
+        'connect_skipped_superseded',
+        'connect skipped: superseded by disconnect/pause or newer connect',
+      );
+      return;
+    }
     if (wsUrl == null || wsUrl!.isEmpty) {
       _relayerIsolateLog(
         'connect_skipped_empty_url',
@@ -846,8 +914,18 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
         },
       );
 
-      const connectedEvent = _RelayerEventMessage(
+      if (connectGen != connectGeneration) {
+        await closeChannel();
+        _relayerIsolateLog(
+          'connect_aborted_before_connected_event',
+          'superseded before connected event — closing channel',
+        );
+        return;
+      }
+
+      final connectedEvent = _RelayerEventMessage(
         type: _RelayerEventType.connected,
+        data: {'connectGen': connectGen},
       );
       mainSendPort.send(connectedEvent.toJson());
       _relayerIsolateLog(
@@ -855,6 +933,14 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
         'sent connected event to main (socket object created)',
       );
     } on Exception catch (e) {
+      if (connectGen != connectGeneration) {
+        await closeChannel();
+        _relayerIsolateLog(
+          'connect_exception_ignored_superseded',
+          'connect failed but superseded — not forwarding error',
+        );
+        return;
+      }
       _relayerIsolateLog('connect_exception', e.toString());
       const errorEvent = _RelayerEventMessage(
         type: _RelayerEventType.error,
@@ -897,10 +983,34 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
           'connect control received',
         );
         wsUrl = control.data?['wsUrl'] as String?;
+        final wireGen = control.data!['connectGen'] as int;
+        // Keep isolate generation aligned with main so disconnect/pause can
+        // invalidate this attempt (see [connectGeneration]).
+        connectGeneration = wireGen;
         await closeChannel();
-        await connect();
+        if (wireGen != connectGeneration) {
+          _relayerIsolateLog(
+            'control_connect_aborted_superseded_during_close',
+            'connect aborted: disconnect/pause during closeChannel',
+          );
+          break;
+        }
+        // Do not await inner [connect]: the ReceivePort listener would stay
+        // blocked until WebSocket setup finishes, so a pause/disconnect control
+        // queued after this connect would be processed too late (PR #361 review
+        // 4096354225: cancel at isolate boundary).
+        unawaited(
+          () async {
+            await Future<void>.delayed(Duration.zero);
+            if (wireGen != connectGeneration) {
+              return;
+            }
+            await connect(wireGen);
+          }(),
+        );
 
       case _RelayerControlType.disconnect:
+        connectGeneration++;
         _relayerIsolateLog('control_disconnect', 'disconnect control received');
         unawaited(closeChannel());
         const event = _RelayerEventMessage(
@@ -913,6 +1023,7 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
         );
 
       case _RelayerControlType.dispose:
+        connectGeneration++;
         _relayerIsolateLog('control_dispose', 'dispose control received');
         unawaited(closeChannel());
         controlPort.close();

--- a/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
+++ b/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
@@ -29,6 +29,26 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 // Relayer transport adapter (WebSocket over cloud)
 // ============================================================================
 
+/// Whether a [disconnected] event from the relayer isolate should update main
+/// transport state. Stale `onDone` / disconnect from a superseded socket
+/// carries an older [eventConnectGen] and must be ignored (PR #361 review
+/// 4097788212).
+bool relayerDisconnectEventAppliesToSession({
+  required int? eventConnectGen,
+  required int? activeRelayerConnectGen,
+  required int? expectedConnectedGen,
+}) {
+  if (eventConnectGen == null) {
+    // Legacy events without generation: preserve previous apply-all behavior.
+    return true;
+  }
+  final pending = expectedConnectedGen != null &&
+      eventConnectGen == expectedConnectedGen;
+  final active = activeRelayerConnectGen != null &&
+      eventConnectGen == activeRelayerConnectGen;
+  return pending || active;
+}
+
 /// Relayer transport: connects to FF1 device via relayer server.
 ///
 /// Connection flow:
@@ -102,6 +122,10 @@ class FF1RelayerTransport implements FF1WifiTransport {
   /// Isolate echoes `connectGen` in the connected event; we ignore events that
   /// do not match, or any event after pause cleared the expectation (PR #361).
   int? _expectedConnectedGen;
+
+  /// Generation of the socket last accepted as connected (pairs with isolate
+  /// `disconnected` `connectGen` for stale-event filtering).
+  int? _activeRelayerConnectGen;
 
   int _flowSequence = 0;
 
@@ -358,6 +382,7 @@ disconnect requested while teardown in progress; waiting existing teardown''',
 
     _reconnectSuppressed = true;
     _expectedConnectedGen = null;
+    _activeRelayerConnectGen = null;
     _teardownCompleter ??= Completer<void>();
     final completer = _teardownCompleter!;
 
@@ -452,6 +477,7 @@ disconnect requested while teardown in progress; waiting existing teardown''',
   @override
   void pauseConnection() {
     _expectedConnectedGen = null;
+    _activeRelayerConnectGen = null;
     final flowId = _nextFlowId('pause');
     _log.info('Pausing relayer connection (app background)');
     _slog.info(
@@ -600,6 +626,7 @@ disconnect requested while teardown in progress; waiting existing teardown''',
           break;
         }
         _expectedConnectedGen = null;
+        _activeRelayerConnectGen = connectGen;
         _isConnected = true;
         _lastError = null;
         _reconnectAttempts = 0;
@@ -618,6 +645,30 @@ disconnect requested while teardown in progress; waiting existing teardown''',
         );
 
       case _RelayerEventType.disconnected:
+        final eventGen = event.data?['connectGen'] as int?;
+        if (!relayerDisconnectEventAppliesToSession(
+          eventConnectGen: eventGen,
+          activeRelayerConnectGen: _activeRelayerConnectGen,
+          expectedConnectedGen: _expectedConnectedGen,
+        )) {
+          _slog.info(
+            category: LogCategory.wifi,
+            event: 'ws_disconnected_ignored_stale',
+            message: 'ignoring disconnected event (stale socket vs newer '
+                'session)',
+            payload: {
+              'deviceId': _device?.deviceId,
+              'eventConnectGen': eventGen,
+              'activeRelayerConnectGen': _activeRelayerConnectGen,
+              'expectedConnectedGen': _expectedConnectedGen,
+            },
+          );
+          break;
+        }
+        if (eventGen != null && eventGen == _expectedConnectedGen) {
+          _expectedConnectedGen = null;
+        }
+        _activeRelayerConnectGen = null;
         _isConnected = false;
         if (!_connectionStateController.isClosed) {
           _connectionStateController.add(false);
@@ -628,6 +679,7 @@ disconnect requested while teardown in progress; waiting existing teardown''',
           message: 'WebSocket disconnected from relayer',
           payload: {
             'deviceId': _device?.deviceId,
+            'eventConnectGen': eventGen,
             'reconnectSuppressed': _reconnectSuppressed,
             'reconnectAttempts': _reconnectAttempts,
             'lastError': _lastError,
@@ -898,8 +950,9 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
           };
           mainSendPort.send(errorData);
           unawaited(closeChannel());
-          const disconnectedEvent = _RelayerEventMessage(
+          final disconnectedEvent = _RelayerEventMessage(
             type: _RelayerEventType.disconnected,
+            data: {'connectGen': connectGen},
           );
           mainSendPort.send(disconnectedEvent.toJson());
           _relayerIsolateLog(
@@ -912,8 +965,9 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
             'ws_stream_done',
             'websocket stream closed (onDone)',
           );
-          const event = _RelayerEventMessage(
+          final event = _RelayerEventMessage(
             type: _RelayerEventType.disconnected,
+            data: {'connectGen': connectGen},
           );
           mainSendPort.send(event.toJson());
         },
@@ -957,8 +1011,9 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
       mainSendPort.send(errorData);
       unawaited(closeChannel());
       // Send disconnected so main schedules reconnect (initial connect failure)
-      const disconnectedEvent = _RelayerEventMessage(
+      final disconnectedEvent = _RelayerEventMessage(
         type: _RelayerEventType.disconnected,
+        data: {'connectGen': connectGen},
       );
       mainSendPort.send(disconnectedEvent.toJson());
       _relayerIsolateLog(
@@ -1015,11 +1070,13 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
         );
 
       case _RelayerControlType.disconnect:
+        final closedGen = connectGeneration;
         connectGeneration++;
         _relayerIsolateLog('control_disconnect', 'disconnect control received');
         unawaited(closeChannel());
-        const event = _RelayerEventMessage(
+        final event = _RelayerEventMessage(
           type: _RelayerEventType.disconnected,
+          data: {'connectGen': closedGen},
         );
         mainSendPort.send(event.toJson());
         _relayerIsolateLog(

--- a/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
+++ b/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
@@ -29,7 +29,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 // Relayer transport adapter (WebSocket over cloud)
 // ============================================================================
 
-/// Whether a [disconnected] event from the relayer isolate should update main
+/// Whether a disconnected event from the relayer isolate should update main
 /// transport state. Stale `onDone` / disconnect from a superseded socket
 /// carries an older [eventConnectGen] and must be ignored (PR #361 review
 /// 4097788212).
@@ -210,6 +210,11 @@ class FF1RelayerTransport implements FF1WifiTransport {
     // Disconnect from previous device
     if (_isConnected) {
       await disconnect();
+      // disconnect() sets _reconnectSuppressed for lifecycle/teardown. That must
+      // not block the replacement session this connect() is about to open:
+      // otherwise forceReconnect self-suppresses at _connectInternal (PR #361
+      // review 4097958860).
+      _reconnectSuppressed = false;
     }
 
     // Cache connection parameters for reconnect

--- a/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
+++ b/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
@@ -130,7 +130,7 @@ class FF1RelayerTransport implements FF1WifiTransport {
   }
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -180,7 +180,7 @@ class FF1RelayerTransport implements FF1WifiTransport {
             'transport connect skipped because socket is already connected',
         payload: {'flowId': flowId, 'deviceId': device.deviceId},
       );
-      return;
+      return true;
     }
 
     // Disconnect from previous device
@@ -197,7 +197,10 @@ class FF1RelayerTransport implements FF1WifiTransport {
 
     try {
       _isConnecting = true;
-      await _connectInternal(flowId: flowId);
+      final dispatched = await _connectInternal(flowId: flowId);
+      if (!dispatched) {
+        return false;
+      }
       _slog.info(
         category: LogCategory.wifi,
         event: 'transport_connect_control_sent',
@@ -209,6 +212,7 @@ class FF1RelayerTransport implements FF1WifiTransport {
           'isConnecting': _isConnecting,
         },
       );
+      return true;
     } catch (e) {
       _isConnecting = false;
       _lastError = e.toString();
@@ -223,7 +227,7 @@ class FF1RelayerTransport implements FF1WifiTransport {
     }
   }
 
-  Future<void> _connectInternal({String? flowId}) async {
+  Future<bool> _connectInternal({String? flowId}) async {
     // Build WebSocket URL
     final wsUrl =
         '$_relayerUrl/api/notification?'
@@ -288,7 +292,7 @@ class FF1RelayerTransport implements FF1WifiTransport {
         message: 'connect control skipped because transport is suppressed',
         payload: {'flowId': flowId, 'deviceId': _device?.deviceId},
       );
-      return;
+      return false;
     }
 
     // Send connect control message. wireGen is assigned here with no await
@@ -313,6 +317,7 @@ class FF1RelayerTransport implements FF1WifiTransport {
 
     // Reset reconnect attempts on successful connect
     _reconnectAttempts = 0;
+    return true;
   }
 
   @override

--- a/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
+++ b/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
@@ -192,6 +192,23 @@ class FF1RelayerTransport implements FF1WifiTransport {
       throw error;
     }
 
+    // Resume/reconnect must not open a new socket while a previous main-side
+    // teardown is still in flight (100ms grace + isolate kill).
+    // `pauseConnection` can clear `_isConnected` before that work finishes, so
+    // we cannot infer "no teardown" from the connected flag alone (PR #361
+    // review 4098243960).
+    final teardownInFlight = _teardownCompleter;
+    if (teardownInFlight != null) {
+      _slog.info(
+        category: LogCategory.wifi,
+        event: 'transport_connect_waiting_teardown',
+        message: 'connect waiting for in-flight disconnect teardown before '
+            'proceeding',
+        payload: {'flowId': flowId, 'deviceId': device.deviceId},
+      );
+      await teardownInFlight.future;
+    }
+
     // Clear reconnect suppression on any connect. If only cleared on
     // forceReconnect, a manual connect after app was backgrounded (before any
     // device connected) would leave _reconnectSuppressed stuck true, silently
@@ -214,8 +231,16 @@ class FF1RelayerTransport implements FF1WifiTransport {
       return true;
     }
 
-    // Disconnect from previous device
-    if (_isConnected) {
+    // `pauseConnection` can set `_isConnected` false while the isolate is
+    // still closing; always run full main-side teardown when resources remain.
+    final needsDisconnectFromPreviousSession =
+        _isConnected ||
+        _isConnecting ||
+        _isolate != null ||
+        _isolateSendPort != null;
+
+    // Disconnect from previous device / stale isolate
+    if (needsDisconnectFromPreviousSession) {
       final pauseGenBeforeDisconnect = _relayerPauseGeneration;
       await disconnect();
       // If pauseConnection() ran while disconnect was tearing down, reopening

--- a/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
+++ b/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
@@ -63,9 +63,11 @@ class FF1RelayerTransport implements FF1WifiTransport {
     required String relayerUrl,
     Logger? logger,
     Future<void> Function()? debugBeforeConnectControlDispatch,
+    Future<void> Function()? debugBeforeDisconnectGraceDelay,
   }) : _relayerUrl = relayerUrl,
        _log = logger ?? Logger('FF1RelayerTransport'),
-       _debugBeforeConnectControlDispatch = debugBeforeConnectControlDispatch {
+       _debugBeforeConnectControlDispatch = debugBeforeConnectControlDispatch,
+       _debugBeforeDisconnectGraceDelay = debugBeforeDisconnectGraceDelay {
     _slog = AppStructuredLog.forLogger(
       _log,
       context: {'component': 'ff1_relayer_transport'},
@@ -76,6 +78,11 @@ class FF1RelayerTransport implements FF1WifiTransport {
   final Logger _log;
   late final StructuredLogger _slog;
   final Future<void> Function()? _debugBeforeConnectControlDispatch;
+  final Future<void> Function()? _debugBeforeDisconnectGraceDelay;
+
+  /// Bumps on each [pauseConnection] so [connect] can tell if lifecycle pause
+  /// won during an in-flight [disconnect] (PR #361 review 4098103277).
+  int _relayerPauseGeneration = 0;
 
   // Connection state
   bool _isConnected = false;
@@ -209,7 +216,21 @@ class FF1RelayerTransport implements FF1WifiTransport {
 
     // Disconnect from previous device
     if (_isConnected) {
+      final pauseGenBeforeDisconnect = _relayerPauseGeneration;
       await disconnect();
+      // If pauseConnection() ran while disconnect was tearing down, reopening
+      // here would violate the background contract (PR #361 review 4098103277).
+      if (_relayerPauseGeneration != pauseGenBeforeDisconnect) {
+        _slog.info(
+          category: LogCategory.wifi,
+          event: 'transport_connect_aborted_pause_during_disconnect',
+          message:
+              'connect aborted after disconnect because relayer pause won '
+              'during teardown',
+          payload: {'flowId': flowId, 'deviceId': device.deviceId},
+        );
+        return false;
+      }
       // disconnect() sets _reconnectSuppressed for lifecycle/teardown. That must
       // not block the replacement session this connect() is about to open:
       // otherwise forceReconnect self-suppresses at _connectInternal (PR #361
@@ -418,6 +439,11 @@ disconnect requested while teardown in progress; waiting existing teardown''',
         },
       );
 
+      final beforeGrace = _debugBeforeDisconnectGraceDelay;
+      if (beforeGrace != null) {
+        await beforeGrace();
+      }
+
       await Future<void>.delayed(const Duration(milliseconds: 100));
       _slog.info(
         category: LogCategory.wifi,
@@ -504,6 +530,7 @@ disconnect requested while teardown in progress; waiting existing teardown''',
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     _reconnectSuppressed = true;
+    _relayerPauseGeneration++;
 
     // Always send disconnect when isolate exists. _connectInternal() drops
     // _isConnecting before the isolate sends its connection event, so there

--- a/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
+++ b/lib/infra/ff1/wifi_transport/ff1_relayer_transport.dart
@@ -764,6 +764,25 @@ disconnect requested while teardown in progress; waiting existing teardown''',
         }
 
       case _RelayerEventType.error:
+        final eventGen = event.data?['connectGen'] as int?;
+        if (!relayerDisconnectEventAppliesToSession(
+          eventConnectGen: eventGen,
+          activeRelayerConnectGen: _activeRelayerConnectGen,
+          expectedConnectedGen: _expectedConnectedGen,
+        )) {
+          _slog.info(
+            category: LogCategory.wifi,
+            event: 'ws_error_ignored_stale',
+            message: 'ignoring stale error from superseded relayer session',
+            payload: {
+              'deviceId': _device?.deviceId,
+              'eventConnectGen': eventGen,
+              'activeRelayerConnectGen': _activeRelayerConnectGen,
+              'expectedConnectedGen': _expectedConnectedGen,
+            },
+          );
+          break;
+        }
         final errorMsg = event.data?['error'] as String? ?? 'Unknown error';
         _lastError = errorMsg;
         _slog.warning(
@@ -782,6 +801,26 @@ disconnect requested while teardown in progress; waiting existing teardown''',
         }
 
       case _RelayerEventType.notification:
+        final eventGen = event.data?['connectGen'] as int?;
+        if (!relayerDisconnectEventAppliesToSession(
+          eventConnectGen: eventGen,
+          activeRelayerConnectGen: _activeRelayerConnectGen,
+          expectedConnectedGen: _expectedConnectedGen,
+        )) {
+          _slog.info(
+            category: LogCategory.wifi,
+            event: 'isolate_notification_ignored_stale',
+            message:
+                'ignoring stale notification from superseded relayer session',
+            payload: {
+              'deviceId': _device?.deviceId,
+              'eventConnectGen': eventGen,
+              'activeRelayerConnectGen': _activeRelayerConnectGen,
+              'expectedConnectedGen': _expectedConnectedGen,
+            },
+          );
+          break;
+        }
         final notificationData = event.data?['notification'] as Map?;
         if (notificationData != null) {
           try {
@@ -1001,7 +1040,10 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
             );
             final eventData = <String, dynamic>{
               ...event.toJson(),
-              'data': {'notification': notification.toJson()},
+              'data': {
+                'connectGen': connectGen,
+                'notification': notification.toJson(),
+              },
             };
             mainSendPort.send(eventData);
             _relayerIsolateLog(
@@ -1019,7 +1061,7 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
           );
           final errorData = <String, dynamic>{
             ...errorEvent.toJson(),
-            'data': {'error': error.toString()},
+            'data': {'connectGen': connectGen, 'error': error.toString()},
           };
           mainSendPort.send(errorData);
           unawaited(closeChannel());
@@ -1079,7 +1121,7 @@ void _relayerIsolateEntry(SendPort mainSendPort) {
       );
       final errorData = <String, dynamic>{
         ...errorEvent.toJson(),
-        'data': {'error': e.toString()},
+        'data': {'connectGen': connectGen, 'error': e.toString()},
       };
       mainSendPort.send(errorData);
       unawaited(closeChannel());

--- a/lib/infra/ff1/wifi_transport/ff1_wifi_transport.dart
+++ b/lib/infra/ff1/wifi_transport/ff1_wifi_transport.dart
@@ -32,8 +32,16 @@ abstract class FF1WifiTransport {
   ///   app resume when connection may be stale (Timer-based reconnect does
   ///   not fire while app is suspended)
   ///
+  /// Returns `false` when the connect attempt stopped before dispatching
+  /// transport work (e.g. lifecycle [pauseConnection] won while the relayer
+  /// was still preparing the isolate). Callers must not treat that as a
+  /// successful session — no socket was opened.
+  ///
+  /// Returns `true` when connect control was dispatched or the session was
+  /// already connected (no-op skip).
+  ///
   /// Throws: [FF1WifiTransportError] if connection fails
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -128,6 +128,7 @@ dev_dependencies:
   # Platform interfaces
   path_provider_platform_interface: any
   patrol: ^4.3.0
+  fake_async: any
 dependency_overrides:
   path_provider_foundation: 2.6.0
 

--- a/test/integration/app/lifecycle/lifecycle_wifi_relayer_integration_test.dart
+++ b/test/integration/app/lifecycle/lifecycle_wifi_relayer_integration_test.dart
@@ -1,0 +1,112 @@
+import 'package:app/app/providers/app_lifecycle_provider.dart';
+import 'package:app/app/providers/ff1_wifi_providers.dart';
+import 'package:app/app/providers/indexer_tokens_provider.dart';
+import 'package:app/domain/models/ff1_device.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+import '../../../unit/app/providers/provider_test_helpers.dart';
+
+/// Cross-module integration: [AppLifecycleNotifier] + [FF1WifiConnectionNotifier]
+/// + [FF1WifiControl] fake — exercises lifecycle → pause → resume → reconnect
+/// without a real relayer transport (see relayer isolate unit tests for I/O).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'integration: inactive debounce pauses relayer then resume reconnects',
+    (tester) async {
+      final binding = tester.binding;
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+      final wifiControl = _IntegrationFakeWifiControl();
+      final tokensSync = _RecordingTokensSyncCoordinator();
+      final container = ProviderContainer.test(
+        overrides: [
+          ff1WifiControlProvider.overrideWithValue(wifiControl),
+          ff1WifiConnectionProvider.overrideWith(
+            FF1WifiConnectionNotifier.new,
+          ),
+          tokensSyncCoordinatorProvider.overrideWith(() => tokensSync),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      });
+
+      container.listen(appLifecycleProvider, (_, _) {});
+      await tester.pump();
+
+      await container.read(ff1WifiConnectionProvider.notifier).connect(
+        device: const FF1Device(
+          name: 'FF1',
+          remoteId: 'remote-1',
+          deviceId: 'device-1',
+          topicId: 'topic-1',
+        ),
+        userId: 'user-1',
+        apiKey: 'api-key-1',
+      );
+      wifiControl.resetCounts();
+
+      expect(container.read(appLifecycleProvider), AppLifecycleState.resumed);
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(wifiControl.pauseCount, 1);
+      expect(wifiControl.reconnectCount, 0);
+      expect(
+        container.read(appLifecycleProvider),
+        AppLifecycleState.inactive,
+      );
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+
+      expect(wifiControl.reconnectCount, 1);
+      expect(container.read(appLifecycleProvider), AppLifecycleState.resumed);
+    },
+  );
+}
+
+class _IntegrationFakeWifiControl extends FakeWifiControl {
+  int pauseCount = 0;
+  int reconnectCount = 0;
+
+  @override
+  void pauseConnection() {
+    pauseCount++;
+    super.pauseConnection();
+  }
+
+  @override
+  Future<bool> reconnect() async {
+    reconnectCount++;
+    emitTransportConnection(isConnected: true);
+    return true;
+  }
+
+  void resetCounts() {
+    pauseCount = 0;
+    reconnectCount = 0;
+  }
+}
+
+class _RecordingTokensSyncCoordinator extends TokensSyncCoordinatorNotifier {
+  @override
+  TokensSyncState build() => const TokensSyncState();
+
+  @override
+  void startSyncCollectionPolling({
+    Duration interval = const Duration(minutes: 5),
+  }) {}
+
+  @override
+  void pauseSyncCollectionPolling() {}
+
+  @override
+  Future<void> syncAllTrackedAddresses() async {}
+}

--- a/test/unit/app/lifecycle/inactive_wifi_pause_schedule_test.dart
+++ b/test/unit/app/lifecycle/inactive_wifi_pause_schedule_test.dart
@@ -1,0 +1,179 @@
+import 'package:app/app/lifecycle/inactive_wifi_pause_schedule.dart';
+import 'package:app/infra/logging/structured_logger.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+
+void main() {
+  group('wifiPauseDebouncerActionFor', () {
+    test('maps resumed to cancel timer only', () {
+      expect(
+        wifiPauseDebouncerActionFor(AppLifecycleState.resumed),
+        WifiPauseDebouncerAction.cancelTimerOnly,
+      );
+    });
+
+    test('maps inactive to schedule debounce', () {
+      expect(
+        wifiPauseDebouncerActionFor(AppLifecycleState.inactive),
+        WifiPauseDebouncerAction.scheduleInactiveTimerIfNone,
+      );
+    });
+
+    test('maps paused detached hidden to immediate pause', () {
+      for (final s in [
+        AppLifecycleState.paused,
+        AppLifecycleState.detached,
+        AppLifecycleState.hidden,
+      ]) {
+        expect(
+          wifiPauseDebouncerActionFor(s),
+          WifiPauseDebouncerAction.cancelTimerAndPauseWifiNow,
+        );
+      }
+    });
+  });
+
+  group('shouldRunDebouncedInactiveWifiPause', () {
+    test('false when resumed', () {
+      expect(
+        shouldRunDebouncedInactiveWifiPause(AppLifecycleState.resumed),
+        isFalse,
+      );
+    });
+
+    test('true when not resumed', () {
+      for (final s in [
+        AppLifecycleState.inactive,
+        AppLifecycleState.paused,
+        AppLifecycleState.detached,
+        AppLifecycleState.hidden,
+      ]) {
+        expect(shouldRunDebouncedInactiveWifiPause(s), isTrue);
+      }
+    });
+  });
+
+  group('InactiveRelayerWifiPauseCoordinator', () {
+    test('inactive schedules one pause after debounce', () {
+      FakeAsync().run((async) {
+        final coord = InactiveRelayerWifiPauseCoordinator(
+          debounce: const Duration(milliseconds: 100),
+          structuredLog: AppStructuredLog.forLogger(
+            Logger('test'),
+            context: const {'component': 'test'},
+          ),
+        );
+        var pauseCount = 0;
+        AppLifecycleState current = AppLifecycleState.inactive;
+
+        coord.onLifecycle(
+          state: AppLifecycleState.inactive,
+          readLifecycle: () => current,
+          pauseRelayerWifi: () => pauseCount++,
+        );
+
+        expect(pauseCount, 0);
+        async.elapse(const Duration(milliseconds: 99));
+        expect(pauseCount, 0);
+        async.elapse(const Duration(milliseconds: 2));
+        expect(pauseCount, 1);
+
+        coord.dispose();
+      });
+    });
+
+    test('resumed cancels pending inactive pause', () {
+      FakeAsync().run((async) {
+        final coord = InactiveRelayerWifiPauseCoordinator(
+          debounce: const Duration(milliseconds: 100),
+          structuredLog: AppStructuredLog.forLogger(
+            Logger('test'),
+            context: const {'component': 'test'},
+          ),
+        );
+        var pauseCount = 0;
+        AppLifecycleState current = AppLifecycleState.inactive;
+
+        coord.onLifecycle(
+          state: AppLifecycleState.inactive,
+          readLifecycle: () => current,
+          pauseRelayerWifi: () => pauseCount++,
+        );
+
+        async.elapse(const Duration(milliseconds: 50));
+        current = AppLifecycleState.resumed;
+        coord.onLifecycle(
+          state: AppLifecycleState.resumed,
+          readLifecycle: () => current,
+          pauseRelayerWifi: () => pauseCount++,
+        );
+
+        async.elapse(const Duration(milliseconds: 200));
+        expect(pauseCount, 0);
+
+        coord.dispose();
+      });
+    });
+
+    test('duplicate inactive does not reschedule timer', () {
+      FakeAsync().run((async) {
+        final coord = InactiveRelayerWifiPauseCoordinator(
+          debounce: const Duration(milliseconds: 100),
+          structuredLog: AppStructuredLog.forLogger(
+            Logger('test'),
+            context: const {'component': 'test'},
+          ),
+        );
+        var pauseCount = 0;
+        final current = AppLifecycleState.inactive;
+
+        coord.onLifecycle(
+          state: AppLifecycleState.inactive,
+          readLifecycle: () => current,
+          pauseRelayerWifi: () => pauseCount++,
+        );
+        coord.onLifecycle(
+          state: AppLifecycleState.inactive,
+          readLifecycle: () => current,
+          pauseRelayerWifi: () => pauseCount++,
+        );
+
+        async.elapse(const Duration(milliseconds: 100));
+        expect(pauseCount, 1);
+
+        coord.dispose();
+      });
+    });
+
+    test('timer fire skips pause when lifecycle is resumed', () {
+      FakeAsync().run((async) {
+        final coord = InactiveRelayerWifiPauseCoordinator(
+          debounce: const Duration(milliseconds: 100),
+          structuredLog: AppStructuredLog.forLogger(
+            Logger('test'),
+            context: const {'component': 'test'},
+          ),
+        );
+        var pauseCount = 0;
+        AppLifecycleState current = AppLifecycleState.inactive;
+
+        coord.onLifecycle(
+          state: AppLifecycleState.inactive,
+          readLifecycle: () => current,
+          pauseRelayerWifi: () => pauseCount++,
+        );
+
+        async.elapse(const Duration(milliseconds: 50));
+        // Simulate race: timer still pending but readLifecycle returns resumed
+        // (e.g. user returned to app; next tick sees resumed).
+        current = AppLifecycleState.resumed;
+        async.elapse(const Duration(milliseconds: 60));
+        expect(pauseCount, 0);
+
+        coord.dispose();
+      });
+    });
+  });
+}

--- a/test/unit/app/lifecycle/inactive_wifi_pause_schedule_test.dart
+++ b/test/unit/app/lifecycle/inactive_wifi_pause_schedule_test.dart
@@ -66,7 +66,7 @@ void main() {
           ),
         );
         var pauseCount = 0;
-        AppLifecycleState current = AppLifecycleState.inactive;
+        const current = AppLifecycleState.inactive;
 
         coord.onLifecycle(
           state: AppLifecycleState.inactive,
@@ -84,6 +84,28 @@ void main() {
       });
     });
 
+    test('paused invokes immediate pause exactly once', () {
+      final coord = InactiveRelayerWifiPauseCoordinator(
+        debounce: const Duration(milliseconds: 100),
+        structuredLog: AppStructuredLog.forLogger(
+          Logger('test'),
+          context: const {'component': 'test'},
+        ),
+      );
+      var pauseCount = 0;
+      const current = AppLifecycleState.paused;
+
+      coord.onLifecycle(
+        state: AppLifecycleState.paused,
+        readLifecycle: () => current,
+        pauseRelayerWifi: () => pauseCount++,
+      );
+
+      expect(pauseCount, 1);
+
+      coord.dispose();
+    });
+
     test('resumed cancels pending inactive pause', () {
       FakeAsync().run((async) {
         final coord = InactiveRelayerWifiPauseCoordinator(
@@ -94,7 +116,7 @@ void main() {
           ),
         );
         var pauseCount = 0;
-        AppLifecycleState current = AppLifecycleState.inactive;
+        var current = AppLifecycleState.inactive;
 
         coord.onLifecycle(
           state: AppLifecycleState.inactive,
@@ -127,18 +149,19 @@ void main() {
           ),
         );
         var pauseCount = 0;
-        final current = AppLifecycleState.inactive;
+        const current = AppLifecycleState.inactive;
 
-        coord.onLifecycle(
-          state: AppLifecycleState.inactive,
-          readLifecycle: () => current,
-          pauseRelayerWifi: () => pauseCount++,
-        );
-        coord.onLifecycle(
-          state: AppLifecycleState.inactive,
-          readLifecycle: () => current,
-          pauseRelayerWifi: () => pauseCount++,
-        );
+        coord
+          ..onLifecycle(
+            state: AppLifecycleState.inactive,
+            readLifecycle: () => current,
+            pauseRelayerWifi: () => pauseCount++,
+          )
+          ..onLifecycle(
+            state: AppLifecycleState.inactive,
+            readLifecycle: () => current,
+            pauseRelayerWifi: () => pauseCount++,
+          );
 
         async.elapse(const Duration(milliseconds: 100));
         expect(pauseCount, 1);
@@ -157,7 +180,7 @@ void main() {
           ),
         );
         var pauseCount = 0;
-        AppLifecycleState current = AppLifecycleState.inactive;
+        var current = AppLifecycleState.inactive;
 
         coord.onLifecycle(
           state: AppLifecycleState.inactive,

--- a/test/unit/app/providers/app_lifecycle_provider_test.dart
+++ b/test/unit/app/providers/app_lifecycle_provider_test.dart
@@ -2,9 +2,9 @@ import 'package:app/app/providers/app_lifecycle_provider.dart';
 import 'package:app/app/providers/ff1_wifi_providers.dart';
 import 'package:app/app/providers/indexer_tokens_provider.dart';
 import 'package:app/domain/models/ff1_device.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'provider_test_helpers.dart';
 
@@ -14,8 +14,8 @@ void main() {
   testWidgets(
     'inactive to resumed before debounce does not pause or reconnect relayer',
     (tester) async {
-      final binding = tester.binding;
-      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      final binding = tester.binding
+        ..handleAppLifecycleStateChanged(AppLifecycleState.resumed);
 
       final wifiControl = _LifecycleAwareFakeWifiControl();
       final tokensSync = _RecordingTokensSyncCoordinator();
@@ -54,8 +54,8 @@ void main() {
   testWidgets(
     'inactive that reaches debounce pauses and reconnects on resume',
     (tester) async {
-      final binding = tester.binding;
-      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      final binding = tester.binding
+        ..handleAppLifecycleStateChanged(AppLifecycleState.resumed);
 
       final wifiControl = _LifecycleAwareFakeWifiControl();
       final tokensSync = _RecordingTokensSyncCoordinator();
@@ -95,8 +95,8 @@ void main() {
   testWidgets(
     'paused to resumed reconnects only after lifecycle pause',
     (tester) async {
-      final binding = tester.binding;
-      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      final binding = tester.binding
+        ..handleAppLifecycleStateChanged(AppLifecycleState.resumed);
 
       final wifiControl = _LifecycleAwareFakeWifiControl();
       final tokensSync = _RecordingTokensSyncCoordinator();
@@ -122,6 +122,88 @@ void main() {
       wifiControl.resetLifecycleCounts();
 
       binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+      expect(wifiControl.pauseCount, 1);
+      expect(wifiControl.reconnectCount, 0);
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+
+      expect(wifiControl.reconnectCount, 1);
+    },
+  );
+
+  testWidgets(
+    'hidden to resumed reconnects only after lifecycle pause',
+    (tester) async {
+      final binding = tester.binding
+        ..handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+      final wifiControl = _LifecycleAwareFakeWifiControl();
+      final tokensSync = _RecordingTokensSyncCoordinator();
+      final container = ProviderContainer.test(
+        overrides: [
+          ff1WifiControlProvider.overrideWithValue(wifiControl),
+          ff1WifiConnectionProvider.overrideWith(
+            FF1WifiConnectionNotifier.new,
+          ),
+          tokensSyncCoordinatorProvider.overrideWith(() => tokensSync),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      });
+
+      container.listen(appLifecycleProvider, (_, _) {});
+      await tester.pump();
+      tokensSync.resetCounts();
+
+      await _connectDevice(container);
+      wifiControl.resetLifecycleCounts();
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      await tester.pump();
+      expect(wifiControl.pauseCount, 1);
+      expect(wifiControl.reconnectCount, 0);
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+
+      expect(wifiControl.reconnectCount, 1);
+    },
+  );
+
+  testWidgets(
+    'detached to resumed reconnects only after lifecycle pause',
+    (tester) async {
+      final binding = tester.binding
+        ..handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+      final wifiControl = _LifecycleAwareFakeWifiControl();
+      final tokensSync = _RecordingTokensSyncCoordinator();
+      final container = ProviderContainer.test(
+        overrides: [
+          ff1WifiControlProvider.overrideWithValue(wifiControl),
+          ff1WifiConnectionProvider.overrideWith(
+            FF1WifiConnectionNotifier.new,
+          ),
+          tokensSyncCoordinatorProvider.overrideWith(() => tokensSync),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      });
+
+      container.listen(appLifecycleProvider, (_, _) {});
+      await tester.pump();
+      tokensSync.resetCounts();
+
+      await _connectDevice(container);
+      wifiControl.resetLifecycleCounts();
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.detached);
       await tester.pump();
       expect(wifiControl.pauseCount, 1);
       expect(wifiControl.reconnectCount, 0);

--- a/test/unit/app/providers/app_lifecycle_provider_test.dart
+++ b/test/unit/app/providers/app_lifecycle_provider_test.dart
@@ -1,0 +1,203 @@
+import 'package:app/app/providers/app_lifecycle_provider.dart';
+import 'package:app/app/providers/ff1_wifi_providers.dart';
+import 'package:app/app/providers/indexer_tokens_provider.dart';
+import 'package:app/domain/models/ff1_device.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/widgets.dart';
+
+import 'provider_test_helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'inactive to resumed before debounce does not pause or reconnect relayer',
+    (tester) async {
+      final binding = tester.binding;
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+      final wifiControl = _LifecycleAwareFakeWifiControl();
+      final tokensSync = _RecordingTokensSyncCoordinator();
+      final container = ProviderContainer.test(
+        overrides: [
+          ff1WifiControlProvider.overrideWithValue(wifiControl),
+          ff1WifiConnectionProvider.overrideWith(
+            FF1WifiConnectionNotifier.new,
+          ),
+          tokensSyncCoordinatorProvider.overrideWith(() => tokensSync),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      });
+
+      container.listen(appLifecycleProvider, (_, _) {});
+      await tester.pump();
+      tokensSync.resetCounts();
+
+      await _connectDevice(container);
+      wifiControl.resetLifecycleCounts();
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      await tester.pump(const Duration(milliseconds: 100));
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(wifiControl.pauseCount, 0);
+      expect(wifiControl.reconnectCount, 0);
+    },
+  );
+
+  testWidgets(
+    'inactive that reaches debounce pauses and reconnects on resume',
+    (tester) async {
+      final binding = tester.binding;
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+      final wifiControl = _LifecycleAwareFakeWifiControl();
+      final tokensSync = _RecordingTokensSyncCoordinator();
+      final container = ProviderContainer.test(
+        overrides: [
+          ff1WifiControlProvider.overrideWithValue(wifiControl),
+          ff1WifiConnectionProvider.overrideWith(
+            FF1WifiConnectionNotifier.new,
+          ),
+          tokensSyncCoordinatorProvider.overrideWith(() => tokensSync),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      });
+
+      container.listen(appLifecycleProvider, (_, _) {});
+      await tester.pump();
+      tokensSync.resetCounts();
+
+      await _connectDevice(container);
+      wifiControl.resetLifecycleCounts();
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(wifiControl.pauseCount, 1);
+      expect(wifiControl.reconnectCount, 0);
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+
+      expect(wifiControl.reconnectCount, 1);
+    },
+  );
+
+  testWidgets(
+    'paused to resumed reconnects only after lifecycle pause',
+    (tester) async {
+      final binding = tester.binding;
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+      final wifiControl = _LifecycleAwareFakeWifiControl();
+      final tokensSync = _RecordingTokensSyncCoordinator();
+      final container = ProviderContainer.test(
+        overrides: [
+          ff1WifiControlProvider.overrideWithValue(wifiControl),
+          ff1WifiConnectionProvider.overrideWith(
+            FF1WifiConnectionNotifier.new,
+          ),
+          tokensSyncCoordinatorProvider.overrideWith(() => tokensSync),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      });
+
+      container.listen(appLifecycleProvider, (_, _) {});
+      await tester.pump();
+      tokensSync.resetCounts();
+
+      await _connectDevice(container);
+      wifiControl.resetLifecycleCounts();
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+      expect(wifiControl.pauseCount, 1);
+      expect(wifiControl.reconnectCount, 0);
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+
+      expect(wifiControl.reconnectCount, 1);
+    },
+  );
+}
+
+Future<void> _connectDevice(ProviderContainer container) {
+  return container.read(ff1WifiConnectionProvider.notifier).connect(
+    device: const FF1Device(
+      name: 'FF1',
+      remoteId: 'remote-1',
+      deviceId: 'device-1',
+      topicId: 'topic-1',
+    ),
+    userId: 'user-1',
+    apiKey: 'api-key-1',
+  );
+}
+
+class _RecordingTokensSyncCoordinator extends TokensSyncCoordinatorNotifier {
+  int syncAllTrackedAddressesCount = 0;
+  int startSyncCollectionPollingCount = 0;
+  int pauseSyncCollectionPollingCount = 0;
+
+  @override
+  TokensSyncState build() => const TokensSyncState();
+
+  @override
+  void startSyncCollectionPolling({
+    Duration interval = const Duration(minutes: 5),
+  }) {
+    startSyncCollectionPollingCount++;
+  }
+
+  @override
+  void pauseSyncCollectionPolling() {
+    pauseSyncCollectionPollingCount++;
+  }
+
+  @override
+  Future<void> syncAllTrackedAddresses() async {
+    syncAllTrackedAddressesCount++;
+  }
+
+  void resetCounts() {
+    syncAllTrackedAddressesCount = 0;
+    startSyncCollectionPollingCount = 0;
+    pauseSyncCollectionPollingCount = 0;
+  }
+}
+
+class _LifecycleAwareFakeWifiControl extends FakeWifiControl {
+  int pauseCount = 0;
+  int reconnectCount = 0;
+
+  @override
+  void pauseConnection() {
+    pauseCount++;
+    super.pauseConnection();
+  }
+
+  @override
+  Future<bool> reconnect() async {
+    reconnectCount++;
+    emitTransportConnection(isConnected: true);
+    return true;
+  }
+
+  void resetLifecycleCounts() {
+    pauseCount = 0;
+    reconnectCount = 0;
+  }
+}

--- a/test/unit/app/providers/ff1_wifi_connect_sentry_reporting_test.dart
+++ b/test/unit/app/providers/ff1_wifi_connect_sentry_reporting_test.dart
@@ -38,7 +38,7 @@ class _ThrowingConnectTransport implements FF1WifiTransport {
   bool get isConnecting => false;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -101,7 +101,7 @@ class _ReconnectSecondCallFailsTransport implements FF1WifiTransport {
   bool get isConnecting => false;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -109,7 +109,7 @@ class _ReconnectSecondCallFailsTransport implements FF1WifiTransport {
   }) async {
     _connectCount++;
     if (_connectCount == 1) {
-      return;
+      return true;
     }
     _errors.add(const FF1WifiNetworkError('reconnect transport failure'));
     throw Exception('reconnect failed');

--- a/test/unit/app/providers/ff1_wifi_providers_test.dart
+++ b/test/unit/app/providers/ff1_wifi_providers_test.dart
@@ -114,11 +114,13 @@ void main() {
         topicId: 'topic-1',
       );
 
-      await container.read(ff1WifiConnectionProvider.notifier).connect(
-        device: device,
-        userId: 'u1',
-        apiKey: 'k1',
-      );
+      await container
+          .read(ff1WifiConnectionProvider.notifier)
+          .connect(
+            device: device,
+            userId: 'u1',
+            apiKey: 'k1',
+          );
       expect(container.read(ff1WifiConnectionProvider).isConnected, isTrue);
 
       await container.read(ff1WifiConnectionProvider.notifier).reconnect();
@@ -151,11 +153,13 @@ void main() {
         topicId: 'topic-1',
       );
 
-      await container.read(ff1WifiConnectionProvider.notifier).connect(
-        device: device,
-        userId: 'u1',
-        apiKey: 'k1',
-      );
+      await container
+          .read(ff1WifiConnectionProvider.notifier)
+          .connect(
+            device: device,
+            userId: 'u1',
+            apiKey: 'k1',
+          );
       expect(container.read(ff1WifiConnectionProvider).isConnected, isTrue);
 
       await container.read(ff1WifiConnectionProvider.notifier).reconnect();
@@ -959,6 +963,120 @@ void main() {
       expect(versionService.deviceVersions, ['2.0.0']);
     },
   );
+
+  test(
+    'reconnect schedules required version check after suppressed initial '
+    'connect',
+    () async {
+      await ensureDotEnvLoaded();
+
+      final deviceService = MockFF1BluetoothDeviceService();
+      final wifiControl = _SuppressedThenReconnectTransportControl(
+        reconnectDeviceStatus: const FF1DeviceStatus(latestVersion: '2.0.0'),
+      );
+      final versionService = _RecordingVersionService();
+      const device = FF1Device(
+        name: 'FF1-A',
+        remoteId: 'remote-a',
+        deviceId: 'device-a',
+        topicId: 'topic-a',
+        branchName: 'main',
+      );
+
+      final container = ProviderContainer.test(
+        overrides: [
+          ff1BluetoothDeviceServiceProvider.overrideWithValue(deviceService),
+          ff1WifiControlProvider.overrideWithValue(wifiControl),
+          ff1WifiConnectionProvider.overrideWith(
+            FF1WifiConnectionNotifier.new,
+          ),
+          versionServiceProvider.overrideWithValue(versionService),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      container.listen(
+        ff1AutoConnectWatcherProvider,
+        (_, _) {},
+      );
+
+      deviceService
+        ..devices = [device]
+        ..activeDeviceId = device.deviceId;
+      container.invalidate(activeFF1BluetoothDeviceProvider);
+      await container.read(activeFF1BluetoothDeviceProvider.future);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(container.read(ff1WifiConnectionProvider).isConnected, isFalse);
+      expect(versionService.deviceVersions, isEmpty);
+
+      await container.read(ff1WifiConnectionProvider.notifier).reconnect();
+      await Future<void>.delayed(const Duration(milliseconds: 120));
+
+      expect(container.read(ff1WifiConnectionProvider).isConnected, isTrue);
+      expect(versionService.deviceVersions, ['2.0.0']);
+    },
+  );
+
+  test(
+    'pause before version status re-arms version check on reconnect',
+    () async {
+      await ensureDotEnvLoaded();
+
+      final deviceService = MockFF1BluetoothDeviceService();
+      final wifiControl = FakeWifiControl();
+      final versionService = _RecordingVersionService();
+      const device = FF1Device(
+        name: 'FF1-A',
+        remoteId: 'remote-a',
+        deviceId: 'device-a',
+        topicId: 'topic-a',
+        branchName: 'main',
+      );
+
+      final container = ProviderContainer.test(
+        overrides: [
+          ff1BluetoothDeviceServiceProvider.overrideWithValue(deviceService),
+          ff1WifiControlProvider.overrideWithValue(wifiControl),
+          ff1WifiConnectionProvider.overrideWith(
+            FF1WifiConnectionNotifier.new,
+          ),
+          versionServiceProvider.overrideWithValue(versionService),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      container.listen(
+        ff1AutoConnectWatcherProvider,
+        (_, _) {},
+      );
+
+      deviceService
+        ..devices = [device]
+        ..activeDeviceId = device.deviceId;
+      container.invalidate(activeFF1BluetoothDeviceProvider);
+      await container.read(activeFF1BluetoothDeviceProvider.future);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(container.read(ff1WifiConnectionProvider).isConnected, isTrue);
+      expect(versionService.deviceVersions, isEmpty);
+
+      container.read(ff1WifiConnectionProvider.notifier).pauseConnection();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(container.read(ff1WifiConnectionProvider).isConnected, isFalse);
+      expect(versionService.deviceVersions, isEmpty);
+
+      await container.read(ff1WifiConnectionProvider.notifier).reconnect();
+      wifiControl.emitDeviceStatus(
+        const FF1DeviceStatus(latestVersion: '2.0.0'),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 120));
+
+      expect(container.read(ff1WifiConnectionProvider).isConnected, isTrue);
+      expect(versionService.deviceVersions, ['2.0.0']);
+    },
+  );
   test(
     'ff1AutoConnectWatcherProvider disconnects the old device before switching',
     () async {
@@ -1162,7 +1280,6 @@ void main() {
       );
     },
   );
-
 }
 
 FF1NotificationMessage _connectionNotification({required bool isConnected}) {
@@ -1421,6 +1538,47 @@ class _AutoStatusWifiControl extends FakeWifiControl {
       emitDeviceStatus(status);
     }
     return ok;
+  }
+}
+
+class _SuppressedThenReconnectTransportControl extends FakeWifiControl {
+  _SuppressedThenReconnectTransportControl({
+    required this.reconnectDeviceStatus,
+  }) : super(transport: _SuppressedThenReconnectTransport());
+
+  final FF1DeviceStatus reconnectDeviceStatus;
+
+  @override
+  Future<bool> reconnect() async {
+    final ok = await super.reconnect();
+    if (ok) {
+      emitDeviceStatus(reconnectDeviceStatus);
+      await Future<void>.delayed(Duration.zero);
+    }
+    return ok;
+  }
+}
+
+class _SuppressedThenReconnectTransport extends FakeWifiTransport {
+  int _connectCount = 0;
+
+  @override
+  Future<bool> connect({
+    required FF1Device device,
+    required String userId,
+    required String apiKey,
+    bool forceReconnect = false,
+  }) async {
+    _connectCount++;
+    if (_connectCount == 1) {
+      return false;
+    }
+    return super.connect(
+      device: device,
+      userId: userId,
+      apiKey: apiKey,
+      forceReconnect: forceReconnect,
+    );
   }
 }
 

--- a/test/unit/app/providers/ff1_wifi_providers_test.dart
+++ b/test/unit/app/providers/ff1_wifi_providers_test.dart
@@ -1207,14 +1207,14 @@ class _StallingWifiTransport extends FakeWifiTransport {
   final Completer<void> until;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
     bool forceReconnect = false,
   }) async {
     await until.future;
-    await super.connect(
+    return super.connect(
       device: device,
       userId: userId,
       apiKey: apiKey,
@@ -1243,7 +1243,7 @@ class _OverlappingNotifierConnectTransport extends FakeWifiTransport {
   }
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -1255,7 +1255,7 @@ class _OverlappingNotifierConnectTransport extends FakeWifiTransport {
     } else if (_connectCount == 2) {
       await _secondConnect.future;
     }
-    await super.connect(
+    return super.connect(
       device: device,
       userId: userId,
       apiKey: apiKey,
@@ -1297,7 +1297,7 @@ class _InspectableWifiTransport implements FF1WifiTransport {
   bool get isConnecting => false;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -1305,6 +1305,7 @@ class _InspectableWifiTransport implements FF1WifiTransport {
   }) async {
     _isConnected = true;
     _connections.add(true);
+    return true;
   }
 
   @override
@@ -1347,7 +1348,7 @@ class _InspectableWifiControl extends FF1WifiControl {
   FF1Device? lastConnectedDevice;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -1358,7 +1359,7 @@ class _InspectableWifiControl extends FF1WifiControl {
       switchConnectPlayerStatus = currentPlayerStatus;
       switchConnectIsDeviceConnected = isDeviceConnected;
     }
-    await super.connect(device: device, userId: userId, apiKey: apiKey);
+    return super.connect(device: device, userId: userId, apiKey: apiKey);
   }
 }
 
@@ -1405,16 +1406,21 @@ class _AutoStatusWifiControl extends FakeWifiControl {
   final Map<String, FF1DeviceStatus> statusesByDeviceId;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
   }) async {
-    await super.connect(device: device, userId: userId, apiKey: apiKey);
+    final ok = await super.connect(
+      device: device,
+      userId: userId,
+      apiKey: apiKey,
+    );
     final status = statusesByDeviceId[device.deviceId];
     if (status != null) {
       emitDeviceStatus(status);
     }
+    return ok;
   }
 }
 
@@ -1472,7 +1478,7 @@ class _BlockingWifiControl extends FF1WifiControl {
   }
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -1484,6 +1490,7 @@ class _BlockingWifiControl extends FF1WifiControl {
       firstConnectStarted.complete();
     }
     await _connectGate.future;
+    return true;
   }
 
   @override
@@ -1511,12 +1518,14 @@ class _NoopWifiTransport implements FF1WifiTransport {
       const Stream<FF1NotificationMessage>.empty();
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
     bool forceReconnect = false,
-  }) async {}
+  }) async {
+    return true;
+  }
 
   @override
   void dispose() {}

--- a/test/unit/app/providers/ff1_wifi_providers_test.dart
+++ b/test/unit/app/providers/ff1_wifi_providers_test.dart
@@ -94,6 +94,79 @@ void main() {
   });
 
   test(
+    'reconnect clears notifier connected when control.reconnect returns false',
+    () async {
+      final wifiControl = _ReconnectFalseControl();
+      final container = ProviderContainer.test(
+        overrides: [
+          ff1WifiControlProvider.overrideWithValue(wifiControl),
+          ff1WifiConnectionProvider.overrideWith(
+            FF1WifiConnectionNotifier.new,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      const device = FF1Device(
+        name: 'FF1',
+        remoteId: 'remote-1',
+        deviceId: 'device-1',
+        topicId: 'topic-1',
+      );
+
+      await container.read(ff1WifiConnectionProvider.notifier).connect(
+        device: device,
+        userId: 'u1',
+        apiKey: 'k1',
+      );
+      expect(container.read(ff1WifiConnectionProvider).isConnected, isTrue);
+
+      await container.read(ff1WifiConnectionProvider.notifier).reconnect();
+
+      final after = container.read(ff1WifiConnectionProvider);
+      expect(after.isConnected, isFalse);
+      expect(after.isConnecting, isFalse);
+      expect(after.device?.deviceId, device.deviceId);
+    },
+  );
+
+  test(
+    'reconnect keeps notifier connected when control.reconnect returns true',
+    () async {
+      final wifiControl = FakeWifiControl();
+      final container = ProviderContainer.test(
+        overrides: [
+          ff1WifiControlProvider.overrideWithValue(wifiControl),
+          ff1WifiConnectionProvider.overrideWith(
+            FF1WifiConnectionNotifier.new,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      const device = FF1Device(
+        name: 'FF1',
+        remoteId: 'remote-1',
+        deviceId: 'device-1',
+        topicId: 'topic-1',
+      );
+
+      await container.read(ff1WifiConnectionProvider.notifier).connect(
+        device: device,
+        userId: 'u1',
+        apiKey: 'k1',
+      );
+      expect(container.read(ff1WifiConnectionProvider).isConnected, isTrue);
+
+      await container.read(ff1WifiConnectionProvider.notifier).reconnect();
+
+      final after = container.read(ff1WifiConnectionProvider);
+      expect(after.isConnected, isTrue);
+      expect(after.isConnecting, isFalse);
+    },
+  );
+
+  test(
     'stale connect completion does not clear newer connect spinner',
     () async {
       final transport = _OverlappingNotifierConnectTransport();
@@ -1314,6 +1387,14 @@ class _RecordingVersionService extends VersionService {
     deviceVersions.add(deviceVersion);
     return VersionCompatibilityResult.compatible;
   }
+}
+
+/// Control that always reports reconnect failure (notifier must clear state).
+class _ReconnectFalseControl extends FakeWifiControl {
+  _ReconnectFalseControl() : super();
+
+  @override
+  Future<bool> reconnect() async => false;
 }
 
 class _AutoStatusWifiControl extends FakeWifiControl {

--- a/test/unit/app/providers/ff1_wifi_providers_test.dart
+++ b/test/unit/app/providers/ff1_wifi_providers_test.dart
@@ -52,6 +52,112 @@ void main() {
     expect(container.read(ff1WifiConnectionProvider).isConnected, isFalse);
   });
 
+  test('pauseConnection clears isConnecting if connect awaits', () async {
+    final stall = Completer<void>();
+    final transport = _StallingWifiTransport(stall);
+    final wifiControl = FakeWifiControl(transport: transport);
+
+    final container = ProviderContainer.test(
+      overrides: [
+        ff1WifiControlProvider.overrideWithValue(wifiControl),
+        ff1WifiConnectionProvider.overrideWith(
+          FF1WifiConnectionNotifier.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    const device = FF1Device(
+      name: 'FF1',
+      remoteId: 'remote-1',
+      deviceId: 'device-1',
+      topicId: 'topic-1',
+    );
+
+    final notifier = container.read(ff1WifiConnectionProvider.notifier);
+    final connectFuture = notifier.connect(
+      device: device,
+      userId: 'u1',
+      apiKey: 'k1',
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    expect(container.read(ff1WifiConnectionProvider).isConnecting, isTrue);
+
+    notifier.pauseConnection();
+    expect(container.read(ff1WifiConnectionProvider).isConnecting, isFalse);
+
+    stall.complete();
+    await connectFuture;
+
+    expect(container.read(ff1WifiConnectionProvider).isConnecting, isFalse);
+  });
+
+  test(
+    'stale connect completion does not clear newer connect spinner',
+    () async {
+      final transport = _OverlappingNotifierConnectTransport();
+      final wifiControl = FakeWifiControl(transport: transport);
+
+      final container = ProviderContainer.test(
+        overrides: [
+          ff1WifiControlProvider.overrideWithValue(wifiControl),
+          ff1WifiConnectionProvider.overrideWith(
+            FF1WifiConnectionNotifier.new,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      const deviceA = FF1Device(
+        name: 'FF1-A',
+        remoteId: 'remote-1',
+        deviceId: 'device-1',
+        topicId: 'topic-1',
+      );
+      const deviceB = FF1Device(
+        name: 'FF1-B',
+        remoteId: 'remote-2',
+        deviceId: 'device-2',
+        topicId: 'topic-2',
+      );
+
+      final notifier = container.read(ff1WifiConnectionProvider.notifier);
+      final connectA = notifier.connect(
+        device: deviceA,
+        userId: 'u1',
+        apiKey: 'k1',
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      final connectB = notifier.connect(
+        device: deviceB,
+        userId: 'u1',
+        apiKey: 'k1',
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      expect(container.read(ff1WifiConnectionProvider).isConnecting, isTrue);
+
+      transport.releaseFirstConnect();
+      await connectA;
+
+      final stateAfterStaleCompletion = container.read(
+        ff1WifiConnectionProvider,
+      );
+      expect(stateAfterStaleCompletion.isConnecting, isTrue);
+      expect(stateAfterStaleCompletion.device?.deviceId, deviceB.deviceId);
+
+      transport.releaseSecondConnect();
+      await connectB;
+
+      final finalState = container.read(ff1WifiConnectionProvider);
+      expect(finalState.isConnecting, isFalse);
+      expect(finalState.isConnected, isTrue);
+      expect(finalState.device?.deviceId, deviceB.deviceId);
+    },
+  );
+
   test(
     'ff1AutoConnectWatcherProvider connects when active device is set',
     () async {
@@ -1019,6 +1125,70 @@ FF1NotificationMessage _playerStatusNotification({
     notificationType: FF1NotificationType.playerStatus,
     timestamp: DateTime.fromMillisecondsSinceEpoch(0),
   );
+}
+
+/// Delays [FakeWifiTransport.connect] until [until] completes (race tests).
+class _StallingWifiTransport extends FakeWifiTransport {
+  _StallingWifiTransport(this.until);
+
+  final Completer<void> until;
+
+  @override
+  Future<void> connect({
+    required FF1Device device,
+    required String userId,
+    required String apiKey,
+    bool forceReconnect = false,
+  }) async {
+    await until.future;
+    await super.connect(
+      device: device,
+      userId: userId,
+      apiKey: apiKey,
+      forceReconnect: forceReconnect,
+    );
+  }
+}
+
+/// Holds two connect calls open independently so notifier tests can verify that
+/// a stale completion never clears the spinner owned by the newer connect.
+class _OverlappingNotifierConnectTransport extends FakeWifiTransport {
+  final Completer<void> _firstConnect = Completer<void>();
+  final Completer<void> _secondConnect = Completer<void>();
+  int _connectCount = 0;
+
+  void releaseFirstConnect() {
+    if (!_firstConnect.isCompleted) {
+      _firstConnect.complete();
+    }
+  }
+
+  void releaseSecondConnect() {
+    if (!_secondConnect.isCompleted) {
+      _secondConnect.complete();
+    }
+  }
+
+  @override
+  Future<void> connect({
+    required FF1Device device,
+    required String userId,
+    required String apiKey,
+    bool forceReconnect = false,
+  }) async {
+    _connectCount++;
+    if (_connectCount == 1) {
+      await _firstConnect.future;
+    } else if (_connectCount == 2) {
+      await _secondConnect.future;
+    }
+    await super.connect(
+      device: device,
+      userId: userId,
+      apiKey: apiKey,
+      forceReconnect: forceReconnect,
+    );
+  }
 }
 
 class _InspectableWifiTransport implements FF1WifiTransport {

--- a/test/unit/app/providers/provider_test_helpers.dart
+++ b/test/unit/app/providers/provider_test_helpers.dart
@@ -233,7 +233,7 @@ class FakeWifiTransport implements FF1WifiTransport {
   bool get isConnecting => _isConnecting;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -243,6 +243,7 @@ class FakeWifiTransport implements FF1WifiTransport {
     _isConnected = true;
     _isConnecting = false;
     _connections.add(true);
+    return true;
   }
 
   @override
@@ -333,14 +334,14 @@ class FakeWifiControl extends FF1WifiControl {
   FF1Device? lastConnectedDevice;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
   }) async {
     connectCalled = true;
     lastConnectedDevice = device;
-    await super.connect(device: device, userId: userId, apiKey: apiKey);
+    return super.connect(device: device, userId: userId, apiKey: apiKey);
   }
 
   @override

--- a/test/unit/infra/ff1/ff1_relayer_transport_test.dart
+++ b/test/unit/infra/ff1/ff1_relayer_transport_test.dart
@@ -234,4 +234,57 @@ void main() {
       );
     },
   );
+
+  test(
+    'connect(forceReconnect) returns false when pause wins during disconnect '
+    'teardown (PR #361 review 4098103277)',
+    () async {
+      late FF1RelayerTransport transport;
+      transport = FF1RelayerTransport(
+        relayerUrl: 'wss://example.invalid/relayer',
+        debugBeforeDisconnectGraceDelay: () async {
+          transport.pauseConnection();
+        },
+      );
+      const device = FF1Device(
+        name: 'FF1',
+        remoteId: 'remote-1',
+        deviceId: 'device-1',
+        topicId: 'topic-1',
+      );
+
+      final firstConnected = Completer<void>();
+      final sub = transport.connectionStateStream.listen((connected) {
+        if (connected && !firstConnected.isCompleted) {
+          firstConnected.complete();
+        }
+      });
+      addTearDown(() async {
+        await sub.cancel();
+        await transport.disposeFuture();
+      });
+
+      final ok1 = await transport.connect(
+        device: device,
+        userId: 'user-1',
+        apiKey: 'api-key-1',
+      );
+      expect(ok1, isTrue);
+      await firstConnected.future.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () {
+          fail('expected live socket before pause-during-disconnect test');
+        },
+      );
+
+      final ok2 = await transport.connect(
+        device: device,
+        userId: 'user-1',
+        apiKey: 'api-key-1',
+        forceReconnect: true,
+      );
+      expect(ok2, isFalse);
+      expect(transport.isConnected, isFalse);
+    },
+  );
 }

--- a/test/unit/infra/ff1/ff1_relayer_transport_test.dart
+++ b/test/unit/infra/ff1/ff1_relayer_transport_test.dart
@@ -177,4 +177,61 @@ void main() {
       expect(transport.isConnected, isFalse);
     },
   );
+
+  test(
+    'connect(forceReconnect: true) after live socket dispatches replacement '
+    'session (no self-suppression)',
+    () async {
+      final transport = FF1RelayerTransport(
+        relayerUrl: 'wss://example.invalid/relayer',
+      );
+      const device = FF1Device(
+        name: 'FF1',
+        remoteId: 'remote-1',
+        deviceId: 'device-1',
+        topicId: 'topic-1',
+      );
+
+      final firstConnected = Completer<void>();
+      final sub = transport.connectionStateStream.listen((connected) {
+        if (connected && !firstConnected.isCompleted) {
+          firstConnected.complete();
+        }
+      });
+      addTearDown(() async {
+        await sub.cancel();
+        await transport.disposeFuture();
+      });
+
+      final ok1 = await transport.connect(
+        device: device,
+        userId: 'user-1',
+        apiKey: 'api-key-1',
+      );
+      expect(ok1, isTrue);
+      await firstConnected.future.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () {
+          fail(
+            'expected relayer isolate to emit connected (live socket) before '
+            'forceReconnect regression assertions',
+          );
+        },
+      );
+      expect(transport.isConnected, isTrue);
+
+      final ok2 = await transport.connect(
+        device: device,
+        userId: 'user-1',
+        apiKey: 'api-key-1',
+        forceReconnect: true,
+      );
+      expect(
+        ok2,
+        isTrue,
+        reason: 'forceReconnect must open a new session after disconnect; '
+            'must not return false solely because disconnect() set suppression',
+      );
+    },
+  );
 }

--- a/test/unit/infra/ff1/ff1_relayer_transport_test.dart
+++ b/test/unit/infra/ff1/ff1_relayer_transport_test.dart
@@ -93,9 +93,13 @@ void main() {
       // If completer wasn't reset, cycle 2 would complete immediately (< 50ms).
       // With proper reset, cycle 2 should also have the 100ms delay from
       // teardown.
-      expect(cycle2Duration.inMilliseconds, greaterThan(80),
-          reason: 'Cycle 2 must execute full teardown, not reuse completed '
-              'completer from cycle 1 (proves completer was reset)');
+      expect(
+        cycle2Duration.inMilliseconds,
+        greaterThan(80),
+        reason:
+            'Cycle 2 must execute full teardown, not reuse completed '
+            'completer from cycle 1 (proves completer was reset)',
+      );
     },
   );
 
@@ -229,7 +233,8 @@ void main() {
       expect(
         ok2,
         isTrue,
-        reason: 'forceReconnect must open a new session after disconnect; '
+        reason:
+            'forceReconnect must open a new session after disconnect; '
             'must not return false solely because disconnect() set suppression',
       );
     },
@@ -283,6 +288,80 @@ void main() {
         apiKey: 'api-key-1',
         forceReconnect: true,
       );
+      expect(ok2, isFalse);
+      expect(transport.isConnected, isFalse);
+    },
+  );
+
+  test(
+    'connect(forceReconnect) aborts when pause wins while waiting for prior '
+    'teardown',
+    () async {
+      final reachedTeardownWait = Completer<void>();
+      final releaseTeardown = Completer<void>();
+      late FF1RelayerTransport transport;
+      transport = FF1RelayerTransport(
+        relayerUrl: 'wss://example.invalid/relayer',
+        debugBeforeDisconnectGraceDelay: () async {
+          if (!reachedTeardownWait.isCompleted) {
+            reachedTeardownWait.complete();
+          }
+          await releaseTeardown.future;
+        },
+      );
+      const device = FF1Device(
+        name: 'FF1',
+        remoteId: 'remote-1',
+        deviceId: 'device-1',
+        topicId: 'topic-1',
+      );
+
+      final firstConnected = Completer<void>();
+      final sub = transport.connectionStateStream.listen((connected) {
+        if (connected && !firstConnected.isCompleted) {
+          firstConnected.complete();
+        }
+      });
+      addTearDown(() async {
+        await sub.cancel();
+        await transport.disposeFuture();
+      });
+
+      final ok1 = await transport.connect(
+        device: device,
+        userId: 'user-1',
+        apiKey: 'api-key-1',
+      );
+      expect(ok1, isTrue);
+      await firstConnected.future.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () {
+          fail('expected live socket before teardown-wait pause test');
+        },
+      );
+
+      final disconnectFuture = transport.disconnect();
+      await reachedTeardownWait.future.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () {
+          fail('expected disconnect teardown to enter grace delay');
+        },
+      );
+
+      final connectFuture = transport.connect(
+        device: device,
+        userId: 'user-1',
+        apiKey: 'api-key-1',
+        forceReconnect: true,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      transport.pauseConnection();
+      releaseTeardown.complete();
+
+      final ok2 = await connectFuture;
+      await disconnectFuture;
+
       expect(ok2, isFalse);
       expect(transport.isConnected, isFalse);
     },
@@ -347,8 +426,8 @@ void main() {
             apiKey: 'api-key-1',
           )
           .then((_) {
-        thirdCompleted = true;
-      });
+            thirdCompleted = true;
+          });
 
       await Future<void>.delayed(const Duration(milliseconds: 50));
       expect(

--- a/test/unit/infra/ff1/ff1_relayer_transport_test.dart
+++ b/test/unit/infra/ff1/ff1_relayer_transport_test.dart
@@ -123,9 +123,10 @@ void main() {
       await reachedDispatchBoundary.future;
       transport.pauseConnection();
       releaseDispatch.complete();
-      await connectFuture;
+      final connectOk = await connectFuture;
       await Future<void>.delayed(const Duration(milliseconds: 250));
 
+      expect(connectOk, isFalse);
       expect(events.where((isConnected) => isConnected), isEmpty);
       expect(transport.isConnected, isFalse);
     },

--- a/test/unit/infra/ff1/ff1_relayer_transport_test.dart
+++ b/test/unit/infra/ff1/ff1_relayer_transport_test.dart
@@ -5,6 +5,52 @@ import 'package:app/infra/ff1/wifi_transport/ff1_relayer_transport.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('relayerDisconnectEventAppliesToSession', () {
+    test('ignores stale gen vs active session', () {
+      expect(
+        relayerDisconnectEventAppliesToSession(
+          eventConnectGen: 1,
+          activeRelayerConnectGen: 2,
+          expectedConnectedGen: null,
+        ),
+        isFalse,
+      );
+    });
+
+    test('accepts disconnect for active socket gen', () {
+      expect(
+        relayerDisconnectEventAppliesToSession(
+          eventConnectGen: 2,
+          activeRelayerConnectGen: 2,
+          expectedConnectedGen: null,
+        ),
+        isTrue,
+      );
+    });
+
+    test('accepts disconnect for in-flight expected gen', () {
+      expect(
+        relayerDisconnectEventAppliesToSession(
+          eventConnectGen: 3,
+          activeRelayerConnectGen: null,
+          expectedConnectedGen: 3,
+        ),
+        isTrue,
+      );
+    });
+
+    test('legacy null gen still applies', () {
+      expect(
+        relayerDisconnectEventAppliesToSession(
+          eventConnectGen: null,
+          activeRelayerConnectGen: 2,
+          expectedConnectedGen: 4,
+        ),
+        isTrue,
+      );
+    });
+  });
+
   test(
     'dispose awaits disconnect before closing connection state stream',
     () async {

--- a/test/unit/infra/ff1/ff1_relayer_transport_test.dart
+++ b/test/unit/infra/ff1/ff1_relayer_transport_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:app/domain/models/ff1_device.dart';
 import 'package:app/infra/ff1/wifi_transport/ff1_relayer_transport.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -15,7 +18,8 @@ void main() {
   );
 
   test(
-    'concurrent disconnect calls share single teardown completer (cycle 1 and 2)',
+    'concurrent disconnect calls share single teardown completer '
+    '(cycle 1 and 2)',
     () async {
       final transport = FF1RelayerTransport(
         relayerUrl: 'wss://example.invalid/relayer',
@@ -41,7 +45,8 @@ void main() {
       final cycle2Duration = DateTime.now().difference(cycle2Start);
 
       // If completer wasn't reset, cycle 2 would complete immediately (< 50ms).
-      // With proper reset, cycle 2 should also have the 100ms delay from teardown.
+      // With proper reset, cycle 2 should also have the 100ms delay from
+      // teardown.
       expect(cycle2Duration.inMilliseconds, greaterThan(80),
           reason: 'Cycle 2 must execute full teardown, not reuse completed '
               'completer from cycle 1 (proves completer was reset)');
@@ -53,10 +58,7 @@ void main() {
     () async {
       final transport = FF1RelayerTransport(
         relayerUrl: 'wss://example.invalid/relayer',
-      );
-
-      // Call dispose
-      transport.dispose();
+      )..dispose();
 
       // Wait for any pending async operations
       await Future<void>.delayed(const Duration(milliseconds: 200));
@@ -67,14 +69,12 @@ void main() {
   );
 
   test(
-    'connectionStateStream does not throw when added to after close during dispose',
+    'connectionStateStream does not throw when added to after close '
+    'during dispose',
     () async {
       final transport = FF1RelayerTransport(
         relayerUrl: 'wss://example.invalid/relayer',
-      );
-
-      // Dispose the transport
-      transport.dispose();
+      )..dispose();
 
       // Wait to allow async dispose to complete
       await Future<void>.delayed(const Duration(milliseconds: 200));
@@ -86,6 +86,48 @@ void main() {
         },
         returnsNormally,
       );
+    },
+  );
+
+  test(
+    'pause skips queued connect control before it reaches isolate',
+    () async {
+      final reachedDispatchBoundary = Completer<void>();
+      final releaseDispatch = Completer<void>();
+      final transport = FF1RelayerTransport(
+        relayerUrl: 'wss://example.invalid/relayer',
+        debugBeforeConnectControlDispatch: () {
+          reachedDispatchBoundary.complete();
+          return releaseDispatch.future;
+        },
+      );
+      final events = <bool>[];
+      final sub = transport.connectionStateStream.listen(events.add);
+
+      addTearDown(() async {
+        await sub.cancel();
+        await transport.disposeFuture();
+      });
+
+      final connectFuture = transport.connect(
+        device: const FF1Device(
+          name: 'FF1',
+          remoteId: 'remote-1',
+          deviceId: 'device-1',
+          topicId: 'topic-1',
+        ),
+        userId: 'user-1',
+        apiKey: 'api-key-1',
+      );
+
+      await reachedDispatchBoundary.future;
+      transport.pauseConnection();
+      releaseDispatch.complete();
+      await connectFuture;
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+
+      expect(events.where((isConnected) => isConnected), isEmpty);
+      expect(transport.isConnected, isFalse);
     },
   );
 }

--- a/test/unit/infra/ff1/ff1_relayer_transport_test.dart
+++ b/test/unit/infra/ff1/ff1_relayer_transport_test.dart
@@ -49,6 +49,17 @@ void main() {
         isTrue,
       );
     });
+
+    test('stale notification/error gen does not apply to current session', () {
+      expect(
+        relayerDisconnectEventAppliesToSession(
+          eventConnectGen: 1,
+          activeRelayerConnectGen: 2,
+          expectedConnectedGen: 2,
+        ),
+        isFalse,
+      );
+    });
   });
 
   test(

--- a/test/unit/infra/ff1/ff1_relayer_transport_test.dart
+++ b/test/unit/infra/ff1/ff1_relayer_transport_test.dart
@@ -287,4 +287,80 @@ void main() {
       expect(transport.isConnected, isFalse);
     },
   );
+
+  test(
+    'connect waits for in-flight disconnect teardown before proceeding '
+    '(PR #361 review 4098243960)',
+    () async {
+      final releaseTeardown = Completer<void>();
+      late FF1RelayerTransport transport;
+      transport = FF1RelayerTransport(
+        relayerUrl: 'wss://example.invalid/relayer',
+        debugBeforeDisconnectGraceDelay: () async {
+          await releaseTeardown.future;
+        },
+      );
+      const device = FF1Device(
+        name: 'FF1',
+        remoteId: 'remote-1',
+        deviceId: 'device-1',
+        topicId: 'topic-1',
+      );
+
+      final firstConnected = Completer<void>();
+      final sub = transport.connectionStateStream.listen((connected) {
+        if (connected && !firstConnected.isCompleted) {
+          firstConnected.complete();
+        }
+      });
+      addTearDown(() async {
+        await sub.cancel();
+        await transport.disposeFuture();
+      });
+
+      await transport.connect(
+        device: device,
+        userId: 'user-1',
+        apiKey: 'api-key-1',
+      );
+      await firstConnected.future.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () {
+          fail('expected live socket before teardown-wait test');
+        },
+      );
+
+      final secondReconnect = transport.connect(
+        device: device,
+        userId: 'user-1',
+        apiKey: 'api-key-1',
+        forceReconnect: true,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      var thirdCompleted = false;
+      final thirdConnect = transport
+          .connect(
+            device: device,
+            userId: 'user-1',
+            apiKey: 'api-key-1',
+          )
+          .then((_) {
+        thirdCompleted = true;
+      });
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        thirdCompleted,
+        isFalse,
+        reason: 'third connect must wait for teardown, not run ahead of it',
+      );
+
+      releaseTeardown.complete();
+      await secondReconnect;
+      await thirdConnect;
+      expect(thirdCompleted, isTrue);
+    },
+  );
 }

--- a/test/unit/infra/ff1/ff1_wifi_control_test.dart
+++ b/test/unit/infra/ff1/ff1_wifi_control_test.dart
@@ -193,6 +193,26 @@ void main() {
     );
   });
 
+  group('FF1WifiControl.connect transport dispatch flag', () {
+    test('returns false when transport reports connect not dispatched', () async {
+      final transport = _SuppressedDispatchTransport();
+      final control = FF1WifiControl(transport: transport);
+      addTearDown(control.dispose);
+      const device = FF1Device(
+        name: 'FF1',
+        remoteId: 'remote',
+        deviceId: 'device',
+        topicId: 'topic',
+      );
+      final ok = await control.connect(
+        device: device,
+        userId: 'user',
+        apiKey: 'key',
+      );
+      expect(ok, isFalse);
+    });
+  });
+
   group('FF1WifiControl.getDeviceRealtimeMetrics', () {
     test(
       'uses default 6 second timeout for realtime metrics request',
@@ -509,7 +529,7 @@ class _StallThenThrowTransport implements FF1WifiTransport {
   bool get isConnecting => false;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -567,7 +587,7 @@ class _HappyReconnectTransport implements FF1WifiTransport {
   bool get isConnecting => false;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -576,6 +596,7 @@ class _HappyReconnectTransport implements FF1WifiTransport {
     if (forceReconnect) {
       forceReconnectConnectCount++;
     }
+    return true;
   }
 
   @override
@@ -633,7 +654,7 @@ class _ReconnectRaceTransport implements FF1WifiTransport {
   bool get isConnecting => false;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -644,6 +665,7 @@ class _ReconnectRaceTransport implements FF1WifiTransport {
       _pendingSecondConnect = Completer<void>();
       await _pendingSecondConnect!.future;
     }
+    return true;
   }
 
   @override
@@ -703,7 +725,7 @@ class _OverlappingConnectTransport implements FF1WifiTransport {
   bool get isConnecting => false;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
@@ -713,14 +735,70 @@ class _OverlappingConnectTransport implements FF1WifiTransport {
     if (_connectCalls == 1) {
       _firstConnectBlock = Completer<void>();
       await _firstConnectBlock!.future;
-      return;
+      return true;
     }
+    return true;
   }
 
   @override
   void pauseConnection() {
     pauseConnectionCount++;
   }
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> sendCommand(Map<String, dynamic> command) async {}
+
+  @override
+  void dispose() {
+    unawaited(_notifications.close());
+    unawaited(_connections.close());
+    unawaited(_errors.close());
+  }
+
+  @override
+  Future<void> disposeFuture() async {
+    dispose();
+  }
+}
+
+/// Minimal transport: [connect] completes with `false` (relayer suppressed
+/// before connect control — PR #361).
+class _SuppressedDispatchTransport implements FF1WifiTransport {
+  final _notifications = StreamController<FF1NotificationMessage>.broadcast();
+  final _connections = StreamController<bool>.broadcast();
+  final _errors = StreamController<FF1WifiTransportError>.broadcast();
+
+  @override
+  Stream<bool> get connectionStateStream => _connections.stream;
+
+  @override
+  Stream<FF1NotificationMessage> get notificationStream =>
+      _notifications.stream;
+
+  @override
+  Stream<FF1WifiTransportError> get errorStream => _errors.stream;
+
+  @override
+  bool get isConnected => false;
+
+  @override
+  bool get isConnecting => false;
+
+  @override
+  Future<bool> connect({
+    required FF1Device device,
+    required String userId,
+    required String apiKey,
+    bool forceReconnect = false,
+  }) async {
+    return false;
+  }
+
+  @override
+  void pauseConnection() {}
 
   @override
   Future<void> disconnect() async {}
@@ -802,12 +880,14 @@ class _DelayedConnectionFalseAfterDisconnectTransport
   bool get isConnecting => false;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
     bool forceReconnect = false,
-  }) async {}
+  }) async {
+    return true;
+  }
 
   @override
   void pauseConnection() {}
@@ -853,12 +933,14 @@ class _FakeWifiTransport implements FF1WifiTransport {
   Stream<FF1NotificationMessage> get notificationStream => const Stream.empty();
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
     bool forceReconnect = false,
-  }) async {}
+  }) async {
+    return true;
+  }
 
   @override
   void pauseConnection() {}
@@ -907,12 +989,14 @@ class _NotificationTestTransport implements FF1WifiTransport {
       _notifications.stream;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
     bool forceReconnect = false,
-  }) async {}
+  }) async {
+    return true;
+  }
 
   @override
   void pauseConnection() {}
@@ -959,12 +1043,14 @@ class _CustomDisposeTransport implements FF1WifiTransport {
   Stream<FF1NotificationMessage> get notificationStream => const Stream.empty();
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
     bool forceReconnect = false,
-  }) async {}
+  }) async {
+    return true;
+  }
 
   @override
   void pauseConnection() {}
@@ -1008,12 +1094,14 @@ class _SwitchingTransport implements FF1WifiTransport {
   bool get isConnecting => false;
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
     bool forceReconnect = false,
-  }) async {}
+  }) async {
+    return true;
+  }
 
   void emitNotification(FF1NotificationMessage notification) {
     _notifications.add(notification);

--- a/test/unit/infra/ff1/ff1_wifi_control_test.dart
+++ b/test/unit/infra/ff1/ff1_wifi_control_test.dart
@@ -194,23 +194,26 @@ void main() {
   });
 
   group('FF1WifiControl.connect transport dispatch flag', () {
-    test('returns false when transport reports connect not dispatched', () async {
-      final transport = _SuppressedDispatchTransport();
-      final control = FF1WifiControl(transport: transport);
-      addTearDown(control.dispose);
-      const device = FF1Device(
-        name: 'FF1',
-        remoteId: 'remote',
-        deviceId: 'device',
-        topicId: 'topic',
-      );
-      final ok = await control.connect(
-        device: device,
-        userId: 'user',
-        apiKey: 'key',
-      );
-      expect(ok, isFalse);
-    });
+    test(
+      'returns false when transport reports connect not dispatched',
+      () async {
+        final transport = _SuppressedDispatchTransport();
+        final control = FF1WifiControl(transport: transport);
+        addTearDown(control.dispose);
+        const device = FF1Device(
+          name: 'FF1',
+          remoteId: 'remote',
+          deviceId: 'device',
+          topicId: 'topic',
+        );
+        final ok = await control.connect(
+          device: device,
+          userId: 'user',
+          apiKey: 'key',
+        );
+        expect(ok, isFalse);
+      },
+    );
   });
 
   group('FF1WifiControl.getDeviceRealtimeMetrics', () {
@@ -313,60 +316,63 @@ void main() {
   });
 
   group('FF1WifiControl.connect', () {
-    test('clears replayed device state when switching to a different device', () async {
-      final transport = _SwitchingTransport();
-      final control = FF1WifiControl(transport: transport);
+    test(
+      'clears replayed device state when switching to a different device',
+      () async {
+        final transport = _SwitchingTransport();
+        final control = FF1WifiControl(transport: transport);
 
-      addTearDown(control.dispose);
+        addTearDown(control.dispose);
 
-      const deviceA = FF1Device(
-        name: 'FF1 A',
-        remoteId: 'remote-a',
-        deviceId: 'device-a',
-        topicId: 'topic-a',
-      );
-      const deviceB = FF1Device(
-        name: 'FF1 B',
-        remoteId: 'remote-b',
-        deviceId: 'device-b',
-        topicId: 'topic-b',
-      );
+        const deviceA = FF1Device(
+          name: 'FF1 A',
+          remoteId: 'remote-a',
+          deviceId: 'device-a',
+          topicId: 'topic-a',
+        );
+        const deviceB = FF1Device(
+          name: 'FF1 B',
+          remoteId: 'remote-b',
+          deviceId: 'device-b',
+          topicId: 'topic-b',
+        );
 
-      await control.connect(device: deviceA, userId: 'u', apiKey: 'k');
-      transport.emitNotification(
-        FF1NotificationMessage(
-          type: FF1WifiMessageType.notification,
-          notificationType: FF1NotificationType.deviceStatus,
-          timestamp: DateTime.fromMillisecondsSinceEpoch(1),
-          message: const {
-            'installedVersion': '1.0.0',
-            'latestVersion': '2.0.0',
-          },
-        ),
-      );
-      transport.emitNotification(
-        FF1NotificationMessage(
-          type: FF1WifiMessageType.notification,
-          notificationType: FF1NotificationType.connection,
-          timestamp: DateTime.fromMillisecondsSinceEpoch(2),
-          message: const {'isConnected': true},
-        ),
-      );
-      await Future<void>.delayed(Duration.zero);
+        await control.connect(device: deviceA, userId: 'u', apiKey: 'k');
+        transport.emitNotification(
+          FF1NotificationMessage(
+            type: FF1WifiMessageType.notification,
+            notificationType: FF1NotificationType.deviceStatus,
+            timestamp: DateTime.fromMillisecondsSinceEpoch(1),
+            message: const {
+              'installedVersion': '1.0.0',
+              'latestVersion': '2.0.0',
+            },
+          ),
+        );
+        transport.emitNotification(
+          FF1NotificationMessage(
+            type: FF1WifiMessageType.notification,
+            notificationType: FF1NotificationType.connection,
+            timestamp: DateTime.fromMillisecondsSinceEpoch(2),
+            message: const {'isConnected': true},
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
 
-      expect(control.currentDeviceStatus?.latestVersion, '2.0.0');
-      expect(control.isDeviceConnected, isTrue);
+        expect(control.currentDeviceStatus?.latestVersion, '2.0.0');
+        expect(control.isDeviceConnected, isTrue);
 
-      final nextDisconnected = control.connectionStatusStream.firstWhere(
-        (status) => !status.isConnected,
-      );
+        final nextDisconnected = control.connectionStatusStream.firstWhere(
+          (status) => !status.isConnected,
+        );
 
-      await control.connect(device: deviceB, userId: 'u', apiKey: 'k');
+        await control.connect(device: deviceB, userId: 'u', apiKey: 'k');
 
-      expect(control.currentDeviceStatus, isNull);
-      expect(control.isDeviceConnected, isFalse);
-      expect((await nextDisconnected).isConnected, isFalse);
-    });
+        expect(control.currentDeviceStatus, isNull);
+        expect(control.isDeviceConnected, isFalse);
+        expect((await nextDisconnected).isConnected, isFalse);
+      },
+    );
 
     test(
       'superseded connect completion does not pause transport over newer '
@@ -476,6 +482,34 @@ void main() {
         // Stale reconnect must not call transport.pause (only the explicit
         // control.pauseConnection above should).
         expect(transport.pauseConnectionCount, 1);
+      },
+    );
+
+    test(
+      'captures the first fresh device status when reconnect emits it before returning',
+      () async {
+        final transport = _ReconnectEmitsEarlyStatusTransport();
+        final control = FF1WifiControl(transport: transport);
+
+        addTearDown(control.dispose);
+
+        const device = FF1Device(
+          name: 'FF1',
+          remoteId: 'remote-1',
+          deviceId: 'device-1',
+          topicId: 'topic-1',
+        );
+
+        await control.connect(device: device, userId: 'u', apiKey: 'k');
+
+        final reconnectFuture = control.reconnect();
+        await Future<void>.delayed(Duration.zero);
+        final status = await control.freshDeviceStatusFuture();
+        final ok = await reconnectFuture;
+
+        expect(ok, isTrue);
+        expect(status?.latestVersion, '2.0.0');
+        expect(status?.installedVersion, '1.0.0');
       },
     );
 
@@ -596,6 +630,78 @@ class _HappyReconnectTransport implements FF1WifiTransport {
     if (forceReconnect) {
       forceReconnectConnectCount++;
     }
+    return true;
+  }
+
+  @override
+  void pauseConnection() {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> sendCommand(Map<String, dynamic> command) async {}
+
+  @override
+  void dispose() {
+    unawaited(_notifications.close());
+    unawaited(_connections.close());
+    unawaited(_errors.close());
+  }
+
+  @override
+  Future<void> disposeFuture() async {
+    dispose();
+  }
+}
+
+/// Emits the first reconnect device status before returning from connect.
+class _ReconnectEmitsEarlyStatusTransport implements FF1WifiTransport {
+  final _notifications = StreamController<FF1NotificationMessage>.broadcast();
+  final _connections = StreamController<bool>.broadcast();
+  final _errors = StreamController<FF1WifiTransportError>.broadcast();
+
+  int _connectCalls = 0;
+
+  @override
+  Stream<bool> get connectionStateStream => _connections.stream;
+
+  @override
+  Stream<FF1NotificationMessage> get notificationStream =>
+      _notifications.stream;
+
+  @override
+  Stream<FF1WifiTransportError> get errorStream => _errors.stream;
+
+  @override
+  bool get isConnected => true;
+
+  @override
+  bool get isConnecting => false;
+
+  @override
+  Future<bool> connect({
+    required FF1Device device,
+    required String userId,
+    required String apiKey,
+    bool forceReconnect = false,
+  }) async {
+    _connectCalls++;
+    if (_connectCalls == 1) {
+      return true;
+    }
+
+    _notifications.add(
+      FF1NotificationMessage(
+        type: FF1WifiMessageType.notification,
+        notificationType: FF1NotificationType.deviceStatus,
+        message: const {
+          'installedVersion': '1.0.0',
+          'latestVersion': '2.0.0',
+        },
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1),
+      ),
+    );
     return true;
   }
 

--- a/test/unit/infra/ff1/ff1_wifi_control_test.dart
+++ b/test/unit/infra/ff1/ff1_wifi_control_test.dart
@@ -143,7 +143,7 @@ void main() {
         );
         await Future<void>.delayed(Duration.zero);
 
-        transport.emitConnectionState(false);
+        transport.emitConnectionState(connected: false);
         await Future<void>.delayed(Duration.zero);
 
         final clearedStatus = await control.ffpDdcPanelStatusStream.first;
@@ -348,6 +348,115 @@ void main() {
       expect((await nextDisconnected).isConnected, isFalse);
     });
   });
+
+  group('FF1WifiControl.reconnect', () {
+    test(
+      'returns false and tears down transport when superseded before '
+      'transport connect completes',
+      () async {
+        final transport = _ReconnectRaceTransport();
+        final control = FF1WifiControl(transport: transport);
+
+        addTearDown(control.dispose);
+
+        const device = FF1Device(
+          name: 'FF1',
+          remoteId: 'remote-1',
+          deviceId: 'device-1',
+          topicId: 'topic-1',
+        );
+
+        await control.connect(
+          device: device,
+          userId: 'u',
+          apiKey: 'k',
+        );
+        expect(transport.connectInvocationCount, 1);
+
+        final reconnectFuture = control.reconnect();
+        await Future<void>.delayed(Duration.zero);
+        expect(transport.connectInvocationCount, 2);
+
+        control.pauseConnection();
+
+        transport.releasePendingConnect();
+
+        final ok = await reconnectFuture;
+        expect(ok, isFalse);
+        expect(transport.pauseConnectionCount, greaterThanOrEqualTo(1));
+      },
+    );
+  });
+}
+
+/// First [connect] completes immediately; second [connect] (reconnect) awaits
+/// [releasePendingConnect] so tests can interleave [pauseConnection].
+class _ReconnectRaceTransport implements FF1WifiTransport {
+  final _notifications = StreamController<FF1NotificationMessage>.broadcast();
+  final _connections = StreamController<bool>.broadcast();
+  final _errors = StreamController<FF1WifiTransportError>.broadcast();
+
+  int connectInvocationCount = 0;
+  int pauseConnectionCount = 0;
+  Completer<void>? _pendingSecondConnect;
+
+  void releasePendingConnect() {
+    _pendingSecondConnect?.complete();
+    _pendingSecondConnect = null;
+  }
+
+  @override
+  Stream<bool> get connectionStateStream => _connections.stream;
+
+  @override
+  Stream<FF1NotificationMessage> get notificationStream =>
+      _notifications.stream;
+
+  @override
+  Stream<FF1WifiTransportError> get errorStream => _errors.stream;
+
+  @override
+  bool get isConnected => false;
+
+  @override
+  bool get isConnecting => false;
+
+  @override
+  Future<void> connect({
+    required FF1Device device,
+    required String userId,
+    required String apiKey,
+    bool forceReconnect = false,
+  }) async {
+    connectInvocationCount++;
+    if (connectInvocationCount >= 2) {
+      _pendingSecondConnect = Completer<void>();
+      await _pendingSecondConnect!.future;
+    }
+  }
+
+  @override
+  void pauseConnection() {
+    pauseConnectionCount++;
+  }
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> sendCommand(Map<String, dynamic> command) async {}
+
+  @override
+  void dispose() {
+    unawaited(_notifications.close());
+    unawaited(_connections.close());
+    unawaited(_errors.close());
+  }
+
+  @override
+  Future<void> disposeFuture() async {
+    dispose();
+  }
 }
 
 class _RecordingRestClient {
@@ -495,7 +604,7 @@ class _NotificationTestTransport implements FF1WifiTransport {
     _notifications.add(message);
   }
 
-  void emitConnectionState(bool connected) {
+  void emitConnectionState({required bool connected}) {
     _connections.add(connected);
   }
 

--- a/test/unit/infra/ff1/ff1_wifi_control_test.dart
+++ b/test/unit/infra/ff1/ff1_wifi_control_test.dart
@@ -389,6 +389,35 @@ void main() {
         expect(transport.pauseConnectionCount, 0);
       },
     );
+
+    test(
+      'superseded connect error from transport does not propagate',
+      () async {
+        final transport = _StallThenThrowTransport();
+        final control = FF1WifiControl(transport: transport);
+
+        addTearDown(control.dispose);
+
+        const device = FF1Device(
+          name: 'FF1',
+          remoteId: 'remote-1',
+          deviceId: 'device-1',
+          topicId: 'topic-1',
+        );
+
+        final connectFuture = control.connect(
+          device: device,
+          userId: 'u',
+          apiKey: 'k',
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        control.pauseConnection();
+        transport.releaseWithError();
+
+        await expectLater(connectFuture, completes);
+      },
+    );
   });
 
   group('FF1WifiControl.reconnect', () {
@@ -429,7 +458,146 @@ void main() {
         expect(transport.pauseConnectionCount, 1);
       },
     );
+
+    test('returns true when transport reconnect succeeds', () async {
+      final transport = _HappyReconnectTransport();
+      final control = FF1WifiControl(transport: transport);
+
+      addTearDown(control.dispose);
+
+      const device = FF1Device(
+        name: 'FF1',
+        remoteId: 'remote-1',
+        deviceId: 'device-1',
+        topicId: 'topic-1',
+      );
+
+      await control.connect(device: device, userId: 'u', apiKey: 'k');
+      final ok = await control.reconnect();
+      expect(ok, isTrue);
+      expect(transport.forceReconnectConnectCount, 1);
+    });
   });
+}
+
+/// Stalls first transport `connect` until `releaseWithError`, then throws
+/// (for superseded-error path).
+class _StallThenThrowTransport implements FF1WifiTransport {
+  final _notifications = StreamController<FF1NotificationMessage>.broadcast();
+  final _connections = StreamController<bool>.broadcast();
+  final _errors = StreamController<FF1WifiTransportError>.broadcast();
+  Completer<void>? _stall;
+
+  void releaseWithError() {
+    _stall?.complete();
+  }
+
+  @override
+  Stream<bool> get connectionStateStream => _connections.stream;
+
+  @override
+  Stream<FF1NotificationMessage> get notificationStream =>
+      _notifications.stream;
+
+  @override
+  Stream<FF1WifiTransportError> get errorStream => _errors.stream;
+
+  @override
+  bool get isConnected => false;
+
+  @override
+  bool get isConnecting => false;
+
+  @override
+  Future<void> connect({
+    required FF1Device device,
+    required String userId,
+    required String apiKey,
+    bool forceReconnect = false,
+  }) async {
+    _stall = Completer<void>();
+    await _stall!.future;
+    throw Exception('boom');
+  }
+
+  @override
+  void pauseConnection() {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> sendCommand(Map<String, dynamic> command) async {}
+
+  @override
+  void dispose() {
+    unawaited(_notifications.close());
+    unawaited(_connections.close());
+    unawaited(_errors.close());
+  }
+
+  @override
+  Future<void> disposeFuture() async {
+    dispose();
+  }
+}
+
+/// Minimal transport: counts `connect` calls with `forceReconnect: true`.
+class _HappyReconnectTransport implements FF1WifiTransport {
+  final _notifications = StreamController<FF1NotificationMessage>.broadcast();
+  final _connections = StreamController<bool>.broadcast();
+  final _errors = StreamController<FF1WifiTransportError>.broadcast();
+
+  int forceReconnectConnectCount = 0;
+
+  @override
+  Stream<bool> get connectionStateStream => _connections.stream;
+
+  @override
+  Stream<FF1NotificationMessage> get notificationStream =>
+      _notifications.stream;
+
+  @override
+  Stream<FF1WifiTransportError> get errorStream => _errors.stream;
+
+  @override
+  bool get isConnected => false;
+
+  @override
+  bool get isConnecting => false;
+
+  @override
+  Future<void> connect({
+    required FF1Device device,
+    required String userId,
+    required String apiKey,
+    bool forceReconnect = false,
+  }) async {
+    if (forceReconnect) {
+      forceReconnectConnectCount++;
+    }
+  }
+
+  @override
+  void pauseConnection() {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> sendCommand(Map<String, dynamic> command) async {}
+
+  @override
+  void dispose() {
+    unawaited(_notifications.close());
+    unawaited(_connections.close());
+    unawaited(_errors.close());
+  }
+
+  @override
+  Future<void> disposeFuture() async {
+    dispose();
+  }
 }
 
 /// First [connect] completes immediately; second [connect] (reconnect) awaits

--- a/test/unit/infra/ff1/ff1_wifi_control_test.dart
+++ b/test/unit/infra/ff1/ff1_wifi_control_test.dart
@@ -347,12 +347,53 @@ void main() {
       expect(control.isDeviceConnected, isFalse);
       expect((await nextDisconnected).isConnected, isFalse);
     });
+
+    test(
+      'superseded connect completion does not pause transport over newer '
+      'session',
+      () async {
+        final transport = _OverlappingConnectTransport();
+        final control = FF1WifiControl(transport: transport);
+
+        addTearDown(control.dispose);
+
+        const deviceA = FF1Device(
+          name: 'FF1',
+          remoteId: 'remote-1',
+          deviceId: 'device-1',
+          topicId: 'topic-1',
+        );
+        const deviceB = FF1Device(
+          name: 'FF1',
+          remoteId: 'remote-2',
+          deviceId: 'device-2',
+          topicId: 'topic-2',
+        );
+
+        final firstConnect = control.connect(
+          device: deviceA,
+          userId: 'u',
+          apiKey: 'k',
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        await control.connect(
+          device: deviceB,
+          userId: 'u',
+          apiKey: 'k',
+        );
+
+        transport.releaseFirstConnect();
+        await firstConnect;
+
+        expect(transport.pauseConnectionCount, 0);
+      },
+    );
   });
 
   group('FF1WifiControl.reconnect', () {
     test(
-      'returns false and tears down transport when superseded before '
-      'transport connect completes',
+      'returns false when superseded before transport connect completes',
       () async {
         final transport = _ReconnectRaceTransport();
         final control = FF1WifiControl(transport: transport);
@@ -383,7 +424,9 @@ void main() {
 
         final ok = await reconnectFuture;
         expect(ok, isFalse);
-        expect(transport.pauseConnectionCount, greaterThanOrEqualTo(1));
+        // Stale reconnect must not call transport.pause (only the explicit
+        // control.pauseConnection above should).
+        expect(transport.pauseConnectionCount, 1);
       },
     );
   });
@@ -432,6 +475,77 @@ class _ReconnectRaceTransport implements FF1WifiTransport {
     if (connectInvocationCount >= 2) {
       _pendingSecondConnect = Completer<void>();
       await _pendingSecondConnect!.future;
+    }
+  }
+
+  @override
+  void pauseConnection() {
+    pauseConnectionCount++;
+  }
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> sendCommand(Map<String, dynamic> command) async {}
+
+  @override
+  void dispose() {
+    unawaited(_notifications.close());
+    unawaited(_connections.close());
+    unawaited(_errors.close());
+  }
+
+  @override
+  Future<void> disposeFuture() async {
+    dispose();
+  }
+}
+
+/// First [connect] blocks until [releaseFirstConnect]; later [connect] calls
+/// return immediately so two overlapping control connects can be modeled.
+class _OverlappingConnectTransport implements FF1WifiTransport {
+  final _notifications = StreamController<FF1NotificationMessage>.broadcast();
+  final _connections = StreamController<bool>.broadcast();
+  final _errors = StreamController<FF1WifiTransportError>.broadcast();
+
+  int _connectCalls = 0;
+  Completer<void>? _firstConnectBlock;
+  int pauseConnectionCount = 0;
+
+  void releaseFirstConnect() {
+    _firstConnectBlock?.complete();
+    _firstConnectBlock = null;
+  }
+
+  @override
+  Stream<bool> get connectionStateStream => _connections.stream;
+
+  @override
+  Stream<FF1NotificationMessage> get notificationStream =>
+      _notifications.stream;
+
+  @override
+  Stream<FF1WifiTransportError> get errorStream => _errors.stream;
+
+  @override
+  bool get isConnected => false;
+
+  @override
+  bool get isConnecting => false;
+
+  @override
+  Future<void> connect({
+    required FF1Device device,
+    required String userId,
+    required String apiKey,
+    bool forceReconnect = false,
+  }) async {
+    _connectCalls++;
+    if (_connectCalls == 1) {
+      _firstConnectBlock = Completer<void>();
+      await _firstConnectBlock!.future;
+      return;
     }
   }
 

--- a/test/unit/ui/screens/device_config_screen_test.dart
+++ b/test/unit/ui/screens/device_config_screen_test.dart
@@ -402,12 +402,14 @@ class _FakeWifiTransport implements FF1WifiTransport {
       const Stream<FF1NotificationMessage>.empty();
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
     bool forceReconnect = false,
-  }) async {}
+  }) async {
+    return true;
+  }
 
   @override
   void dispose() {}

--- a/test/unit/ui/screens/device_config_update_prompt_test.dart
+++ b/test/unit/ui/screens/device_config_update_prompt_test.dart
@@ -684,12 +684,14 @@ class _PromptRaceTransport implements FF1WifiTransport {
   }
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
     bool forceReconnect = false,
-  }) async {}
+  }) async {
+    return true;
+  }
 
   @override
   void pauseConnection() {}

--- a/test/unit/widgets/artwork_playing_controls_test.dart
+++ b/test/unit/widgets/artwork_playing_controls_test.dart
@@ -285,12 +285,14 @@ class _FakeWifiTransport implements FF1WifiTransport {
       const Stream<FF1NotificationMessage>.empty();
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
     bool forceReconnect = false,
-  }) async {}
+  }) async {
+    return true;
+  }
 
   @override
   void dispose() {}

--- a/test/unit/widgets/ffp_monitor_ddc_section_test.dart
+++ b/test/unit/widgets/ffp_monitor_ddc_section_test.dart
@@ -621,12 +621,14 @@ class _FakeWifiTransport implements FF1WifiTransport {
       const Stream<FF1NotificationMessage>.empty();
 
   @override
-  Future<void> connect({
+  Future<bool> connect({
     required FF1Device device,
     required String userId,
     required String apiKey,
     bool forceReconnect = false,
-  }) async {}
+  }) async {
+    return true;
+  }
 
   @override
   void dispose() {}


### PR DESCRIPTION
## Summary
Addresses iOS lifecycle churn around FF1 relayer Wi‑Fi (Sentry FF-APP-67 / #346): brief `inactive` transitions no longer always tear down the relayer; overlapping reconnect vs pause is serialized so stale async work cannot leave transport or notifier state inconsistent.

## Changes
- **Inactive debounce (350ms):** relayer Wi‑Fi pause is debounced only for `AppLifecycleState.inactive`; `paused` / `detached` / `hidden` pause immediately; `resumed` cancels pending debounce and triggers reconnect as before.
- **Control layer:** `_wifiOpGeneration` invalidates in-flight `connect` / `reconnect` after `await transport.connect`; `reconnect()` returns `Future<bool>`. Superseded completions **do not** mutate transport (no `_transport.pauseConnection()` on stale branches) so a late async result cannot tear down a newer in-flight connect/reconnect ([review feedback](https://github.com/feral-file/ff-app/pull/361#pullrequestreview-4089069869)).
- **Notifier:** `_connectEpoch` on `pauseConnection`; `reconnect` respects control `bool` and stale epoch.
- **Tests:** coordinator (FakeAsync); `FF1WifiControl` reconnect supersede + overlapping connect supersede (no extra transport pause).

## Verification
- `scripts/agent-helpers/post-implementation-checks.sh HEAD` clean on latest commit
- Review pool: accept (prior); bot merge blocker on stale `pauseConnection` addressed in follow-up commit

Fixes #346

Made with [Cursor](https://cursor.com)