### PR TITLE
fix: pause audio/video/webview playback when app moves to background

### DIFF
--- a/lib/app/providers/ff1_wifi_providers.dart
+++ b/lib/app/providers/ff1_wifi_providers.dart
@@ -442,7 +442,7 @@ final ff1ConnectionStatusStreamProvider = StreamProvider<FF1ConnectionStatus>(
 /// Whether the connected FF1 device supports shuffle and loop modes.
 ///
 /// Returns true only when the device has sent a player status that includes
-/// [FF1PlayerStatus.shuffle] or [FF1PlayerStatus.loopMode] — these fields
+/// both [FF1PlayerStatus.shuffle] and [FF1PlayerStatus.loopMode] — these fields
 /// are absent on older firmware that does not support playback modes.
 final ff1SupportsPlaybackModesProvider = Provider<bool>((ref) {
   final status = ref.watch(ff1CurrentPlayerStatusProvider);

--- a/lib/design/layout_constants.dart
+++ b/lib/design/layout_constants.dart
@@ -92,12 +92,13 @@ class LayoutConstants {
   static final double space20 = PrimitivesTokens.spacingSpace20.toDouble();
 
   // Page padding
-  /// Setup page horizontal padding (44px)
+  /// Horizontal padding for hero/onboarding/setup-wizard screens that show
+  /// large title text with minimal interactive content (44px).
   static final double setupPageHorizontal = PrimitivesTokens
       .spacingSetupPageHorizontal
       .toDouble();
 
-  /// Default page horizontal padding (16px)
+  /// Horizontal padding for content, list, and form screens (16px).
   static final double pageHorizontalDefault = PrimitivesTokens
       .spacingPageHorizontalDefault
       .toDouble();

--- a/lib/nft_rendering/audio_rendering_widget.dart
+++ b/lib/nft_rendering/audio_rendering_widget.dart
@@ -80,7 +80,9 @@ class _AudioNFTRenderingWidgetState
       }
 
       widget.onLoaded?.call(time: _player?.duration?.inSeconds);
-      await _player?.play();
+      if (!isBackgroundPaused) {
+        await _player?.play();
+      }
     } catch (e) {
       _log.warning('Failed to play audio source: $audioURL. Error: $e');
     }
@@ -106,6 +108,9 @@ class _AudioNFTRenderingWidgetState
       await _resumeAudio();
     }
   }
+
+  @override
+  bool get isPlaying => _player?.playing ?? false;
 
   @override
   Future<void> mute() async {

--- a/lib/nft_rendering/audio_rendering_widget.dart
+++ b/lib/nft_rendering/audio_rendering_widget.dart
@@ -80,7 +80,7 @@ class _AudioNFTRenderingWidgetState
       }
 
       widget.onLoaded?.call(time: _player?.duration?.inSeconds);
-      if (!isBackgroundPaused) {
+      if (!isInBackground) {
         await _player?.play();
       }
     } catch (e) {

--- a/lib/nft_rendering/audio_rendering_widget.dart
+++ b/lib/nft_rendering/audio_rendering_widget.dart
@@ -33,7 +33,8 @@ class AudioNFTRenderingWidget extends NFTRenderingWidget {
 }
 
 class _AudioNFTRenderingWidgetState
-    extends NFTRenderingWidgetState<AudioNFTRenderingWidget> {
+    extends NFTRenderingWidgetState<AudioNFTRenderingWidget>
+    with WidgetsBindingObserver, LifecycleAwarePlaybackMixin {
   AudioPlayer? _player;
   String? _thumbnailURL;
   final _progressStreamController = StreamController<double>();
@@ -41,12 +42,14 @@ class _AudioNFTRenderingWidgetState
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _thumbnailURL = widget.thumbnailURL;
     unawaited(_initializeAudioPlayer());
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     unawaited(_disposeAudioPlayer());
     unawaited(_progressStreamController.close());
     super.dispose();

--- a/lib/nft_rendering/nft_rendering_widget.dart
+++ b/lib/nft_rendering/nft_rendering_widget.dart
@@ -132,6 +132,27 @@ abstract class NFTRenderingWidgetState<T extends NFTRenderingWidget>
   void unmute() {}
 }
 
+/// Mixin that pauses playback when the app moves to background and resumes
+/// it when the app returns to foreground. Apply alongside [WidgetsBindingObserver].
+///
+/// Only reacts to [AppLifecycleState.paused] (not [AppLifecycleState.inactive])
+/// to avoid spurious pauses during in-app navigation transitions.
+mixin LifecycleAwarePlaybackMixin<T extends NFTRenderingWidget>
+    on NFTRenderingWidgetState<T>, WidgetsBindingObserver {
+  bool _pausedForBackground = false;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused) {
+      _pausedForBackground = true;
+      pause();
+    } else if (state == AppLifecycleState.resumed && _pausedForBackground) {
+      _pausedForBackground = false;
+      resume();
+    }
+  }
+}
+
 class NoPreviewUrlWidget extends StatelessWidget {
   const NoPreviewUrlWidget({super.key});
 

--- a/lib/nft_rendering/nft_rendering_widget.dart
+++ b/lib/nft_rendering/nft_rendering_widget.dart
@@ -149,22 +149,32 @@ abstract class NFTRenderingWidgetState<T extends NFTRenderingWidget>
 mixin LifecycleAwarePlaybackMixin<T extends NFTRenderingWidget>
     on NFTRenderingWidgetState<T>, WidgetsBindingObserver {
   bool _pausedForBackground = false;
+  bool _isInBackground = false;
 
   /// Whether this mixin paused playback due to the app going to background.
   /// Subclasses can read this during async initialization to avoid starting
   /// playback while the app is already in the background.
   bool get isBackgroundPaused => _pausedForBackground;
 
+  /// Whether the app is currently in the background, regardless of whether
+  /// media was playing at the time of backgrounding. Use this to guard
+  /// async initialization code that should not start playback while backgrounded.
+  bool get isInBackground => _isInBackground;
+
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused) {
+      _isInBackground = true;
       if (isPlaying) {
         _pausedForBackground = true;
         pause();
       }
-    } else if (state == AppLifecycleState.resumed && _pausedForBackground) {
-      _pausedForBackground = false;
-      resume();
+    } else if (state == AppLifecycleState.resumed) {
+      _isInBackground = false;
+      if (_pausedForBackground) {
+        _pausedForBackground = false;
+        resume();
+      }
     }
   }
 }

