### PR TITLE
feat: playback progress indicator and bottom fade gradient

### DIFF
--- a/lib/app/providers/playback_progress_provider.dart
+++ b/lib/app/providers/playback_progress_provider.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+
+import 'package:app/app/providers/ff1_wifi_providers.dart';
+import 'package:app/infra/ff1/wifi_protocol/ff1_wifi_messages.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Default item display duration in seconds when none is specified by DP-1.
+const int _kDefaultItemDurationSeconds = 60;
+
+/// Playback progress state: the item currently being tracked and its progress.
+typedef PlaybackProgressState = ({String? itemId, double progress});
+
+/// Tracks elapsed playback time for the current DP-1 item.
+///
+/// Resets to 0 whenever the current work index changes. Pauses the internal
+/// timer while the player is paused or in sleep mode. Emits progress as a
+/// 0.0–1.0 fraction of the item's duration.
+final playbackProgressProvider =
+    NotifierProvider<PlaybackProgressNotifier, PlaybackProgressState>(
+      PlaybackProgressNotifier.new,
+    );
+
+/// Notifier for [playbackProgressProvider].
+class PlaybackProgressNotifier
+    extends Notifier<PlaybackProgressState> {
+  Timer? _timer;
+  String? _currentItemId;
+  int _currentItemDurationSeconds = _kDefaultItemDurationSeconds;
+  int _elapsedSeconds = 0;
+
+  @override
+  PlaybackProgressState build() {
+    ref
+      ..onDispose(() => _timer?.cancel())
+      ..listen<FF1PlayerStatus?>(
+        ff1CurrentPlayerStatusProvider,
+        (_, next) => _onStatusChanged(next),
+      );
+    // Defer initial sync so build() returns first and state is writable.
+    unawaited(Future.microtask(() {
+      if (!ref.mounted) return;
+      _onStatusChanged(ref.read(ff1CurrentPlayerStatusProvider));
+    }));
+    return (itemId: null, progress: 0.0);
+  }
+
+  void _onStatusChanged(FF1PlayerStatus? status) {
+    if (status == null ||
+        status.items == null ||
+        status.currentWorkIndex == null) {
+      _reset(null);
+      return;
+    }
+
+    final index = status.currentWorkIndex!;
+    final items = status.items!;
+    if (index < 0 || index >= items.length) {
+      _reset(null);
+      return;
+    }
+
+    final item = items[index];
+    final newItemId = item.id;
+    final duration =
+        item.duration > 0 ? item.duration : _kDefaultItemDurationSeconds;
+
+    final shouldPause =
+        status.isPaused || (status.sleepMode == true);
+
+    if (newItemId != _currentItemId) {
+      _reset(newItemId, duration: duration, startTimer: !shouldPause);
+    } else {
+      _currentItemDurationSeconds = duration;
+      if (shouldPause && _timer != null) {
+        _timer!.cancel();
+        _timer = null;
+      } else if (!shouldPause && _timer == null) {
+        _startTimer();
+      }
+    }
+  }
+
+  void _reset(
+    String? itemId, {
+    int duration = _kDefaultItemDurationSeconds,
+    bool startTimer = true,
+  }) {
+    _timer?.cancel();
+    _timer = null;
+    _elapsedSeconds = 0;
+    _currentItemId = itemId;
+    _currentItemDurationSeconds =
+        duration > 0 ? duration : _kDefaultItemDurationSeconds;
+    state = (itemId: itemId, progress: 0.0);
+    if (itemId != null && startTimer) {
+      _startTimer();
+    }
+  }
+
+  void _startTimer() {
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      _elapsedSeconds++;
+      final progress =
+          (_elapsedSeconds / _currentItemDurationSeconds).clamp(0.0, 1.0);
+      state = (itemId: _currentItemId, progress: progress);
+    });
+  }
+}

