### PR TITLE
fix: grid/rhythm audit, onboarding UX polish, and WiFi screen cleanup

### DIFF
--- a/lib/app/providers/ff1_wifi_providers.dart
+++ b/lib/app/providers/ff1_wifi_providers.dart
@@ -442,7 +442,7 @@ final ff1ConnectionStatusStreamProvider = StreamProvider<FF1ConnectionStatus>(
 /// Whether the connected FF1 device supports shuffle and loop modes.
 ///
 /// Returns true only when the device has sent a player status that includes
-/// [FF1PlayerStatus.shuffle] or [FF1PlayerStatus.loopMode] — these fields
+/// both [FF1PlayerStatus.shuffle] and [FF1PlayerStatus.loopMode] — these fields
 /// are absent on older firmware that does not support playback modes.
 final ff1SupportsPlaybackModesProvider = Provider<bool>((ref) {
   final status = ref.watch(ff1CurrentPlayerStatusProvider);

--- a/lib/design/layout_constants.dart
+++ b/lib/design/layout_constants.dart
@@ -92,12 +92,13 @@ class LayoutConstants {
   static final double space20 = PrimitivesTokens.spacingSpace20.toDouble();
 
   // Page padding
-  /// Setup page horizontal padding (44px)
+  /// Horizontal padding for hero/onboarding/setup-wizard screens that show
+  /// large title text with minimal interactive content (44px).
   static final double setupPageHorizontal = PrimitivesTokens
       .spacingSetupPageHorizontal
       .toDouble();
 
-  /// Default page horizontal padding (16px)
+  /// Horizontal padding for content, list, and form screens (16px).
   static final double pageHorizontalDefault = PrimitivesTokens
       .spacingPageHorizontalDefault
       .toDouble();

--- a/lib/ui/screens/device_config_screen.dart
+++ b/lib/ui/screens/device_config_screen.dart
@@ -214,7 +214,7 @@ class _DeviceConfigScreenState extends ConsumerState<DeviceConfigScreen>
             left: LayoutConstants.pageHorizontalDefault,
             right: LayoutConstants.pageHorizontalDefault,
             child: PrimaryAsyncButton(
-              padding: const EdgeInsets.only(top: 13, bottom: 10),
+
               onTap: () async {
                 context.go(Routes.home);
               },

--- a/lib/ui/screens/ff1_setup/ff1_updating_page.dart
+++ b/lib/ui/screens/ff1_setup/ff1_updating_page.dart
@@ -1,6 +1,7 @@
 import 'package:app/app/routing/routes.dart';
 import 'package:app/design/app_typography.dart';
 import 'package:app/design/build/primitives.dart';
+import 'package:app/design/layout_constants.dart';
 import 'package:app/widgets/appbars/setup_app_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -32,7 +33,9 @@ class FF1UpdatingPage extends StatelessWidget {
         backgroundColor: PrimitivesTokens.colorsDarkGrey,
         body: SafeArea(
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 44),
+            padding: EdgeInsets.symmetric(
+              horizontal: LayoutConstants.setupPageHorizontal,
+            ),
             child: Stack(
               children: [
                 Column(

--- a/lib/ui/screens/ff1_setup/start_setup_ff1_page.dart
+++ b/lib/ui/screens/ff1_setup/start_setup_ff1_page.dart
@@ -281,7 +281,6 @@ class _StartButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CustomPrimaryButton(
-      padding: const EdgeInsets.only(top: 13, bottom: 10),
       color: PrimitivesTokens.colorsLightBlue,
       onTap: onPressed,
       child: Row(

--- a/lib/ui/screens/onboarding/onboarding_add_address_page.dart
+++ b/lib/ui/screens/onboarding/onboarding_add_address_page.dart
@@ -47,6 +47,8 @@ class OnboardingAddAddressPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final actionGate = ref.watch(onboardingAddAddressActionGateProvider);
+    final addresses = ref.watch(addressesProvider).value ?? [];
+    final hasAddresses = addresses.isNotEmpty;
 
     return Scaffold(
       backgroundColor: PrimitivesTokens.colorsDarkGrey,
@@ -58,15 +60,18 @@ class OnboardingAddAddressPage extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'See the art you already own',
+              hasAddresses ? 'Your addresses' : 'See the art you already own',
               style: AppTypography.h2(context).white,
             ),
             SizedBox(height: ContentRhythm.titleSupportGap),
             Text(
-              'Add your Ethereum and Tezos addresses to pull in the works '
-              'you collect. Use the app as a clear lens on your digital '
-              'collection, '
-              'even before you connect a device.',
+              hasAddresses
+                  ? "We'll sync your collection when you continue. "
+                      'Add more if you collect across multiple wallets.'
+                  : 'Add your Ethereum and Tezos addresses to pull in the works '
+                      'you collect. Use the app as a clear lens on your digital '
+                      'collection, '
+                      'even before you connect a device.',
               style: ContentRhythm.title(context),
             ),
             SizedBox(height: ContentRhythm.titleSupportGap),
@@ -107,34 +112,23 @@ class OnboardingAddAddressPage extends ConsumerWidget {
           key: GoldPathPatrolKeys.onboardingAddAddressSecondary,
           onPressed: () => _onNext(context, ref),
           enabled: actionGate.actionsEnabled,
-          child: Consumer(
-            builder: (context, ref, _) {
-              final addressesAsync = ref.watch(addressesProvider);
-              final addresses = addressesAsync.value ?? [];
-              final actionGate = ref.watch(
-                onboardingAddAddressActionGateProvider,
-              );
-              final label = actionGate.actionsEnabled
-                  ? (addresses.isEmpty ? 'Skip for now' : 'Next')
-                  : 'Please wait';
-
-              return Row(
-                children: [
-                  Text(
-                    label,
-                    style: AppTypography.body(context).lightBlue,
-                  ),
-                  SizedBox(width: LayoutConstants.space2),
-                  SvgPicture.asset(
-                    'assets/images/arrow_right.svg',
-                    colorFilter: const ColorFilter.mode(
-                      PrimitivesTokens.colorsLightBlue,
-                      BlendMode.srcIn,
-                    ),
-                  ),
-                ],
-              );
-            },
+          child: Row(
+            children: [
+              Text(
+                actionGate.actionsEnabled
+                    ? (hasAddresses ? 'Next' : 'Skip for now')
+                    : 'Please wait',
+                style: AppTypography.body(context).lightBlue,
+              ),
+              SizedBox(width: LayoutConstants.space2),
+              SvgPicture.asset(
+                'assets/images/arrow_right.svg',
+                colorFilter: const ColorFilter.mode(
+                  PrimitivesTokens.colorsLightBlue,
+                  BlendMode.srcIn,
+                ),
+              ),
+            ],
           ),
         ),
         hintText: actionGate.actionsEnabled

--- a/lib/ui/screens/release_notes_screen.dart
+++ b/lib/ui/screens/release_notes_screen.dart
@@ -2,6 +2,7 @@ import 'package:app/app/providers/release_notes_provider.dart';
 import 'package:app/app/routing/routes.dart';
 import 'package:app/design/app_typography.dart';
 import 'package:app/design/build/primitives.dart';
+import 'package:app/design/layout_constants.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:app/widgets/appbars/setup_app_bar.dart';
 import 'package:flutter/material.dart';
@@ -43,7 +44,7 @@ class ReleaseNotesScreen extends ConsumerWidget {
           }
 
           return ListView.separated(
-            padding: const EdgeInsets.symmetric(vertical: 24),
+            padding: EdgeInsets.symmetric(vertical: LayoutConstants.space6),
             itemCount: releaseNotes.length,
             separatorBuilder: (context, index) => const Divider(
               height: 1,
@@ -52,9 +53,9 @@ class ReleaseNotesScreen extends ConsumerWidget {
             itemBuilder: (context, index) {
               final releaseNote = releaseNotes[index];
               return ListTile(
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 20,
-                  vertical: 10,
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: LayoutConstants.space5,
+                  vertical: LayoutConstants.space2,
                 ),
                 title: Text(
                   releaseNote.date,
@@ -66,7 +67,7 @@ class ReleaseNotesScreen extends ConsumerWidget {
                     releaseNote.ffOsTitle != null ||
                         releaseNote.mobileAppTitle != null
                     ? Padding(
-                        padding: const EdgeInsets.only(top: 8),
+                        padding: EdgeInsets.only(top: LayoutConstants.space2),
                         child: Text(
                           [
                             if (releaseNote.ffOsTitle != null)

--- a/lib/ui/screens/scan_qr_page.dart
+++ b/lib/ui/screens/scan_qr_page.dart
@@ -201,7 +201,7 @@ class _ScanQrPageState extends ConsumerState<ScanQrPage>
         : 'Scan a Feral File deeplink or wallet address';
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 70),
+      padding: EdgeInsets.symmetric(horizontal: LayoutConstants.space18),
       child: DecoratedBox(
         decoration: BoxDecoration(
           color: Colors.black.withValues(alpha: 0.62),

--- a/lib/ui/screens/scan_wifi_network_screen.dart
+++ b/lib/ui/screens/scan_wifi_network_screen.dart
@@ -98,28 +98,6 @@ class _ScanWiFiNetworkScreenState extends ConsumerState<ScanWiFiNetworkScreen> {
     super.dispose();
   }
 
-  /// Parse SSID from scan result (may contain "ssid|security" format)
-  String _parseSSID(String result) {
-    if (result.contains('|')) {
-      final parts = result.split('|');
-      return parts.isNotEmpty ? parts.first : result;
-    }
-    return result;
-  }
-
-  /// Check if network is open (from "ssid|security" format)
-  bool _isOpenNetwork(String result) {
-    if (!result.contains('|')) {
-      return false;
-    }
-    final parts = result.split('|');
-    if (parts.length > 1) {
-      final security = parts[1].trim().toUpperCase();
-      return security == 'OPEN';
-    }
-    return false;
-  }
-
   @override
   Widget build(BuildContext context) {
     final setupState = ref.watch(ff1SetupOrchestratorProvider);
@@ -138,7 +116,7 @@ class _ScanWiFiNetworkScreenState extends ConsumerState<ScanWiFiNetworkScreen> {
       body: SafeArea(
         child: Padding(
           padding: EdgeInsets.symmetric(
-            horizontal: LayoutConstants.setupPageHorizontal,
+            horizontal: LayoutConstants.pageHorizontalDefault,
           ),
           child: KeyboardVisibilityBuilder(
             builder: (context, isKeyboardVisible) {
@@ -255,9 +233,9 @@ class _ScanWiFiNetworkScreenState extends ConsumerState<ScanWiFiNetworkScreen> {
   }
 
   Widget _networkItem(BuildContext context, WiFiNetwork network) {
-    // Parse SSID and check if open (if scan result contains security info)
-    final ssid = _parseSSID(network.ssid);
-    final isOpen = _isOpenNetwork(network.ssid);
+    final wifiPoint = WifiPoint.fromWifiScanResult(network.ssid);
+    final ssid = wifiPoint.ssid;
+    final isOpen = wifiPoint.isOpenNetwork ?? false;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -288,7 +266,7 @@ class _ScanWiFiNetworkScreenState extends ConsumerState<ScanWiFiNetworkScreen> {
                 .read(ff1SetupOrchestratorProvider.notifier)
                 .requestEnterWifiPassword(
                   device: deviceToPass,
-                  wifiAccessPoint: WifiPoint(ssid),
+                  wifiAccessPoint: wifiPoint,
                 );
           },
           child: SizedBox(

--- a/lib/ui/screens/send_wifi_credentials_screen.dart
+++ b/lib/ui/screens/send_wifi_credentials_screen.dart
@@ -87,28 +87,6 @@ class _EnterWiFiPasswordScreenState
   ProviderSubscription<FF1SetupState>? _setupSub;
   ProviderSubscription<WiFiConnectionState>? _wifiErrorSub;
 
-  /// Parse SSID from networkSsid (may contain "ssid|security" format)
-  String _parseSSID(String ssid) {
-    if (ssid.contains('|')) {
-      final parts = ssid.split('|');
-      return parts.isNotEmpty ? parts.first : ssid;
-    }
-    return ssid;
-  }
-
-  /// Check if network is open (from "ssid|security" format)
-  bool _isOpenNetwork(String ssid) {
-    if (!ssid.contains('|')) {
-      return false;
-    }
-    final parts = ssid.split('|');
-    if (parts.length > 1) {
-      final security = parts[1].trim().toUpperCase();
-      return security == 'OPEN';
-    }
-    return false;
-  }
-
   @override
   void initState() {
     super.initState();
@@ -150,7 +128,7 @@ class _EnterWiFiPasswordScreenState
       },
     );
 
-    final isOpen = _isOpenNetwork(widget.payload.wifiAccessPoint.ssid);
+    final isOpen = widget.payload.wifiAccessPoint.isOpenNetwork ?? false;
     if (isOpen) {
       // Auto-submit for open networks
       unawaited(Future.microtask(_handleSendCredentials));
@@ -174,7 +152,7 @@ class _EnterWiFiPasswordScreenState
   }
 
   Future<void> _handleSendCredentials() async {
-    final isOpen = _isOpenNetwork(widget.payload.wifiAccessPoint.ssid);
+    final isOpen = widget.payload.wifiAccessPoint.isOpenNetwork ?? false;
     final password = isOpen ? '' : _passwordController.text.trim();
 
     if (!isOpen && password.isEmpty) {
@@ -199,7 +177,7 @@ class _EnterWiFiPasswordScreenState
         .read(ff1SetupOrchestratorProvider.notifier)
         .sendWifiCredentialsAndConnect(
           device: widget.payload.device,
-          ssid: _parseSSID(widget.payload.wifiAccessPoint.ssid),
+          ssid: widget.payload.wifiAccessPoint.ssid,
           password: password,
         );
   }
@@ -246,7 +224,7 @@ class _EnterWiFiPasswordScreenState
                 }
               : null,
         );
-        if (_isOpenNetwork(widget.payload.wifiAccessPoint.ssid) && mounted) {
+        if ((widget.payload.wifiAccessPoint.isOpenNetwork ?? false) && mounted) {
           context.pop();
         }
         setState(() {
@@ -272,8 +250,8 @@ class _EnterWiFiPasswordScreenState
       localProcessingFlag: _isProcessing,
       status: connectionState.status,
     );
-    final isOpen = _isOpenNetwork(widget.payload.wifiAccessPoint.ssid);
-    final parsedSsid = _parseSSID(widget.payload.wifiAccessPoint.ssid);
+    final isOpen = widget.payload.wifiAccessPoint.isOpenNetwork ?? false;
+    final parsedSsid = widget.payload.wifiAccessPoint.ssid;
     // Open networks don't need a password; closed networks require one.
     final canSubmit = isOpen || _passwordText.trim().isNotEmpty;
     final reservedBottomBarHeight = shouldReserveNowDisplayingBar
@@ -289,7 +267,7 @@ class _EnterWiFiPasswordScreenState
       body: SafeArea(
         child: Padding(
           padding: EdgeInsets.symmetric(
-            horizontal: LayoutConstants.setupPageHorizontal,
+            horizontal: LayoutConstants.pageHorizontalDefault,
           ),
           child: isProcessing
               ? _buildProcessingView(parsedSsid)

--- a/lib/ui/screens/settings/forget_exist_dialog_content.dart
+++ b/lib/ui/screens/settings/forget_exist_dialog_content.dart
@@ -90,7 +90,7 @@ class _ForgetExistDialogContentState
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Padding(
-                        padding: const EdgeInsets.only(top: 8),
+                        padding: EdgeInsets.only(top: LayoutConstants.space2),
                         child: _dotIcon(color: AppColor.white),
                       ),
                       SizedBox(width: LayoutConstants.space3),
@@ -109,7 +109,7 @@ class _ForgetExistDialogContentState
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Padding(
-                        padding: const EdgeInsets.only(top: 8),
+                        padding: EdgeInsets.only(top: LayoutConstants.space2),
                         child: _dotIcon(color: AppColor.white),
                       ),
                       SizedBox(width: LayoutConstants.space3),
@@ -127,7 +127,7 @@ class _ForgetExistDialogContentState
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Padding(
-                        padding: const EdgeInsets.only(top: 8),
+                        padding: EdgeInsets.only(top: LayoutConstants.space2),
                         child: _dotIcon(color: AppColor.white),
                       ),
                       SizedBox(width: LayoutConstants.space3),

--- a/lib/ui/screens/settings/settings_page.dart
+++ b/lib/ui/screens/settings/settings_page.dart
@@ -259,7 +259,10 @@ class _VersionSection extends StatelessWidget {
         SizedBox(height: LayoutConstants.space6),
         if (packageInfo != null)
           Container(
-            padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 12),
+            padding: EdgeInsets.symmetric(
+              vertical: LayoutConstants.space2,
+              horizontal: LayoutConstants.space3,
+            ),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(50),
               border: Border.all(color: outlineColor),

--- a/lib/widgets/buttons/custom_primary_button.dart
+++ b/lib/widgets/buttons/custom_primary_button.dart
@@ -1,4 +1,3 @@
-import 'package:app/design/layout_constants.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:flutter/material.dart';
 
@@ -15,7 +14,7 @@ class CustomPrimaryButton extends StatelessWidget {
     this.isProcessing = false,
     this.borderColor,
     this.indicatorColor,
-    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
+    this.padding = const EdgeInsets.symmetric(vertical: 12),
     this.borderRadius = 32,
     this.textColor,
   });

--- a/lib/widgets/buttons/custom_primary_button.dart
+++ b/lib/widgets/buttons/custom_primary_button.dart
@@ -1,3 +1,4 @@
+import 'package:app/design/layout_constants.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:flutter/material.dart';
 
@@ -14,7 +15,7 @@ class CustomPrimaryButton extends StatelessWidget {
     this.isProcessing = false,
     this.borderColor,
     this.indicatorColor,
-    this.padding = const EdgeInsets.symmetric(vertical: 13),
+    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
     this.borderRadius = 32,
     this.textColor,
   });

--- a/lib/widgets/buttons/outline_button.dart
+++ b/lib/widgets/buttons/outline_button.dart
@@ -17,7 +17,7 @@ class OutlineButton extends StatelessWidget {
     this.isProcessing = false,
     this.textColor,
     this.borderColor,
-    this.padding = const EdgeInsets.symmetric(vertical: 13),
+    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
     this.rightIcon,
   });
 

--- a/lib/widgets/buttons/outline_button.dart
+++ b/lib/widgets/buttons/outline_button.dart
@@ -17,7 +17,7 @@ class OutlineButton extends StatelessWidget {
     this.isProcessing = false,
     this.textColor,
     this.borderColor,
-    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
+    this.padding = const EdgeInsets.symmetric(vertical: 12),
     this.rightIcon,
   });
 

--- a/lib/widgets/buttons/primary_button.dart
+++ b/lib/widgets/buttons/primary_button.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:app/design/app_typography.dart';
-import 'package:app/design/layout_constants.dart';
 import 'package:app/domain/utils/debounce_util.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:flutter/material.dart';
@@ -20,7 +19,7 @@ class PrimaryButton extends StatelessWidget {
     this.enabled = true,
     this.isProcessing = false,
     this.indicatorColor,
-    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
+    this.padding = const EdgeInsets.symmetric(vertical: 12),
     this.elevatedPadding,
     this.borderRadius = 32,
     this.borderColor,
@@ -150,7 +149,7 @@ class PrimaryAsyncButton extends StatefulWidget {
     this.borderColor,
     this.borderRadius = 32,
     this.processingText,
-    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
+    this.padding = const EdgeInsets.symmetric(vertical: 12),
   });
 
   /// On tap callback.

--- a/lib/widgets/buttons/primary_button.dart
+++ b/lib/widgets/buttons/primary_button.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:app/design/app_typography.dart';
+import 'package:app/design/layout_constants.dart';
 import 'package:app/domain/utils/debounce_util.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:flutter/material.dart';
@@ -19,7 +20,7 @@ class PrimaryButton extends StatelessWidget {
     this.enabled = true,
     this.isProcessing = false,
     this.indicatorColor,
-    this.padding = const EdgeInsets.symmetric(vertical: 13),
+    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
     this.elevatedPadding,
     this.borderRadius = 32,
     this.borderColor,
@@ -149,7 +150,7 @@ class PrimaryAsyncButton extends StatefulWidget {
     this.borderColor,
     this.borderRadius = 32,
     this.processingText,
-    this.padding = const EdgeInsets.symmetric(vertical: 13),
+    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
   });
 
   /// On tap callback.

--- a/patrol_test/gold_path_test.dart
+++ b/patrol_test/gold_path_test.dart
@@ -119,7 +119,7 @@ Future<void> _submitPersonalAddressInOnboarding(
   await _enterAddressAndSubmit($, address);
 
   await $(
-    'See the art you already own',
+    'Your addresses',
   ).waitUntilVisible(timeout: const Duration(minutes: 1));
   await $(address).waitUntilExists(timeout: const Duration(minutes: 1));
 }

--- a/test/unit/domain/models/wifi_point_test.dart
+++ b/test/unit/domain/models/wifi_point_test.dart
@@ -1,0 +1,59 @@
+import 'package:app/domain/models/wifi_point.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('WifiPoint.fromWifiScanResult', () {
+    group('open networks', () {
+      test('marks isOpenNetwork true for OPEN security suffix', () {
+        final point = WifiPoint.fromWifiScanResult('Cafe|OPEN');
+        expect(point.ssid, 'Cafe');
+        expect(point.isOpenNetwork, isTrue);
+      });
+
+      test('is case-insensitive for OPEN suffix', () {
+        expect(
+          WifiPoint.fromWifiScanResult('Cafe|open').isOpenNetwork,
+          isTrue,
+        );
+        expect(
+          WifiPoint.fromWifiScanResult('Cafe|Open').isOpenNetwork,
+          isTrue,
+        );
+      });
+
+      test('trims whitespace around security token', () {
+        final point = WifiPoint.fromWifiScanResult('Cafe| OPEN ');
+        expect(point.ssid, 'Cafe');
+        expect(point.isOpenNetwork, isTrue);
+      });
+    });
+
+    group('secured networks', () {
+      test('marks isOpenNetwork false for WPA2 suffix', () {
+        final point = WifiPoint.fromWifiScanResult('Mars-2026_5G|WPA2');
+        expect(point.ssid, 'Mars-2026_5G');
+        expect(point.isOpenNetwork, isFalse);
+      });
+
+      test('marks isOpenNetwork false for WPA3 suffix', () {
+        final point = WifiPoint.fromWifiScanResult('HomeNetwork|WPA3');
+        expect(point.ssid, 'HomeNetwork');
+        expect(point.isOpenNetwork, isFalse);
+      });
+    });
+
+    group('plain SSIDs (no security suffix)', () {
+      test('returns ssid unchanged and isOpenNetwork false', () {
+        final point = WifiPoint.fromWifiScanResult('PlainSSID');
+        expect(point.ssid, 'PlainSSID');
+        expect(point.isOpenNetwork, isFalse);
+      });
+
+      test('handles SSID with spaces', () {
+        final point = WifiPoint.fromWifiScanResult('My Home Network');
+        expect(point.ssid, 'My Home Network');
+        expect(point.isOpenNetwork, isFalse);
+      });
+    });
+  });
+}

--- a/test/unit/ui/screens/ff1_setup/enter_wifi_password_screen_navigation_test.dart
+++ b/test/unit/ui/screens/ff1_setup/enter_wifi_password_screen_navigation_test.dart
@@ -130,7 +130,73 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets('open network: password field absent, SizedBox shown', (
+    tester,
+  ) async {
+    final container = ProviderContainer(
+      overrides: [
+        ff1SetupOrchestratorProvider.overrideWith(
+          _NoOpOrchestratorNotifier.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final router = GoRouter(
+      initialLocation: Routes.enterWifiPassword,
+      routes: [
+        GoRoute(
+          path: Routes.enterWifiPassword,
+          builder: (context, state) {
+            final payload = EnterWifiPasswordPagePayload(
+              device: const FF1Device(
+                name: 'FF1',
+                remoteId: '00:11',
+                deviceId: 'FF1-1',
+                topicId: 'topic-1',
+              ),
+              wifiAccessPoint: const WifiPoint('Cafe', isOpenNetwork: true),
+            );
+            return EnterWiFiPasswordScreen(payload: payload);
+          },
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pump();
+
+    // Open networks must never render the password input.
+    expect(find.byType(PasswordTextField), findsNothing);
+  });
 }
+
+class _NoOpOrchestratorNotifier extends FF1SetupOrchestratorNotifier {
+  @override
+  FF1SetupState build() => FF1SetupState(
+    step: FF1SetupStep.idle,
+    effectId: 0,
+    effect: null,
+  );
+
+  @override
+  Future<void> sendWifiCredentialsAndConnect({
+    required FF1Device device,
+    required String ssid,
+    required String password,
+  }) async {}
+
+  @override
+  void ackEffect({required int effectId}) {}
+}
+
+// ---------------------------------------------------------------------------
 
 class _FakeConnectNotifier extends ConnectFF1Notifier {
   _FakeConnectNotifier(this._state);


### PR DESCRIPTION
## Problem

Several accumulated issues across onboarding and setup screens:
1. Onboarding add-address page shows identical title/body before and after an address is added — no feedback that anything changed
2. WiFi screens (network list + password entry) used the wide hero padding (44px) intended for setup wizard text screens, not the 16px content padding appropriate for list/form screens
3. All four primary/outline button widgets defaulted to a hardcoded 13px vertical padding (off-grid)
4. Various other screens had hardcoded padding values instead of \`LayoutConstants\` tokens
5. \`_parseSSID\` / \`_isOpenNetwork\` were copy-pasted verbatim across both WiFi screens, and the password screen's copy had a latent bug (always evaluated open-network check against an already-parsed SSID, so auto-submit for open networks never fired)

## Why It Matters

Grid consistency keeps the design system trustworthy — off-grid values are easy to introduce and accumulate. The open-network WiFi bug would silently break passwordless network joining. The onboarding UX issue creates a confusing moment for new users.

## Acceptance Checks

- [ ] Onboarding: after adding an address, title changes to "Your addresses" and body updates to sync confirmation copy
- [ ] WiFi network list and password screens have correct (narrower) horizontal margins
- [ ] Button heights are visually unchanged (1px difference per side)
- [ ] Open WiFi networks auto-submit without showing a password prompt
- [ ] No hardcoded padding values remain in the changed files

## Human Owner

@seanmoss

## How The Agent Was Used

Agent identified all issues via a full audit of `lib/ui/screens/`, traced the WiFi deduplication to the existing `WifiPoint.fromWifiScanResult` factory, spotted the latent open-network bug, and implemented all fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)