--- a/lib/nft_rendering/nft_rendering_widget.dart
+++ b/lib/nft_rendering/nft_rendering_widget.dart
@@ -130,6 +130,11 @@ abstract class NFTRenderingWidgetState<T extends NFTRenderingWidget>
   void mute() {}
 
   void unmute() {}
+
+  /// Whether media is currently playing. Subclasses should override this to
+  /// reflect actual playback state so that [LifecycleAwarePlaybackMixin] can
+  /// avoid resuming content that was already paused before backgrounding.
+  bool get isPlaying => false;
 }
 
 /// Mixin that pauses playback when the app moves to background and resumes
@@ -137,15 +142,26 @@ abstract class NFTRenderingWidgetState<T extends NFTRenderingWidget>
 ///
 /// Only reacts to [AppLifecycleState.paused] (not [AppLifecycleState.inactive])
 /// to avoid spurious pauses during in-app navigation transitions.
+///
+/// The mixin only sets its background-pause flag when [isPlaying] is true at
+/// the moment of backgrounding, so manually paused content stays paused after
+/// the app returns to foreground.
 mixin LifecycleAwarePlaybackMixin<T extends NFTRenderingWidget>
     on NFTRenderingWidgetState<T>, WidgetsBindingObserver {
   bool _pausedForBackground = false;
 
+  /// Whether this mixin paused playback due to the app going to background.
+  /// Subclasses can read this during async initialization to avoid starting
+  /// playback while the app is already in the background.
+  bool get isBackgroundPaused => _pausedForBackground;
+
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused) {
-      _pausedForBackground = true;
-      pause();
+      if (isPlaying) {
+        _pausedForBackground = true;
+        pause();
+      }
     } else if (state == AppLifecycleState.resumed && _pausedForBackground) {
       _pausedForBackground = false;
       resume();

--- a/lib/nft_rendering/video_player_widget.dart
+++ b/lib/nft_rendering/video_player_widget.dart
@@ -44,7 +44,7 @@ class VideoNFTRenderingWidget extends NFTRenderingWidget {
 
 class _VideoNFTRenderingWidgetState
     extends NFTRenderingWidgetState<VideoNFTRenderingWidget>
-    with RouteAware, WidgetsBindingObserver {
+    with RouteAware, WidgetsBindingObserver, LifecycleAwarePlaybackMixin {
   VideoPlayerController? _controller;
   bool _isPreviewLoaded = false;
   bool _isPlayingFailed = false;

--- a/lib/nft_rendering/video_player_widget.dart
+++ b/lib/nft_rendering/video_player_widget.dart
@@ -110,7 +110,7 @@ class _VideoNFTRenderingWidgetState
       }
       await _controller?.setLooping(true);
       if (shouldPauseOrResume) {
-        if (_isPlaying) {
+        if (_isPlaying && !isBackgroundPaused) {
           await resume();
         } else {
           await pause();
@@ -250,6 +250,9 @@ class _VideoNFTRenderingWidgetState
     ),
     fit: BoxFit.cover,
   );
+
+  @override
+  bool get isPlaying => _isPlaying;
 
   @override
   Future<void> pause() async {

--- a/lib/nft_rendering/video_player_widget.dart
+++ b/lib/nft_rendering/video_player_widget.dart
@@ -110,7 +110,7 @@ class _VideoNFTRenderingWidgetState
       }
       await _controller?.setLooping(true);
       if (shouldPauseOrResume) {
-        if (_isPlaying && !isBackgroundPaused) {
+        if (_isPlaying && !isInBackground) {
           await resume();
         } else {
           await pause();

--- a/lib/nft_rendering/webview_rendering_widget.dart
+++ b/lib/nft_rendering/webview_rendering_widget.dart
@@ -38,6 +38,7 @@ class _WebviewNFTRenderingWidgetState
     extends NFTRenderingWidgetState<WebviewNFTRenderingWidget>
     with WidgetsBindingObserver {
   ValueNotifier<bool> isPausing = ValueNotifier(false);
+  bool _pausedForBackground = false;
   WebViewController? _webViewController;
   final TextEditingController _textController = TextEditingController();
   final Color backgroundColor = Colors.black;
@@ -226,9 +227,15 @@ class _WebviewNFTRenderingWidgetState
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
     if (state == AppLifecycleState.paused) {
-      unawaited(onPause());
+      if (!isPausing.value) {
+        _pausedForBackground = true;
+        unawaited(onPause());
+      }
     } else if (state == AppLifecycleState.resumed) {
-      unawaited(onResume());
+      if (_pausedForBackground) {
+        _pausedForBackground = false;
+        unawaited(onResume());
+      }
     } else if (state == AppLifecycleState.detached) {
       // App is being terminated - dispose WebView immediately
       // to prevent native crashes during finalization

--- a/lib/nft_rendering/webview_rendering_widget.dart
+++ b/lib/nft_rendering/webview_rendering_widget.dart
@@ -225,7 +225,11 @@ class _WebviewNFTRenderingWidgetState
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
-    if (state == AppLifecycleState.detached) {
+    if (state == AppLifecycleState.paused) {
+      unawaited(onPause());
+    } else if (state == AppLifecycleState.resumed) {
+      unawaited(onResume());
+    } else if (state == AppLifecycleState.detached) {
       // App is being terminated - dispose WebView immediately
       // to prevent native crashes during finalization
       try {

--- a/lib/nft_rendering/webview_rendering_widget.dart
+++ b/lib/nft_rendering/webview_rendering_widget.dart
@@ -39,6 +39,7 @@ class _WebviewNFTRenderingWidgetState
     with WidgetsBindingObserver {
   ValueNotifier<bool> isPausing = ValueNotifier(false);
   bool _pausedForBackground = false;
+  bool _isInBackground = false;
   WebViewController? _webViewController;
   final TextEditingController _textController = TextEditingController();
   final Color backgroundColor = Colors.black;
@@ -190,6 +191,12 @@ class _WebviewNFTRenderingWidgetState
       if (widget.isMute) {
         await mute();
       }
+
+      // If the app is already in the background when the page finishes
+      // loading, immediately pause any autoplaying media.
+      if (_isInBackground) {
+        await onPause();
+      }
     },
   );
 
@@ -227,11 +234,13 @@ class _WebviewNFTRenderingWidgetState
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
     if (state == AppLifecycleState.paused) {
+      _isInBackground = true;
       if (!isPausing.value) {
         _pausedForBackground = true;
         unawaited(onPause());
       }
     } else if (state == AppLifecycleState.resumed) {
+      _isInBackground = false;
       if (_pausedForBackground) {
         _pausedForBackground = false;
         unawaited(onResume());

--- a/lib/ui/screens/device_config_screen.dart
+++ b/lib/ui/screens/device_config_screen.dart
@@ -214,7 +214,7 @@ class _DeviceConfigScreenState extends ConsumerState<DeviceConfigScreen>
             left: LayoutConstants.pageHorizontalDefault,
             right: LayoutConstants.pageHorizontalDefault,
             child: PrimaryAsyncButton(
-              padding: const EdgeInsets.only(top: 13, bottom: 10),
+
               onTap: () async {
                 context.go(Routes.home);
               },

--- a/lib/ui/screens/ff1_setup/ff1_updating_page.dart
+++ b/lib/ui/screens/ff1_setup/ff1_updating_page.dart
@@ -1,6 +1,7 @@
 import 'package:app/app/routing/routes.dart';
 import 'package:app/design/app_typography.dart';
 import 'package:app/design/build/primitives.dart';
+import 'package:app/design/layout_constants.dart';
 import 'package:app/widgets/appbars/setup_app_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -32,7 +33,9 @@ class FF1UpdatingPage extends StatelessWidget {
         backgroundColor: PrimitivesTokens.colorsDarkGrey,
         body: SafeArea(
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 44),
+            padding: EdgeInsets.symmetric(
+              horizontal: LayoutConstants.setupPageHorizontal,
+            ),
             child: Stack(
               children: [
                 Column(

--- a/lib/ui/screens/ff1_setup/start_setup_ff1_page.dart
+++ b/lib/ui/screens/ff1_setup/start_setup_ff1_page.dart
@@ -281,7 +281,6 @@ class _StartButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CustomPrimaryButton(
-      padding: const EdgeInsets.only(top: 13, bottom: 10),
       color: PrimitivesTokens.colorsLightBlue,
       onTap: onPressed,
       child: Row(

--- a/lib/ui/screens/onboarding/onboarding_add_address_page.dart
+++ b/lib/ui/screens/onboarding/onboarding_add_address_page.dart
@@ -47,6 +47,8 @@ class OnboardingAddAddressPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final actionGate = ref.watch(onboardingAddAddressActionGateProvider);
+    final addresses = ref.watch(addressesProvider).value ?? [];
+    final hasAddresses = addresses.isNotEmpty;
 
     return Scaffold(
       backgroundColor: PrimitivesTokens.colorsDarkGrey,
@@ -58,15 +60,18 @@ class OnboardingAddAddressPage extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'See the art you already own',
+              hasAddresses ? 'Your addresses' : 'See the art you already own',
               style: AppTypography.h2(context).white,
             ),
             SizedBox(height: ContentRhythm.titleSupportGap),
             Text(
-              'Add your Ethereum and Tezos addresses to pull in the works '
-              'you collect. Use the app as a clear lens on your digital '
-              'collection, '
-              'even before you connect a device.',
+              hasAddresses
+                  ? "We'll sync your collection when you continue. "
+                      'Add more if you collect across multiple wallets.'
+                  : 'Add your Ethereum and Tezos addresses to pull in the works '
+                      'you collect. Use the app as a clear lens on your digital '
+                      'collection, '
+                      'even before you connect a device.',
               style: ContentRhythm.title(context),
             ),
             SizedBox(height: ContentRhythm.titleSupportGap),
@@ -107,34 +112,23 @@ class OnboardingAddAddressPage extends ConsumerWidget {
           key: GoldPathPatrolKeys.onboardingAddAddressSecondary,
           onPressed: () => _onNext(context, ref),
           enabled: actionGate.actionsEnabled,
-          child: Consumer(
-            builder: (context, ref, _) {
-              final addressesAsync = ref.watch(addressesProvider);
-              final addresses = addressesAsync.value ?? [];
-              final actionGate = ref.watch(
-                onboardingAddAddressActionGateProvider,
-              );
-              final label = actionGate.actionsEnabled
-                  ? (addresses.isEmpty ? 'Skip for now' : 'Next')
-                  : 'Please wait';
-
-              return Row(
-                children: [
-                  Text(
-                    label,
-                    style: AppTypography.body(context).lightBlue,
-                  ),
-                  SizedBox(width: LayoutConstants.space2),
-                  SvgPicture.asset(
-                    'assets/images/arrow_right.svg',
-                    colorFilter: const ColorFilter.mode(
-                      PrimitivesTokens.colorsLightBlue,
-                      BlendMode.srcIn,
-                    ),
-                  ),
-                ],
-              );
-            },
+          child: Row(
+            children: [
+              Text(
+                actionGate.actionsEnabled
+                    ? (hasAddresses ? 'Next' : 'Skip for now')
+                    : 'Please wait',
+                style: AppTypography.body(context).lightBlue,
+              ),
+              SizedBox(width: LayoutConstants.space2),
+              SvgPicture.asset(
+                'assets/images/arrow_right.svg',
+                colorFilter: const ColorFilter.mode(
+                  PrimitivesTokens.colorsLightBlue,
+                  BlendMode.srcIn,
+                ),
+              ),
+            ],
           ),
         ),
         hintText: actionGate.actionsEnabled

--- a/lib/ui/screens/release_notes_screen.dart
+++ b/lib/ui/screens/release_notes_screen.dart
@@ -2,6 +2,7 @@ import 'package:app/app/providers/release_notes_provider.dart';
 import 'package:app/app/routing/routes.dart';
 import 'package:app/design/app_typography.dart';
 import 'package:app/design/build/primitives.dart';
+import 'package:app/design/layout_constants.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:app/widgets/appbars/setup_app_bar.dart';
 import 'package:flutter/material.dart';
@@ -43,7 +44,7 @@ class ReleaseNotesScreen extends ConsumerWidget {
           }
 
           return ListView.separated(
-            padding: const EdgeInsets.symmetric(vertical: 24),
+            padding: EdgeInsets.symmetric(vertical: LayoutConstants.space6),
             itemCount: releaseNotes.length,
             separatorBuilder: (context, index) => const Divider(
               height: 1,
@@ -52,9 +53,9 @@ class ReleaseNotesScreen extends ConsumerWidget {
             itemBuilder: (context, index) {
               final releaseNote = releaseNotes[index];
               return ListTile(
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 20,
-                  vertical: 10,
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: LayoutConstants.space5,
+                  vertical: LayoutConstants.space2,
                 ),
                 title: Text(
                   releaseNote.date,
@@ -66,7 +67,7 @@ class ReleaseNotesScreen extends ConsumerWidget {
                     releaseNote.ffOsTitle != null ||
                         releaseNote.mobileAppTitle != null
                     ? Padding(
-                        padding: const EdgeInsets.only(top: 8),
+                        padding: EdgeInsets.only(top: LayoutConstants.space2),
                         child: Text(
                           [
                             if (releaseNote.ffOsTitle != null)

--- a/lib/ui/screens/scan_qr_page.dart
+++ b/lib/ui/screens/scan_qr_page.dart
@@ -201,7 +201,7 @@ class _ScanQrPageState extends ConsumerState<ScanQrPage>
         : 'Scan a Feral File deeplink or wallet address';
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 70),
+      padding: EdgeInsets.symmetric(horizontal: LayoutConstants.space18),
       child: DecoratedBox(
         decoration: BoxDecoration(
           color: Colors.black.withValues(alpha: 0.62),

--- a/lib/ui/screens/scan_wifi_network_screen.dart
+++ b/lib/ui/screens/scan_wifi_network_screen.dart
@@ -98,28 +98,6 @@ class _ScanWiFiNetworkScreenState extends ConsumerState<ScanWiFiNetworkScreen> {
     super.dispose();
   }
 
-  /// Parse SSID from scan result (may contain "ssid|security" format)
-  String _parseSSID(String result) {
-    if (result.contains('|')) {
-      final parts = result.split('|');
-      return parts.isNotEmpty ? parts.first : result;
-    }
-    return result;
-  }
-
-  /// Check if network is open (from "ssid|security" format)
-  bool _isOpenNetwork(String result) {
-    if (!result.contains('|')) {
-      return false;
-    }
-    final parts = result.split('|');
-    if (parts.length > 1) {
-      final security = parts[1].trim().toUpperCase();
-      return security == 'OPEN';
-    }
-    return false;
-  }
-
   @override
   Widget build(BuildContext context) {
     final setupState = ref.watch(ff1SetupOrchestratorProvider);
@@ -138,7 +116,7 @@ class _ScanWiFiNetworkScreenState extends ConsumerState<ScanWiFiNetworkScreen> {
       body: SafeArea(
         child: Padding(
           padding: EdgeInsets.symmetric(
-            horizontal: LayoutConstants.setupPageHorizontal,
+            horizontal: LayoutConstants.pageHorizontalDefault,
           ),
           child: KeyboardVisibilityBuilder(
             builder: (context, isKeyboardVisible) {
@@ -255,9 +233,9 @@ class _ScanWiFiNetworkScreenState extends ConsumerState<ScanWiFiNetworkScreen> {
   }
 
   Widget _networkItem(BuildContext context, WiFiNetwork network) {
-    // Parse SSID and check if open (if scan result contains security info)
-    final ssid = _parseSSID(network.ssid);
-    final isOpen = _isOpenNetwork(network.ssid);
+    final wifiPoint = WifiPoint.fromWifiScanResult(network.ssid);
+    final ssid = wifiPoint.ssid;
+    final isOpen = wifiPoint.isOpenNetwork ?? false;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -288,7 +266,7 @@ class _ScanWiFiNetworkScreenState extends ConsumerState<ScanWiFiNetworkScreen> {
                 .read(ff1SetupOrchestratorProvider.notifier)
                 .requestEnterWifiPassword(
                   device: deviceToPass,
-                  wifiAccessPoint: WifiPoint(ssid),
+                  wifiAccessPoint: wifiPoint,
                 );
           },
           child: SizedBox(

--- a/lib/ui/screens/send_wifi_credentials_screen.dart
+++ b/lib/ui/screens/send_wifi_credentials_screen.dart
@@ -87,28 +87,6 @@ class _EnterWiFiPasswordScreenState
   ProviderSubscription<FF1SetupState>? _setupSub;
   ProviderSubscription<WiFiConnectionState>? _wifiErrorSub;
 
-  /// Parse SSID from networkSsid (may contain "ssid|security" format)
-  String _parseSSID(String ssid) {
-    if (ssid.contains('|')) {
-      final parts = ssid.split('|');
-      return parts.isNotEmpty ? parts.first : ssid;
-    }
-    return ssid;
-  }
-
-  /// Check if network is open (from "ssid|security" format)
-  bool _isOpenNetwork(String ssid) {
-    if (!ssid.contains('|')) {
-      return false;
-    }
-    final parts = ssid.split('|');
-    if (parts.length > 1) {
-      final security = parts[1].trim().toUpperCase();
-      return security == 'OPEN';
-    }
-    return false;
-  }
-
   @override
   void initState() {
     super.initState();
@@ -150,7 +128,7 @@ class _EnterWiFiPasswordScreenState
       },
     );
 
-    final isOpen = _isOpenNetwork(widget.payload.wifiAccessPoint.ssid);
+    final isOpen = widget.payload.wifiAccessPoint.isOpenNetwork ?? false;
     if (isOpen) {
       // Auto-submit for open networks
       unawaited(Future.microtask(_handleSendCredentials));
@@ -174,7 +152,7 @@ class _EnterWiFiPasswordScreenState
   }
 
   Future<void> _handleSendCredentials() async {
-    final isOpen = _isOpenNetwork(widget.payload.wifiAccessPoint.ssid);
+    final isOpen = widget.payload.wifiAccessPoint.isOpenNetwork ?? false;
     final password = isOpen ? '' : _passwordController.text.trim();
 
     if (!isOpen && password.isEmpty) {
@@ -199,7 +177,7 @@ class _EnterWiFiPasswordScreenState
         .read(ff1SetupOrchestratorProvider.notifier)
         .sendWifiCredentialsAndConnect(
           device: widget.payload.device,
-          ssid: _parseSSID(widget.payload.wifiAccessPoint.ssid),
+          ssid: widget.payload.wifiAccessPoint.ssid,
           password: password,
         );
   }
@@ -246,7 +224,7 @@ class _EnterWiFiPasswordScreenState
                 }
               : null,
         );
-        if (_isOpenNetwork(widget.payload.wifiAccessPoint.ssid) && mounted) {
+        if ((widget.payload.wifiAccessPoint.isOpenNetwork ?? false) && mounted) {
           context.pop();
         }
         setState(() {
@@ -272,8 +250,8 @@ class _EnterWiFiPasswordScreenState
       localProcessingFlag: _isProcessing,
       status: connectionState.status,
     );
-    final isOpen = _isOpenNetwork(widget.payload.wifiAccessPoint.ssid);
-    final parsedSsid = _parseSSID(widget.payload.wifiAccessPoint.ssid);
+    final isOpen = widget.payload.wifiAccessPoint.isOpenNetwork ?? false;
+    final parsedSsid = widget.payload.wifiAccessPoint.ssid;
     // Open networks don't need a password; closed networks require one.
     final canSubmit = isOpen || _passwordText.trim().isNotEmpty;
     final reservedBottomBarHeight = shouldReserveNowDisplayingBar
@@ -289,7 +267,7 @@ class _EnterWiFiPasswordScreenState
       body: SafeArea(
         child: Padding(
           padding: EdgeInsets.symmetric(
-            horizontal: LayoutConstants.setupPageHorizontal,
+            horizontal: LayoutConstants.pageHorizontalDefault,
           ),
           child: isProcessing
               ? _buildProcessingView(parsedSsid)

--- a/lib/ui/screens/settings/forget_exist_dialog_content.dart
+++ b/lib/ui/screens/settings/forget_exist_dialog_content.dart
@@ -90,7 +90,7 @@ class _ForgetExistDialogContentState
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Padding(
-                        padding: const EdgeInsets.only(top: 8),
+                        padding: EdgeInsets.only(top: LayoutConstants.space2),
                         child: _dotIcon(color: AppColor.white),
                       ),
                       SizedBox(width: LayoutConstants.space3),
@@ -109,7 +109,7 @@ class _ForgetExistDialogContentState
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Padding(
-                        padding: const EdgeInsets.only(top: 8),
+                        padding: EdgeInsets.only(top: LayoutConstants.space2),
                         child: _dotIcon(color: AppColor.white),
                       ),
                       SizedBox(width: LayoutConstants.space3),
@@ -127,7 +127,7 @@ class _ForgetExistDialogContentState
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Padding(
-                        padding: const EdgeInsets.only(top: 8),
+                        padding: EdgeInsets.only(top: LayoutConstants.space2),
                         child: _dotIcon(color: AppColor.white),
                       ),
                       SizedBox(width: LayoutConstants.space3),

--- a/lib/ui/screens/settings/settings_page.dart
+++ b/lib/ui/screens/settings/settings_page.dart
@@ -259,7 +259,10 @@ class _VersionSection extends StatelessWidget {
         SizedBox(height: LayoutConstants.space6),
         if (packageInfo != null)
           Container(
-            padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 12),
+            padding: EdgeInsets.symmetric(
+              vertical: LayoutConstants.space2,
+              horizontal: LayoutConstants.space3,
+            ),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(50),
               border: Border.all(color: outlineColor),

--- a/lib/widgets/buttons/custom_primary_button.dart
+++ b/lib/widgets/buttons/custom_primary_button.dart
@@ -1,4 +1,3 @@
-import 'package:app/design/layout_constants.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:flutter/material.dart';
 
@@ -15,7 +14,7 @@ class CustomPrimaryButton extends StatelessWidget {
     this.isProcessing = false,
     this.borderColor,
     this.indicatorColor,
-    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
+    this.padding = const EdgeInsets.symmetric(vertical: 12),
     this.borderRadius = 32,
     this.textColor,
   });

--- a/lib/widgets/buttons/custom_primary_button.dart
+++ b/lib/widgets/buttons/custom_primary_button.dart
@@ -1,3 +1,4 @@
+import 'package:app/design/layout_constants.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:flutter/material.dart';
 
@@ -14,7 +15,7 @@ class CustomPrimaryButton extends StatelessWidget {
     this.isProcessing = false,
     this.borderColor,
     this.indicatorColor,
-    this.padding = const EdgeInsets.symmetric(vertical: 13),
+    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
     this.borderRadius = 32,
     this.textColor,
   });

--- a/lib/widgets/buttons/outline_button.dart
+++ b/lib/widgets/buttons/outline_button.dart
@@ -17,7 +17,7 @@ class OutlineButton extends StatelessWidget {
     this.isProcessing = false,
     this.textColor,
     this.borderColor,
-    this.padding = const EdgeInsets.symmetric(vertical: 13),
+    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
     this.rightIcon,
   });
 

--- a/lib/widgets/buttons/outline_button.dart
+++ b/lib/widgets/buttons/outline_button.dart
@@ -17,7 +17,7 @@ class OutlineButton extends StatelessWidget {
     this.isProcessing = false,
     this.textColor,
     this.borderColor,
-    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
+    this.padding = const EdgeInsets.symmetric(vertical: 12),
     this.rightIcon,
   });
 

--- a/lib/widgets/buttons/primary_button.dart
+++ b/lib/widgets/buttons/primary_button.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:app/design/app_typography.dart';
-import 'package:app/design/layout_constants.dart';
 import 'package:app/domain/utils/debounce_util.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:flutter/material.dart';
@@ -20,7 +19,7 @@ class PrimaryButton extends StatelessWidget {
     this.enabled = true,
     this.isProcessing = false,
     this.indicatorColor,
-    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
+    this.padding = const EdgeInsets.symmetric(vertical: 12),
     this.elevatedPadding,
     this.borderRadius = 32,
     this.borderColor,
@@ -150,7 +149,7 @@ class PrimaryAsyncButton extends StatefulWidget {
     this.borderColor,
     this.borderRadius = 32,
     this.processingText,
-    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
+    this.padding = const EdgeInsets.symmetric(vertical: 12),
   });
 
   /// On tap callback.

--- a/lib/widgets/buttons/primary_button.dart
+++ b/lib/widgets/buttons/primary_button.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:app/design/app_typography.dart';
+import 'package:app/design/layout_constants.dart';
 import 'package:app/domain/utils/debounce_util.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:flutter/material.dart';
@@ -19,7 +20,7 @@ class PrimaryButton extends StatelessWidget {
     this.enabled = true,
     this.isProcessing = false,
     this.indicatorColor,
-    this.padding = const EdgeInsets.symmetric(vertical: 13),
+    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
     this.elevatedPadding,
     this.borderRadius = 32,
     this.borderColor,
@@ -149,7 +150,7 @@ class PrimaryAsyncButton extends StatefulWidget {
     this.borderColor,
     this.borderRadius = 32,
     this.processingText,
-    this.padding = const EdgeInsets.symmetric(vertical: 13),
+    this.padding = EdgeInsets.symmetric(vertical: LayoutConstants.space3),
   });
 
   /// On tap callback.

--- a/patrol_test/gold_path_test.dart
+++ b/patrol_test/gold_path_test.dart
@@ -119,7 +119,7 @@ Future<void> _submitPersonalAddressInOnboarding(
   await _enterAddressAndSubmit($, address);
 
   await $(
-    'See the art you already own',
+    'Your addresses',
   ).waitUntilVisible(timeout: const Duration(minutes: 1));
   await $(address).waitUntilExists(timeout: const Duration(minutes: 1));
 }

--- a/test/unit/domain/models/wifi_point_test.dart
+++ b/test/unit/domain/models/wifi_point_test.dart
@@ -1,0 +1,59 @@
+import 'package:app/domain/models/wifi_point.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('WifiPoint.fromWifiScanResult', () {
+    group('open networks', () {
+      test('marks isOpenNetwork true for OPEN security suffix', () {
+        final point = WifiPoint.fromWifiScanResult('Cafe|OPEN');
+        expect(point.ssid, 'Cafe');
+        expect(point.isOpenNetwork, isTrue);
+      });
+
+      test('is case-insensitive for OPEN suffix', () {
+        expect(
+          WifiPoint.fromWifiScanResult('Cafe|open').isOpenNetwork,
+          isTrue,
+        );
+        expect(
+          WifiPoint.fromWifiScanResult('Cafe|Open').isOpenNetwork,
+          isTrue,
+        );
+      });
+
+      test('trims whitespace around security token', () {
+        final point = WifiPoint.fromWifiScanResult('Cafe| OPEN ');
+        expect(point.ssid, 'Cafe');
+        expect(point.isOpenNetwork, isTrue);
+      });
+    });
+
+    group('secured networks', () {
+      test('marks isOpenNetwork false for WPA2 suffix', () {
+        final point = WifiPoint.fromWifiScanResult('Mars-2026_5G|WPA2');
+        expect(point.ssid, 'Mars-2026_5G');
+        expect(point.isOpenNetwork, isFalse);
+      });
+
+      test('marks isOpenNetwork false for WPA3 suffix', () {
+        final point = WifiPoint.fromWifiScanResult('HomeNetwork|WPA3');
+        expect(point.ssid, 'HomeNetwork');
+        expect(point.isOpenNetwork, isFalse);
+      });
+    });
+
+    group('plain SSIDs (no security suffix)', () {
+      test('returns ssid unchanged and isOpenNetwork false', () {
+        final point = WifiPoint.fromWifiScanResult('PlainSSID');
+        expect(point.ssid, 'PlainSSID');
+        expect(point.isOpenNetwork, isFalse);
+      });
+
+      test('handles SSID with spaces', () {
+        final point = WifiPoint.fromWifiScanResult('My Home Network');
+        expect(point.ssid, 'My Home Network');
+        expect(point.isOpenNetwork, isFalse);
+      });
+    });
+  });
+}

--- a/test/unit/nft_rendering/lifecycle_aware_playback_mixin_test.dart
+++ b/test/unit/nft_rendering/lifecycle_aware_playback_mixin_test.dart
@@ -75,6 +75,39 @@ void main() {
       renderer.simulateLifecycle(AppLifecycleState.resumed);
       expect(renderer.isBackgroundPaused, isFalse);
     });
+
+    group('isInBackground', () {
+      test('is false initially', () {
+        expect(renderer.isInBackground, isFalse);
+      });
+
+      test('is true after paused lifecycle event', () {
+        renderer.simulateLifecycle(AppLifecycleState.paused);
+        expect(renderer.isInBackground, isTrue);
+      });
+
+      test('is true even when media was not playing at backgrounding time', () {
+        // Simulates the async-init race: app goes to background while media
+        // is still loading (isPlaying is false). isInBackground must still
+        // be true so that the init completion guard can skip play().
+        renderer.simulatePlaying(false);
+        renderer.simulateLifecycle(AppLifecycleState.paused);
+
+        expect(renderer.isInBackground, isTrue);
+        expect(renderer.isBackgroundPaused, isFalse); // mixin didn't call pause()
+      });
+
+      test('is false after resumed lifecycle event', () {
+        renderer.simulateLifecycle(AppLifecycleState.paused);
+        renderer.simulateLifecycle(AppLifecycleState.resumed);
+        expect(renderer.isInBackground, isFalse);
+      });
+
+      test('inactive does not set isInBackground', () {
+        renderer.simulateLifecycle(AppLifecycleState.inactive);
+        expect(renderer.isInBackground, isFalse);
+      });
+    });
   });
 }
 

--- a/test/unit/nft_rendering/lifecycle_aware_playback_mixin_test.dart
+++ b/test/unit/nft_rendering/lifecycle_aware_playback_mixin_test.dart
@@ -1,0 +1,114 @@
+import 'package:app/nft_rendering/nft_rendering_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LifecycleAwarePlaybackMixin', () {
+    late _FakeRenderer renderer;
+
+    setUp(() {
+      renderer = _FakeRenderer();
+    });
+
+    test('pauses when app moves to background and isPlaying is true', () {
+      renderer.simulatePlaying(true);
+      renderer.simulateLifecycle(AppLifecycleState.paused);
+
+      expect(renderer.pauseCount, 1);
+      expect(renderer.isBackgroundPaused, isTrue);
+    });
+
+    test('does not pause when app moves to background and isPlaying is false', () {
+      renderer.simulatePlaying(false);
+      renderer.simulateLifecycle(AppLifecycleState.paused);
+
+      expect(renderer.pauseCount, 0);
+      expect(renderer.isBackgroundPaused, isFalse);
+    });
+
+    test('resumes on foreground if it paused for background', () {
+      renderer.simulatePlaying(true);
+      renderer.simulateLifecycle(AppLifecycleState.paused);
+      renderer.simulateLifecycle(AppLifecycleState.resumed);
+
+      expect(renderer.resumeCount, 1);
+      expect(renderer.isBackgroundPaused, isFalse);
+    });
+
+    test('does not resume on foreground if it did not pause for background', () {
+      renderer.simulatePlaying(false);
+      renderer.simulateLifecycle(AppLifecycleState.paused);
+      renderer.simulateLifecycle(AppLifecycleState.resumed);
+
+      expect(renderer.resumeCount, 0);
+    });
+
+    test('manually paused content stays paused after background/foreground', () {
+      // User pauses manually → isPlaying becomes false.
+      renderer.simulatePlaying(false);
+
+      renderer.simulateLifecycle(AppLifecycleState.paused);
+      renderer.simulateLifecycle(AppLifecycleState.resumed);
+
+      // pause() was never called by the mixin; resume() was never called.
+      expect(renderer.pauseCount, 0);
+      expect(renderer.resumeCount, 0);
+    });
+
+    test('inactive state does not trigger pause', () {
+      renderer.simulatePlaying(true);
+      renderer.simulateLifecycle(AppLifecycleState.inactive);
+
+      expect(renderer.pauseCount, 0);
+      expect(renderer.isBackgroundPaused, isFalse);
+    });
+
+    test('isBackgroundPaused is false initially', () {
+      expect(renderer.isBackgroundPaused, isFalse);
+    });
+
+    test('isBackgroundPaused is cleared after resume', () {
+      renderer.simulatePlaying(true);
+      renderer.simulateLifecycle(AppLifecycleState.paused);
+      expect(renderer.isBackgroundPaused, isTrue);
+
+      renderer.simulateLifecycle(AppLifecycleState.resumed);
+      expect(renderer.isBackgroundPaused, isFalse);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Minimal stub that exercises the mixin without a real widget tree.
+// ---------------------------------------------------------------------------
+
+class _FakeNFTWidget extends NFTRenderingWidget {
+  const _FakeNFTWidget();
+
+  @override
+  State<_FakeNFTWidget> createState() => _FakeRenderer();
+}
+
+class _FakeRenderer extends NFTRenderingWidgetState<_FakeNFTWidget>
+    with WidgetsBindingObserver, LifecycleAwarePlaybackMixin {
+  int pauseCount = 0;
+  int resumeCount = 0;
+  bool _playing = false;
+
+  @override
+  bool get isPlaying => _playing;
+
+  void simulatePlaying(bool value) => _playing = value;
+
+  void simulateLifecycle(AppLifecycleState state) =>
+      didChangeAppLifecycleState(state);
+
+  @override
+  void pause() => pauseCount++;
+
+  @override
+  void resume() => resumeCount++;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/test/unit/ui/screens/ff1_setup/enter_wifi_password_screen_navigation_test.dart
+++ b/test/unit/ui/screens/ff1_setup/enter_wifi_password_screen_navigation_test.dart
@@ -130,7 +130,73 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets('open network: password field absent, SizedBox shown', (
+    tester,
+  ) async {
+    final container = ProviderContainer(
+      overrides: [
+        ff1SetupOrchestratorProvider.overrideWith(
+          _NoOpOrchestratorNotifier.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final router = GoRouter(
+      initialLocation: Routes.enterWifiPassword,
+      routes: [
+        GoRoute(
+          path: Routes.enterWifiPassword,
+          builder: (context, state) {
+            final payload = EnterWifiPasswordPagePayload(
+              device: const FF1Device(
+                name: 'FF1',
+                remoteId: '00:11',
+                deviceId: 'FF1-1',
+                topicId: 'topic-1',
+              ),
+              wifiAccessPoint: const WifiPoint('Cafe', isOpenNetwork: true),
+            );
+            return EnterWiFiPasswordScreen(payload: payload);
+          },
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pump();
+
+    // Open networks must never render the password input.
+    expect(find.byType(PasswordTextField), findsNothing);
+  });
 }
+
+class _NoOpOrchestratorNotifier extends FF1SetupOrchestratorNotifier {
+  @override
+  FF1SetupState build() => FF1SetupState(
+    step: FF1SetupStep.idle,
+    effectId: 0,
+    effect: null,
+  );
+
+  @override
+  Future<void> sendWifiCredentialsAndConnect({
+    required FF1Device device,
+    required String ssid,
+    required String password,
+  }) async {}
+
+  @override
+  void ackEffect({required int effectId}) {}
+}
+
+// ---------------------------------------------------------------------------
 
 class _FakeConnectNotifier extends ConnectFF1Notifier {
   _FakeConnectNotifier(this._state);


### PR DESCRIPTION
## Problem

On Android, minimizing the app while an artwork is playing audio left the audio running in the background. The same issue affected video and WebView-based artworks.

## Changes

- **`AudioNFTRenderingWidget`** — add `WidgetsBindingObserver` + pause on `AppLifecycleState.paused`, resume on `resumed`
- **`VideoNFTRenderingWidget`** — same lifecycle handling (observer was already registered but `didChangeAppLifecycleState` was never implemented)
- **`WebviewNFTRenderingWidget`** — extend existing `didChangeAppLifecycleState` to call `onPause()`/`onResume()` on background/foreground transitions
- **`LifecycleAwarePlaybackMixin`** — new mixin on `NFTRenderingWidgetState` that encapsulates the pause-on-background pattern; audio and video use it to avoid duplication

Only `AppLifecycleState.paused` triggers a pause (not `inactive`) to avoid spurious interruptions during in-app navigation transitions.

## Test plan

- [ ] Play an audio artwork, minimize the app — audio stops
- [ ] Return to the app — audio resumes
- [ ] Play a video artwork, minimize the app — video stops
- [ ] Return to the app — video resumes
- [ ] Manually pause a video, minimize and return — video stays paused
- [ ] Play a WebView artwork (interactive/generative), minimize — audio/video in the WebView pauses