--- a/lib/widgets/bottom_spacing.dart
+++ b/lib/widgets/bottom_spacing.dart
@@ -3,7 +3,8 @@ import 'package:app/design/layout_constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Bottom spacing widget for consistent spacing at the bottom of scrollable content.
+/// Bottom spacing widget for consistent spacing at the bottom of
+/// scrollable content.
 class BottomSpacing extends ConsumerWidget {
   /// Creates a BottomSpacing widget.
   ///
@@ -24,11 +25,12 @@ class BottomSpacing extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final bottomPadding = MediaQuery.of(context).padding.bottom;
-    final baseHeight = bottomPadding + LayoutConstants.space4;
 
     if (!checkNowDisplayingVisibility) {
       return SizedBox(
-        height: baseHeight + LayoutConstants.nowDisplayingBarReservedHeight,
+        height: bottomPadding +
+            LayoutConstants.space20 +
+            LayoutConstants.nowDisplayingBarReservedHeight,
       );
     }
 
@@ -36,12 +38,17 @@ class BottomSpacing extends ConsumerWidget {
       nowDisplayingVisibilityProvider.select((s) => s.shouldShow),
     );
 
+    // When the bar is visible (not scrolling) use a taller base so
+    // content clears the gradient + bar. When hidden (scrolling) use
+    // a smaller base so an extra row of thumbnails is reachable.
     if (!shouldShow) {
-      return SizedBox(height: baseHeight);
+      return SizedBox(height: bottomPadding);
     }
 
     return SizedBox(
-      height: baseHeight + LayoutConstants.nowDisplayingBarReservedHeight,
+      height: bottomPadding +
+          LayoutConstants.space20 +
+          LayoutConstants.nowDisplayingBarReservedHeight,
     );
   }
 }

--- a/lib/widgets/now_displaying_bar/display_item.dart
+++ b/lib/widgets/now_displaying_bar/display_item.dart
@@ -1,3 +1,4 @@
+import 'package:app/app/providers/playback_progress_provider.dart';
 import 'package:app/design/app_typography.dart';
 import 'package:app/design/content_rhythm.dart';
 import 'package:app/design/image_decode_cache.dart';
@@ -7,12 +8,13 @@ import 'package:app/domain/models/playlist_item.dart';
 import 'package:app/widgets/gallery_thumbnail_widgets.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Display item for Now Displaying bar (collapsed and expanded).
 ///
 /// Matches old repo DisplayItem: landscape thumbnail, optional device name,
 /// artist + title with bold.italic in expanded view.
-class NowDisplayingDisplayItem extends StatelessWidget {
+class NowDisplayingDisplayItem extends ConsumerWidget {
   const NowDisplayingDisplayItem({
     required this.item,
     required this.isPlaying,
@@ -29,8 +31,12 @@ class NowDisplayingDisplayItem extends StatelessWidget {
   final VoidCallback? onTap;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final opacity = isPlaying ? 1.0 : 0.5;
+    final progressState = ref.watch(playbackProgressProvider);
+    final progress = progressState.itemId == item.id
+        ? progressState.progress
+        : null;
 
     // Transparent fill matches e.g. [WorkGridCard]: full-bounds hit target so
     // taps register outside text/thumbnail (Row flex padding).
@@ -45,7 +51,7 @@ class NowDisplayingDisplayItem extends StatelessWidget {
                 ? CrossAxisAlignment.center
                 : CrossAxisAlignment.start,
             children: [
-              _Thumbnail(url: item.thumbnailUrl),
+              _Thumbnail(url: item.thumbnailUrl, progress: progress),
               SizedBox(width: LayoutConstants.nowDisplayingDisplayItemGap),
               Expanded(
                 child: Column(
@@ -108,9 +114,10 @@ class NowDisplayingDisplayItem extends StatelessWidget {
 }
 
 class _Thumbnail extends StatelessWidget {
-  const _Thumbnail({required this.url});
+  const _Thumbnail({required this.url, this.progress});
 
   final String? url;
+  final double? progress;
 
   @override
   Widget build(BuildContext context) {
@@ -123,20 +130,77 @@ class _Thumbnail extends StatelessWidget {
       height: thumbH,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(LayoutConstants.space1),
-        child: url == null || url!.isEmpty
-            ? const GalleryNoThumbnailWidget()
-            : CachedNetworkImage(
-                imageUrl: url!,
-                width: thumbW,
-                height: thumbH,
-                memCacheWidth: decodePixelsForLogicalSize(thumbW, dpr),
-                memCacheHeight: decodePixelsForLogicalSize(thumbH, dpr),
-                fit: BoxFit.cover,
-                // Avoid default low filter — cover looks soft on small tiles.
-                filterQuality: FilterQuality.high,
-                placeholder: (_, _) => const GalleryThumbnailPlaceholder(),
-                errorWidget: (_, _, _) => const GalleryThumbnailErrorWidget(),
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: url == null || url!.isEmpty
+                  ? const GalleryNoThumbnailWidget()
+                  : CachedNetworkImage(
+                      imageUrl: url!,
+                      width: thumbW,
+                      height: thumbH,
+                      memCacheWidth:
+                          decodePixelsForLogicalSize(thumbW, dpr),
+                      memCacheHeight:
+                          decodePixelsForLogicalSize(thumbH, dpr),
+                      fit: BoxFit.cover,
+                      filterQuality: FilterQuality.high,
+                      placeholder: (_, _) =>
+                          const GalleryThumbnailPlaceholder(),
+                      errorWidget: (_, _, _) =>
+                          const GalleryThumbnailErrorWidget(),
+                    ),
+            ),
+            if (progress != null)
+              Positioned(
+                bottom: 2,
+                left: 2,
+                right: 2,
+                child: _ProgressBar(progress: progress!),
               ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ProgressBar extends StatelessWidget {
+  const _ProgressBar({required this.progress});
+
+  final double progress;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(40),
+      child: Container(
+        color: Colors.black,
+        padding: const EdgeInsets.all(3),
+        child: LayoutBuilder(
+          builder: (_, constraints) {
+            final trackWidth = constraints.maxWidth;
+            final fillWidth =
+                trackWidth * progress.clamp(0.0, 1.0);
+            return SizedBox(
+              height: 2,
+              child: Stack(
+                children: [
+                  Container(
+                    width: trackWidth,
+                    height: 2,
+                    color: const Color(0xFF2E2E2E),
+                  ),
+                  Container(
+                    width: fillWidth,
+                    height: 2,
+                    color: Colors.white,
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/widgets/overlays/app_global_overlay_layer.dart
+++ b/lib/widgets/overlays/app_global_overlay_layer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:app/app/providers/app_overlay_provider.dart';
+import 'package:app/app/providers/now_displaying_visibility_provider.dart';
 import 'package:app/design/app_typography.dart';
 import 'package:app/theme/app_color.dart';
 import 'package:app/widgets/now_displaying_bar/now_displaying_bar.dart';
@@ -53,6 +54,7 @@ class AppGlobalOverlayLayer extends ConsumerWidget {
             );
           },
         ),
+        const _BottomFadeGradient(),
         NowDisplayingBarOverlay(router: router),
         Material(
           type: MaterialType.transparency,
@@ -197,6 +199,49 @@ class _ToastOverlayPresenterState
       return;
     }
     ref.read(appOverlayProvider.notifier).removeOverlay(widget.overlay.id);
+  }
+}
+
+class _BottomFadeGradient extends ConsumerWidget {
+  const _BottomFadeGradient();
+
+  static const _fadeHeightBarVisible = 120.0;
+  static const _fadeHeightBarHidden = 48.0;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final barVisible = ref.watch(
+      nowDisplayingVisibilityProvider.select((s) => s.shouldShow),
+    );
+    final fadeHeight = barVisible
+        ? _fadeHeightBarVisible
+        : _fadeHeightBarHidden;
+    final bottomInset = MediaQuery.of(context).padding.bottom;
+    final totalHeight = fadeHeight + bottomInset;
+    final opaqueStop = fadeHeight * 0.37 / totalHeight;
+
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 0,
+      height: totalHeight,
+      child: IgnorePointer(
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              stops: [0.0, opaqueStop, 1.0],
+              colors: const [
+                Color(0x002E2E2E),
+                Color(0xFF2E2E2E),
+                Color(0xFF2E2E2E),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/widgets/work_item_thumbnail.dart
+++ b/lib/widgets/work_item_thumbnail.dart
@@ -50,9 +50,6 @@ class WorkItemThumbnail extends StatelessWidget {
   Widget _buildThumbnail() {
     final thumbnailUrl = item.thumbnailUrl;
     if (thumbnailUrl == null || thumbnailUrl.isEmpty) {
-      // Show loading placeholder when thumbnail is missing
-      // (enrichment in progress)
-      // _log.fine('Thumbnail URL is empty for work: ${item.id}, showing loading placeholder');
       return const GalleryThumbnailPlaceholder();
     }
 

--- a/test/unit/widgets/now_displaying/display_item_widget_test.dart
+++ b/test/unit/widgets/now_displaying/display_item_widget_test.dart
@@ -1,12 +1,16 @@
+import 'package:app/app/providers/ff1_wifi_providers.dart';
+import 'package:app/app/providers/playback_progress_provider.dart';
 import 'package:app/domain/models/dp1/dp1_manifest.dart';
 import 'package:app/domain/models/playlist_item.dart';
 import 'package:app/widgets/now_displaying_bar/display_item.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets(
-    'expanded row tap counts in padding above thumbnail (transparent hit fill)',
+    'expanded row tap counts in padding above thumbnail '
+    '(transparent hit fill)',
     (tester) async {
       var tapCount = 0;
       const item = PlaylistItem(
@@ -18,15 +22,20 @@ void main() {
       );
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Center(
-            child: SizedBox(
-              width: 360,
-              child: NowDisplayingDisplayItem(
-                item: item,
-                isPlaying: false,
-                isInExpandedView: true,
-                onTap: () => tapCount++,
+        ProviderScope(
+          overrides: [
+            ff1CurrentPlayerStatusProvider.overrideWithValue(null),
+          ],
+          child: MaterialApp(
+            home: Center(
+              child: SizedBox(
+                width: 360,
+                child: NowDisplayingDisplayItem(
+                  item: item,
+                  isPlaying: false,
+                  isInExpandedView: true,
+                  onTap: () => tapCount++,
+                ),
               ),
             ),
           ),
@@ -34,10 +43,14 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final rect = tester.getRect(find.byType(NowDisplayingDisplayItem));
-      // Row can be taller than the thumbnail; centered thumbnail leaves a
-      // vertical strip above the image that deferToChild would not hit.
-      await tester.tapAt(Offset(rect.left + 12, rect.top + 1));
+      final rect =
+          tester.getRect(find.byType(NowDisplayingDisplayItem));
+      // Row can be taller than the thumbnail; centered thumbnail
+      // leaves a vertical strip above the image that
+      // deferToChild would not hit.
+      await tester.tapAt(
+        Offset(rect.left + 12, rect.top + 1),
+      );
       await tester.pump();
       expect(tapCount, 1);
     },


### PR DESCRIPTION
## Summary
- Add a timer-based progress bar overlay on the Now Displaying bar thumbnail that tracks elapsed playback time per DP-1 item
- Add a bottom fade gradient (transparent → #2E2E2E) behind the now-displaying bar area, extending past the system nav bar
- Make both gradient height and bottom spacing dynamic: taller when the bar is visible, shorter when the bar hides during scrolling so an extra content row is reachable

## Test plan
- [ ] Verify progress bar appears on the Now Displaying thumbnail and advances over the item duration
- [ ] Verify progress resets when item changes
- [ ] Verify bottom fade gradient is visible at the bottom of list screens
- [ ] Verify gradient shrinks and extra content row appears when scrolling (bar hides)
- [ ] Verify no content is clipped behind the gradient when scrolled to the bottom