### PR TITLE
fix: heal malformed playlists before startup bootstrap

### DIFF
--- a/lib/infra/database/app_database.dart
+++ b/lib/infra/database/app_database.dart
@@ -252,15 +252,16 @@ class AppDatabase extends _$AppDatabase {
     await transaction(() async {
       for (final row in rows) {
         final id = row.read<String>('id');
-        final channelId = _repairPlaylistChannelId(
-          id: id,
-          rawChannelId: row.read<String?>('channel_id'),
-        );
         final ownerAddress = row.read<String?>('owner_address');
         final typeValue = _repairPlaylistTypeValue(
           id: id,
           ownerAddress: ownerAddress,
           rawType: row.read<int?>('type'),
+        );
+        final channelId = _repairPlaylistChannelId(
+          id: id,
+          rawChannelId: row.read<String?>('channel_id'),
+          typeValue: typeValue,
         );
         final rawCreatedAtUs = row.read<int?>('created_at_us');
         final rawUpdatedAtUs = row.read<int?>('updated_at_us');
@@ -321,11 +322,11 @@ class AppDatabase extends _$AppDatabase {
     required String? ownerAddress,
     required int? rawType,
   }) {
-    if (rawType != null && PlaylistType.values.any((t) => t.value == rawType)) {
-      return rawType;
-    }
     if (id == Playlist.favoriteId) {
       return PlaylistType.favorite.value;
+    }
+    if (rawType != null && PlaylistType.values.any((t) => t.value == rawType)) {
+      return rawType;
     }
     if (ownerAddress != null && ownerAddress.trim().isNotEmpty) {
       return PlaylistType.addressBased.value;
@@ -336,8 +337,10 @@ class AppDatabase extends _$AppDatabase {
   String? _repairPlaylistChannelId({
     required String id,
     required String? rawChannelId,
+    required int typeValue,
   }) {
-    if (id == Playlist.favoriteId) {
+    if (id == Playlist.favoriteId ||
+        typeValue == PlaylistType.addressBased.value) {
       return Channel.myCollectionId;
     }
     return rawChannelId;

--- a/lib/infra/database/app_database.dart
+++ b/lib/infra/database/app_database.dart
@@ -232,88 +232,8 @@ class AppDatabase extends _$AppDatabase {
       SELECT id, channel_id, type, title, created_at_us, updated_at_us,
              signatures, owner_address, sort_mode, item_count
       FROM playlists
-      WHERE type IS NULL
-         OR title IS NULL
-         OR created_at_us IS NULL
-         OR updated_at_us IS NULL
-         OR signatures IS NULL
-         OR sort_mode IS NULL
-         OR item_count IS NULL
-         OR type NOT IN (0, 1, 2)
-         OR sort_mode NOT IN (0, 1)
-         OR item_count < 0
-         OR item_count != (
-              SELECT COUNT(*)
-              FROM playlist_entries
-              WHERE playlist_id = playlists.id
-            )
-         OR (type = ? AND id != ?)
-         OR (
-              type = ?
-              AND (owner_address IS NULL OR TRIM(owner_address) = '')
-            )
-         OR (
-              type = ?
-              AND owner_address IS NOT NULL
-              AND TRIM(owner_address) != ''
-            )
-         OR (
-              id != ?
-              AND channel_id = ?
-              AND (owner_address IS NULL OR TRIM(owner_address) = '')
-            )
-         OR (
-              id = ?
-              AND owner_address IS NOT NULL
-              AND TRIM(owner_address) != ''
-            )
-         OR (
-              id = ?
-              AND (
-                type != ?
-                OR channel_id IS NULL
-                OR channel_id != ?
-                OR sort_mode != ?
-                OR title != ?
-              )
-            )
-         OR (
-              (
-                type = ?
-                OR (owner_address IS NOT NULL AND TRIM(owner_address) != '')
-              )
-              AND (
-                type != ?
-                OR channel_id IS NULL
-                OR channel_id != ?
-                OR sort_mode != ?
-              )
-            )
-      ORDER BY
-        CASE
-          WHEN owner_address IS NOT NULL AND TRIM(owner_address) != '' THEN 0
-          ELSE 1
-        END,
-        id
+      ORDER BY id
       ''',
-      variables: [
-        Variable<int>(PlaylistType.favorite.value),
-        const Variable<String>(Playlist.favoriteId),
-        Variable<int>(PlaylistType.addressBased.value),
-        Variable<int>(PlaylistType.addressBased.value),
-        const Variable<String>(Playlist.favoriteId),
-        const Variable<String>(Channel.myCollectionId),
-        const Variable<String>(Playlist.favoriteId),
-        const Variable<String>(Playlist.favoriteId),
-        Variable<int>(PlaylistType.favorite.value),
-        const Variable<String>(Channel.myCollectionId),
-        Variable<int>(PlaylistSortMode.provenance.index),
-        const Variable<String>('Favorites'),
-        Variable<int>(PlaylistType.addressBased.value),
-        Variable<int>(PlaylistType.addressBased.value),
-        const Variable<String>(Channel.myCollectionId),
-        Variable<int>(PlaylistSortMode.provenance.index),
-      ],
       readsFrom: {playlists},
     ).get();
 
@@ -321,9 +241,39 @@ class AppDatabase extends _$AppDatabase {
       return;
     }
 
+    // Inspect every playlist row in Dart so repair selection stays aligned with
+    // the same normalization semantics used by the repair helpers. This avoids
+    // missing malformed rows whose owner/channel values only differ by
+    // Unicode/control whitespace that SQLite's default `TRIM()` does not
+    // consider.
+    rows.sort((a, b) {
+      final aHasOwner =
+          a.read<String?>('owner_address')?.trim().isNotEmpty ?? false;
+      final bHasOwner =
+          b.read<String?>('owner_address')?.trim().isNotEmpty ?? false;
+      if (aHasOwner == bHasOwner) {
+        return a.read<String>('id').compareTo(b.read<String>('id'));
+      }
+      return aHasOwner ? -1 : 1;
+    });
+
+    final entryCountRows = await customSelect(
+      '''
+      SELECT playlist_id, COUNT(*) AS entry_count
+      FROM playlist_entries
+      GROUP BY playlist_id
+      ''',
+      readsFrom: {playlistEntries},
+    ).get();
+    final entryCountsByPlaylistId = {
+      for (final row in entryCountRows)
+        row.read<String>('playlist_id'): row.read<int>('entry_count'),
+    };
+
     final nowUs = DateTime.now().microsecondsSinceEpoch;
     await transaction(() async {
       final supersededSnapshotIds = <String>{};
+      var repairedCount = 0;
       for (final row in rows) {
         final id = row.read<String>('id');
         if (supersededSnapshotIds.contains(id)) {
@@ -332,6 +282,23 @@ class AppDatabase extends _$AppDatabase {
         final rawType = row.read<int?>('type');
         final rawChannelId = row.read<String?>('channel_id');
         final ownerAddress = row.read<String?>('owner_address');
+        final entryCount = entryCountsByPlaylistId[id] ?? 0;
+        if (!_playlistNeedsRepair(
+          id: id,
+          rawChannelId: rawChannelId,
+          rawType: rawType,
+          rawTitle: row.read<String?>('title'),
+          rawCreatedAtUs: row.read<int?>('created_at_us'),
+          rawUpdatedAtUs: row.read<int?>('updated_at_us'),
+          rawSignatures: row.read<String?>('signatures'),
+          ownerAddress: ownerAddress,
+          rawSortMode: row.read<int?>('sort_mode'),
+          rawItemCount: row.read<int?>('item_count'),
+          entryCount: entryCount,
+        )) {
+          continue;
+        }
+        repairedCount++;
         final trimmedRawChannelId = rawChannelId?.trim();
         final hasNonPersonalChannel =
             trimmedRawChannelId != null &&
@@ -344,7 +311,7 @@ class AppDatabase extends _$AppDatabase {
           ownerAddress: ownerAddress,
           hasNonPersonalChannel: hasNonPersonalChannel,
         )) {
-          await _deletePlaylistAndOrphanedItems(id);
+          await _deleteMalformedPlaylistAndOrphanedItems(id);
           continue;
         }
         final typeValue = _repairPlaylistTypeValue(
@@ -447,12 +414,96 @@ class AppDatabase extends _$AppDatabase {
           );
         }
       }
-    });
 
-    _log.warning(
-      'Repaired ${rows.length} malformed playlist row(s) before startup reads',
-    );
+      if (repairedCount > 0) {
+        _log.warning(
+          'Repaired $repairedCount malformed playlist row(s) '
+          'before startup reads',
+        );
+      }
+    });
   }
+
+  bool _playlistNeedsRepair({
+    required String id,
+    required String? rawChannelId,
+    required int? rawType,
+    required String? rawTitle,
+    required int? rawCreatedAtUs,
+    required int? rawUpdatedAtUs,
+    required String? rawSignatures,
+    required String? ownerAddress,
+    required int? rawSortMode,
+    required int? rawItemCount,
+    required int entryCount,
+  }) {
+    final trimmedOwnerAddress = ownerAddress?.trim();
+    final hasOwnerAddress =
+        trimmedOwnerAddress != null && trimmedOwnerAddress.isNotEmpty;
+    final trimmedRawChannelId = rawChannelId?.trim();
+
+    if (rawType == null ||
+        rawTitle == null ||
+        rawCreatedAtUs == null ||
+        rawUpdatedAtUs == null ||
+        rawSignatures == null ||
+        rawSortMode == null ||
+        rawItemCount == null) {
+      return true;
+    }
+    if (!_isValidPlaylistTypeValue(rawType) ||
+        !_isValidPlaylistSortModeValue(rawSortMode)) {
+      return true;
+    }
+    if (rawItemCount < 0 || rawItemCount != entryCount) {
+      return true;
+    }
+    if (ownerAddress != trimmedOwnerAddress) {
+      return true;
+    }
+    if (rawType == PlaylistType.favorite.value && id != Playlist.favoriteId) {
+      return true;
+    }
+    if (rawType == PlaylistType.addressBased.value && !hasOwnerAddress) {
+      return true;
+    }
+    if (id != Playlist.favoriteId &&
+        trimmedRawChannelId == Channel.myCollectionId &&
+        !hasOwnerAddress) {
+      return true;
+    }
+    if (id != Playlist.favoriteId &&
+        rawType == PlaylistType.dp1.value &&
+        rawChannelId != null &&
+        trimmedRawChannelId != rawChannelId &&
+        !hasOwnerAddress) {
+      return true;
+    }
+    if (id == Playlist.favoriteId &&
+        (hasOwnerAddress ||
+            rawType != PlaylistType.favorite.value ||
+            rawChannelId == null ||
+            rawChannelId != Channel.myCollectionId ||
+            rawSortMode != PlaylistSortMode.provenance.index ||
+            rawTitle != 'Favorites')) {
+      return true;
+    }
+    if (hasOwnerAddress &&
+        (rawType != PlaylistType.addressBased.value ||
+            id != PlaylistExt.addressPlaylistId(trimmedOwnerAddress) ||
+            rawChannelId == null ||
+            rawChannelId != Channel.myCollectionId ||
+            rawSortMode != PlaylistSortMode.provenance.index)) {
+      return true;
+    }
+    return false;
+  }
+
+  bool _isValidPlaylistTypeValue(int rawType) =>
+      PlaylistType.values.any((type) => type.value == rawType);
+
+  bool _isValidPlaylistSortModeValue(int rawSortMode) =>
+      PlaylistSortMode.values.any((mode) => mode.index == rawSortMode);
 
   String? _repairPlaylistOwnerAddress({
     required String id,
@@ -507,14 +558,7 @@ class AppDatabase extends _$AppDatabase {
         .read<String?>('owner_address')
         ?.trim();
     if (canonicalOwnerAddress == null || canonicalOwnerAddress.isEmpty) {
-      await _movePlaylistEntries(
-        sourcePlaylistId: targetPlaylistId,
-        targetPlaylistId: sourcePlaylistId,
-      );
-      await customStatement(
-        'DELETE FROM playlists WHERE id = ?',
-        <Object?>[targetPlaylistId],
-      );
+      await _deleteMalformedPlaylistAndOrphanedItems(targetPlaylistId);
       return (
         mergedIntoExistingCanonical: false,
         supersededSnapshotId: targetPlaylistId,
@@ -562,7 +606,9 @@ class AppDatabase extends _$AppDatabase {
     );
   }
 
-  Future<void> _deletePlaylistAndOrphanedItems(String playlistId) async {
+  Future<void> _deleteMalformedPlaylistAndOrphanedItems(
+    String playlistId,
+  ) async {
     final itemRows = await customSelect(
       '''
       SELECT item_id
@@ -583,6 +629,10 @@ class AppDatabase extends _$AppDatabase {
       playlists,
     )..where((playlist) => playlist.id.equals(playlistId))).go();
 
+    // Blank-owner My Collection rows have no valid owner or channel identity,
+    // so their item references cannot be surfaced safely through personal
+    // playlist recovery. We purge now-unreferenced items here to avoid leaking
+    // ghost works/search hits back into the global read model.
     for (final itemId in itemIds) {
       final refRow = await customSelect(
         '''
@@ -657,6 +707,9 @@ class AppDatabase extends _$AppDatabase {
     if (id == Playlist.favoriteId ||
         typeValue == PlaylistType.addressBased.value) {
       return Channel.myCollectionId;
+    }
+    if (rawChannelId != null && rawChannelId.isEmpty) {
+      return null;
     }
     if (id != Playlist.favoriteId &&
         typeValue != PlaylistType.addressBased.value &&

--- a/lib/infra/database/app_database.dart
+++ b/lib/infra/database/app_database.dart
@@ -219,6 +219,8 @@ class AppDatabase extends _$AppDatabase {
       'created_at_us',
       'updated_at_us',
       'signatures',
+      'defaults_json',
+      'dynamic_queries_json',
       'sort_mode',
       'item_count',
       'owner_address',
@@ -230,7 +232,8 @@ class AppDatabase extends _$AppDatabase {
     final rows = await customSelect(
       '''
       SELECT id, channel_id, type, title, created_at_us, updated_at_us,
-             signatures, owner_address, sort_mode, item_count
+             signatures, defaults_json, dynamic_queries_json, owner_address,
+             sort_mode, item_count
       FROM playlists
       ORDER BY id
       ''',
@@ -360,6 +363,16 @@ class AppDatabase extends _$AppDatabase {
         final signatures = _repairPlaylistSignaturesJson(
           row.read<String?>('signatures'),
         );
+        final defaultsJson = _repairPlaylistDefaultsJson(
+          rawDefaultsJson: row.read<String?>('defaults_json'),
+          rawType: rawType,
+          typeValue: typeValue,
+        );
+        final dynamicQueriesJson = _repairPlaylistDynamicQueriesJson(
+          rawDynamicQueriesJson: row.read<String?>('dynamic_queries_json'),
+          rawType: rawType,
+          typeValue: typeValue,
+        );
         final sortMode = _repairPlaylistSortModeValue(
           rawSortMode: row.read<int?>('sort_mode'),
           typeValue: typeValue,
@@ -385,6 +398,8 @@ class AppDatabase extends _$AppDatabase {
               created_at_us = ?,
               updated_at_us = ?,
               signatures = ?,
+              defaults_json = ?,
+              dynamic_queries_json = ?,
               sort_mode = ?,
               item_count = ?
           WHERE id = ?
@@ -398,6 +413,8 @@ class AppDatabase extends _$AppDatabase {
             createdAtUs,
             updatedAtUs,
             signatures,
+            defaultsJson,
+            dynamicQueriesJson,
             sortMode,
             itemCount,
             id,
@@ -681,6 +698,10 @@ class AppDatabase extends _$AppDatabase {
     final hasOwnerAddress =
         trimmedOwnerAddress != null && trimmedOwnerAddress.isNotEmpty;
     if (hasOwnerAddress &&
+        id == PlaylistExt.addressPlaylistId(trimmedOwnerAddress)) {
+      return PlaylistType.addressBased.value;
+    }
+    if (hasOwnerAddress &&
         (rawType == PlaylistType.addressBased.value ||
             rawChannelId == Channel.myCollectionId ||
             !hasNonPersonalChannel)) {
@@ -744,6 +765,38 @@ class AppDatabase extends _$AppDatabase {
     final trimmed = rawSignatures?.trim();
     if (trimmed == null || trimmed.isEmpty) {
       return '[]';
+    }
+    return trimmed;
+  }
+
+  String? _repairPlaylistDefaultsJson({
+    required String? rawDefaultsJson,
+    required int? rawType,
+    required int typeValue,
+  }) {
+    if (rawType == PlaylistType.addressBased.value &&
+        typeValue != PlaylistType.addressBased.value) {
+      return null;
+    }
+    final trimmed = rawDefaultsJson?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return null;
+    }
+    return trimmed;
+  }
+
+  String? _repairPlaylistDynamicQueriesJson({
+    required String? rawDynamicQueriesJson,
+    required int? rawType,
+    required int typeValue,
+  }) {
+    if (rawType == PlaylistType.addressBased.value &&
+        typeValue != PlaylistType.addressBased.value) {
+      return null;
+    }
+    final trimmed = rawDynamicQueriesJson?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return null;
     }
     return trimmed;
   }

--- a/lib/infra/database/app_database.dart
+++ b/lib/infra/database/app_database.dart
@@ -6,6 +6,7 @@ import 'package:app/domain/models/channel.dart';
 import 'package:app/domain/models/playlist.dart';
 import 'package:app/infra/database/seed_database_gate.dart';
 import 'package:app/infra/database/tables.dart';
+import 'package:crypto/crypto.dart';
 import 'package:drift/drift.dart';
 import 'package:drift/isolate.dart';
 import 'package:drift/native.dart';
@@ -27,6 +28,12 @@ const _dbResetReindexMarkerFile = 'db_reset_requires_reindex.flag';
 const _ftsMetadataFallbackRank = 500.0;
 const _playlistRepairMarkerTable = 'internal_repair_markers';
 const _playlistRepairMarkerKey = 'playlist_repair_v1_completed';
+const _playlistRepairGenerationKey = 'playlist_repair_v1_generation';
+const _playlistRepairCompletedGenerationKey =
+    'playlist_repair_v1_completed_generation';
+const _playlistRepairStateSidecarSuffix = '.playlist_repair_state.json';
+const _sqliteDatabaseHeaderBytes = 100;
+const _sqliteWalHeaderBytes = 32;
 
 extension _SearchQueryTokens on String {
   List<String> get searchTokens {
@@ -47,17 +54,30 @@ extension _SearchQueryTokens on String {
   tables: [Publishers, Channels, Playlists, Items, PlaylistEntries],
 )
 class AppDatabase extends _$AppDatabase {
+
   /// Creates an AppDatabase instance.
-  AppDatabase() : super(_openConnection());
+  AppDatabase() : this._(_openConnection());
+  AppDatabase._(
+    super.e, {
+    VoidCallback? onPlaylistRepairHashFallback,
+  }) : _onPlaylistRepairHashFallback = onPlaylistRepairHashFallback;
 
   /// Creates an AppDatabase instance from a Drift [DatabaseConnection].
   ///
   /// Used by `computeWithDatabase` to run heavy DB work in a short-lived
   /// isolate while reusing the same sqlite connection.
-  AppDatabase.fromConnection(DatabaseConnection super.e);
+  AppDatabase.fromConnection(DatabaseConnection e) : this._(e);
 
   /// Creates an AppDatabase instance with a custom executor (for testing).
-  AppDatabase.forTesting(super.e);
+  AppDatabase.forTesting(
+    QueryExecutor e, {
+    VoidCallback? onPlaylistRepairHashFallback,
+  }) : this._(
+         e,
+         onPlaylistRepairHashFallback: onPlaylistRepairHashFallback,
+       );
+
+  final VoidCallback? _onPlaylistRepairHashFallback;
 
   @override
   int get schemaVersion => _schemaVersionV1;
@@ -84,9 +104,16 @@ class AppDatabase extends _$AppDatabase {
         await _createIndexes();
         final hadFtsInfrastructure = await _hasCompleteFtsInfrastructure();
         await _createFtsInfrastructure();
-        await _repairMalformedPlaylistRowsIfNeeded();
+        final shouldRefreshPlaylistRepairSidecar =
+            await _repairMalformedPlaylistRowsIfNeeded();
         if (details.wasCreated || details.hadUpgrade || !hadFtsInfrastructure) {
           await _rebuildFtsIndexes();
+        }
+        if (shouldRefreshPlaylistRepairSidecar &&
+            await _hasRepairMarker(_playlistRepairMarkerKey)) {
+          await _writePlaylistRepairSidecar(
+            await _currentPlaylistRepairGeneration(),
+          );
         }
       },
     );
@@ -211,8 +238,8 @@ class AppDatabase extends _$AppDatabase {
   /// providers and services. This preserves the offline-first contract: the app
   /// should repair readable local state and keep going when the damage is local
   /// to a few playlist rows.
-  Future<void> _repairMalformedPlaylistRowsIfNeeded() async {
-    await _ensureRepairMarkerTable();
+  Future<bool> _repairMalformedPlaylistRowsIfNeeded() async {
+    await _ensureRepairMarkerInfrastructure();
     final cols = await _playlistTableColumnNames();
     const requiredCols = {
       'id',
@@ -230,14 +257,34 @@ class AppDatabase extends _$AppDatabase {
     };
     final hasRepairMarker = await _hasRepairMarker(_playlistRepairMarkerKey);
     if (hasRepairMarker && !requiredCols.every(cols.contains)) {
-      return;
+      return false;
     }
+    final currentRepairGeneration = await _currentPlaylistRepairGeneration();
     if (!requiredCols.every(cols.contains)) {
-      await _markRepairCompleted(_playlistRepairMarkerKey);
-      return;
+      await _markRepairCompleted(
+        key: _playlistRepairMarkerKey,
+        value: currentRepairGeneration,
+      );
+      await _markRepairCompleted(
+        key: _playlistRepairCompletedGenerationKey,
+        value: currentRepairGeneration,
+      );
+      return true;
+    }
+    if (hasRepairMarker &&
+        await _playlistRepairSidecarMatches(currentRepairGeneration)) {
+      return false;
     }
     if (hasRepairMarker && !await _playlistMayNeedRepair()) {
-      return;
+      await _markRepairCompleted(
+        key: _playlistRepairMarkerKey,
+        value: currentRepairGeneration,
+      );
+      await _markRepairCompleted(
+        key: _playlistRepairCompletedGenerationKey,
+        value: currentRepairGeneration,
+      );
+      return true;
     }
 
     final rows = await customSelect(
@@ -252,8 +299,15 @@ class AppDatabase extends _$AppDatabase {
     ).get();
 
     if (rows.isEmpty) {
-      await _markRepairCompleted(_playlistRepairMarkerKey);
-      return;
+      await _markRepairCompleted(
+        key: _playlistRepairMarkerKey,
+        value: currentRepairGeneration,
+      );
+      await _markRepairCompleted(
+        key: _playlistRepairCompletedGenerationKey,
+        value: currentRepairGeneration,
+      );
+      return true;
     }
 
     // Inspect every playlist row in Dart so repair selection stays aligned with
@@ -286,6 +340,7 @@ class AppDatabase extends _$AppDatabase {
     };
 
     final nowUs = DateTime.now().microsecondsSinceEpoch;
+    var repairedGeneration = currentRepairGeneration;
     await transaction(() async {
       final supersededSnapshotIds = <String>{};
       var repairedCount = 0;
@@ -456,11 +511,20 @@ class AppDatabase extends _$AppDatabase {
           'before startup reads',
         );
       }
-      await _markRepairCompleted(_playlistRepairMarkerKey);
+      repairedGeneration = await _currentPlaylistRepairGeneration();
+      await _markRepairCompleted(
+        key: _playlistRepairMarkerKey,
+        value: repairedGeneration,
+      );
+      await _markRepairCompleted(
+        key: _playlistRepairCompletedGenerationKey,
+        value: repairedGeneration,
+      );
     });
+    return true;
   }
 
-  Future<void> _ensureRepairMarkerTable() async {
+  Future<void> _ensureRepairMarkerInfrastructure() async {
     await customStatement(
       '''
       CREATE TABLE IF NOT EXISTS $_playlistRepairMarkerTable (
@@ -468,6 +532,36 @@ class AppDatabase extends _$AppDatabase {
         completed_at_us INTEGER NOT NULL
       )
       ''',
+    );
+    await _ensurePlaylistRepairGenerationTrigger(
+      name: 'playlist_repair_generation_playlists_ai',
+      table: 'playlists',
+      event: 'INSERT',
+    );
+    await _ensurePlaylistRepairGenerationTrigger(
+      name: 'playlist_repair_generation_playlists_au',
+      table: 'playlists',
+      event: 'UPDATE',
+    );
+    await _ensurePlaylistRepairGenerationTrigger(
+      name: 'playlist_repair_generation_playlists_ad',
+      table: 'playlists',
+      event: 'DELETE',
+    );
+    await _ensurePlaylistRepairGenerationTrigger(
+      name: 'playlist_repair_generation_entries_ai',
+      table: 'playlist_entries',
+      event: 'INSERT',
+    );
+    await _ensurePlaylistRepairGenerationTrigger(
+      name: 'playlist_repair_generation_entries_au',
+      table: 'playlist_entries',
+      event: 'UPDATE',
+    );
+    await _ensurePlaylistRepairGenerationTrigger(
+      name: 'playlist_repair_generation_entries_ad',
+      table: 'playlist_entries',
+      event: 'DELETE',
     );
   }
 
@@ -484,15 +578,227 @@ class AppDatabase extends _$AppDatabase {
     return row != null;
   }
 
-  Future<void> _markRepairCompleted(String key) async {
+  Future<void> _markRepairCompleted({
+    required String key,
+    required int value,
+  }) async {
     await customStatement(
       '''
       INSERT OR REPLACE INTO $_playlistRepairMarkerTable (
         key, completed_at_us
       ) VALUES (?, ?)
       ''',
-      <Object?>[key, DateTime.now().microsecondsSinceEpoch],
+      <Object?>[key, value],
     );
+  }
+
+  Future<void> _ensurePlaylistRepairGenerationTrigger({
+    required String name,
+    required String table,
+    required String event,
+  }) async {
+    await customStatement(
+      '''
+      CREATE TRIGGER IF NOT EXISTS $name
+      AFTER $event ON $table
+      BEGIN
+        INSERT INTO $_playlistRepairMarkerTable (key, completed_at_us)
+        VALUES ('$_playlistRepairGenerationKey', 1)
+        ON CONFLICT(key) DO UPDATE
+        SET completed_at_us = completed_at_us + 1;
+      END
+      ''',
+    );
+  }
+
+  Future<int?> _repairMarkerValue(String key) async {
+    final row = await customSelect(
+      '''
+      SELECT completed_at_us
+      FROM $_playlistRepairMarkerTable
+      WHERE key = ?
+      LIMIT 1
+      ''',
+      variables: [Variable<String>(key)],
+    ).getSingleOrNull();
+    return row?.read<int>('completed_at_us');
+  }
+
+  Future<int> _currentPlaylistRepairGeneration() async {
+    return await _repairMarkerValue(_playlistRepairGenerationKey) ?? 0;
+  }
+
+  Future<bool> _playlistRepairSidecarMatches(int currentGeneration) async {
+    final sidecar = await _playlistRepairSidecarFile();
+    if (sidecar == null || !sidecar.existsSync()) {
+      return false;
+    }
+    try {
+      final raw = sidecar.readAsStringSync();
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) {
+        return false;
+      }
+      if (decoded['generation'] != currentGeneration) {
+        return false;
+      }
+
+      final expectedFingerprints = decoded['files'];
+      if (expectedFingerprints is! Map<String, dynamic>) {
+        return false;
+      }
+      final currentMetadata = await _playlistRepairFileMetadata();
+      if (_playlistRepairStoredMetadataMatches(
+        expectedFingerprints: expectedFingerprints,
+        currentMetadata: currentMetadata,
+      )) {
+        return true;
+      }
+      _onPlaylistRepairHashFallback?.call();
+      final currentFingerprints = await _playlistRepairFileFingerprints();
+      return jsonEncode(expectedFingerprints) ==
+          jsonEncode(currentFingerprints);
+    } on Object {
+      return false;
+    }
+  }
+
+  Future<void> _writePlaylistRepairSidecar(int generation) async {
+    final sidecar = await _playlistRepairSidecarFile();
+    if (sidecar == null) {
+      return;
+    }
+    try {
+      final payload = <String, Object?>{
+        'generation': generation,
+        'files': await _playlistRepairFileFingerprints(),
+      };
+      File('${sidecar.path}.tmp')
+        ..writeAsStringSync(jsonEncode(payload), flush: true)
+        ..renameSync(sidecar.path);
+    } on Object {
+      // The sidecar is only a startup fast-path cache. If it can't be written,
+      // keep the DB repair result and let the next open fall back to probing.
+    }
+  }
+
+  Future<File?> _playlistRepairSidecarFile() async {
+    final mainDbFile = await _playlistRepairMainDatabaseFile();
+    if (mainDbFile == null) {
+      return null;
+    }
+    return File('${mainDbFile.path}$_playlistRepairStateSidecarSuffix');
+  }
+
+  Future<File?> _playlistRepairMainDatabaseFile() async {
+    final rows = await customSelect('PRAGMA database_list').get();
+    for (final row in rows) {
+      final filePath = row.read<String?>('file');
+      if (filePath == null || filePath.isEmpty) {
+        continue;
+      }
+      return File(filePath);
+    }
+    return null;
+  }
+
+  Future<Map<String, Object?>> _playlistRepairFileFingerprints() async {
+    final mainDbFile = await _playlistRepairMainDatabaseFile();
+    if (mainDbFile == null) {
+      return const {};
+    }
+    // SQLite's `-shm` file is a volatile connection-side cache for WAL
+    // coordination, not durable playlist state. Excluding it keeps healthy
+    // reopens on the metadata-only fast path instead of forcing content hashes
+    // whenever a no-op reopen refreshes shared-memory bookkeeping.
+    return <String, Object?>{
+      'db': _playlistRepairFileFingerprint(mainDbFile),
+      'wal': _playlistRepairFileFingerprint(File('${mainDbFile.path}-wal')),
+    };
+  }
+
+  Future<Map<String, Object?>> _playlistRepairFileMetadata() async {
+    final mainDbFile = await _playlistRepairMainDatabaseFile();
+    if (mainDbFile == null) {
+      return const {};
+    }
+    return <String, Object?>{
+      'db': _playlistRepairFileMetadataEntry(mainDbFile),
+      'wal': _playlistRepairFileMetadataEntry(File('${mainDbFile.path}-wal')),
+    };
+  }
+
+  bool _playlistRepairStoredMetadataMatches({
+    required Map<String, dynamic> expectedFingerprints,
+    required Map<String, Object?> currentMetadata,
+  }) {
+    for (final key in currentMetadata.keys) {
+      final expectedEntry = expectedFingerprints[key];
+      final currentEntry = currentMetadata[key];
+      if (expectedEntry is! Map<String, dynamic> || currentEntry is! Map) {
+        return false;
+      }
+      if (expectedEntry['exists'] != currentEntry['exists'] ||
+          expectedEntry['size'] != currentEntry['size'] ||
+          expectedEntry['modified_at_us'] != currentEntry['modified_at_us'] ||
+          expectedEntry['changed_at_us'] != currentEntry['changed_at_us']) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  Map<String, Object?> _playlistRepairFileMetadataEntry(File file) {
+    if (!file.existsSync()) {
+      return const {'exists': false};
+    }
+    final stat = file.statSync();
+    return <String, Object?>{
+      'exists': true,
+      'size': stat.size,
+      'modified_at_us': stat.modified.microsecondsSinceEpoch,
+      'changed_at_us': stat.changed.microsecondsSinceEpoch,
+    };
+  }
+
+  Map<String, Object?> _playlistRepairFileFingerprint(File file) {
+    if (!file.existsSync()) {
+      return const {'exists': false};
+    }
+    final stat = file.statSync();
+    final raf = file.openSync();
+    try {
+      final hashStartOffset = _playlistRepairFingerprintHashStartOffset(
+        file: file,
+        fileSize: stat.size,
+      );
+      raf.setPositionSync(hashStartOffset);
+      final content = raf.readSync(stat.size - hashStartOffset);
+      return <String, Object?>{
+        'exists': true,
+        'size': stat.size,
+        'modified_at_us': stat.modified.microsecondsSinceEpoch,
+        'changed_at_us': stat.changed.microsecondsSinceEpoch,
+        'content_sha256': sha256.convert(content).toString(),
+      };
+    } finally {
+      raf.closeSync();
+    }
+  }
+
+  int _playlistRepairFingerprintHashStartOffset({
+    required File file,
+    required int fileSize,
+  }) {
+    if (file.path.endsWith('-wal')) {
+      return fileSize > _sqliteWalHeaderBytes ? _sqliteWalHeaderBytes : 0;
+    }
+    if (file.path.endsWith('-shm')) {
+      return 0;
+    }
+    return fileSize > _sqliteDatabaseHeaderBytes
+        ? _sqliteDatabaseHeaderBytes
+        : 0;
   }
 
   Future<bool> _playlistMayNeedRepair() async {
@@ -866,14 +1172,15 @@ class AppDatabase extends _$AppDatabase {
     final trimmedOwnerAddress = ownerAddress?.trim();
     final hasOwnerAddress =
         trimmedOwnerAddress != null && trimmedOwnerAddress.isNotEmpty;
+    // A surviving nonblank owner is the strongest identity signal we have for
+    // a personal playlist. Favor healing back into the personal collection
+    // instead of dropping ownership just because id/channel/type drifted.
     if (hasOwnerAddress &&
-        id == PlaylistExt.addressPlaylistId(trimmedOwnerAddress)) {
-      return PlaylistType.addressBased.value;
-    }
-    if (hasOwnerAddress &&
-        (rawType == PlaylistType.addressBased.value ||
+        (id == PlaylistExt.addressPlaylistId(trimmedOwnerAddress) ||
+            rawType == PlaylistType.addressBased.value ||
             rawChannelId == Channel.myCollectionId ||
-            !hasNonPersonalChannel)) {
+            !hasNonPersonalChannel ||
+            rawType == PlaylistType.dp1.value)) {
       return PlaylistType.addressBased.value;
     }
     if (rawType == PlaylistType.favorite.value) {

--- a/lib/infra/database/app_database.dart
+++ b/lib/infra/database/app_database.dart
@@ -78,10 +78,11 @@ class AppDatabase extends _$AppDatabase {
         // Repair DBs where user_version already advanced but `signatures_json`
         // remains (failed migration, copied file, or pre-release builds).
         await _migratePlaylistsSignaturesJsonIfNeeded();
-        await _repairMalformedPlaylistRowsIfNeeded();
         await _createIndexes();
+        final hadFtsInfrastructure = await _hasCompleteFtsInfrastructure();
         await _createFtsInfrastructure();
-        if (details.wasCreated || details.hadUpgrade) {
+        await _repairMalformedPlaylistRowsIfNeeded();
+        if (details.wasCreated || details.hadUpgrade || !hadFtsInfrastructure) {
           await _rebuildFtsIndexes();
         }
       },
@@ -240,7 +241,70 @@ class AppDatabase extends _$AppDatabase {
          OR type NOT IN (0, 1, 2)
          OR sort_mode NOT IN (0, 1)
          OR item_count < 0
+         OR (type = ? AND id != ?)
+         OR (
+              id = ?
+              AND item_count != (
+                SELECT COUNT(*)
+                FROM playlist_entries
+                WHERE playlist_id = playlists.id
+              )
+            )
+         OR (
+              type = ?
+              AND (owner_address IS NULL OR TRIM(owner_address) = '')
+            )
+         OR (
+              id != ?
+              AND channel_id = ?
+              AND (owner_address IS NULL OR TRIM(owner_address) = '')
+            )
+         OR (
+              id = ?
+              AND owner_address IS NOT NULL
+              AND TRIM(owner_address) != ''
+            )
+         OR (
+              id = ?
+              AND (
+                type != ?
+                OR channel_id IS NULL
+                OR channel_id != ?
+                OR sort_mode != ?
+                OR title != ?
+              )
+            )
+         OR (
+              (
+                type = ?
+                OR (owner_address IS NOT NULL AND TRIM(owner_address) != '')
+              )
+              AND (
+                type != ?
+                OR channel_id IS NULL
+                OR channel_id != ?
+                OR sort_mode != ?
+              )
+            )
       ''',
+      variables: [
+        Variable<int>(PlaylistType.favorite.value),
+        const Variable<String>(Playlist.favoriteId),
+        const Variable<String>(Playlist.favoriteId),
+        Variable<int>(PlaylistType.addressBased.value),
+        const Variable<String>(Playlist.favoriteId),
+        const Variable<String>(Channel.myCollectionId),
+        const Variable<String>(Playlist.favoriteId),
+        const Variable<String>(Playlist.favoriteId),
+        Variable<int>(PlaylistType.favorite.value),
+        const Variable<String>(Channel.myCollectionId),
+        Variable<int>(PlaylistSortMode.provenance.index),
+        const Variable<String>('Favorites'),
+        Variable<int>(PlaylistType.addressBased.value),
+        Variable<int>(PlaylistType.addressBased.value),
+        const Variable<String>(Channel.myCollectionId),
+        Variable<int>(PlaylistSortMode.provenance.index),
+      ],
       readsFrom: {playlists},
     ).get();
 
@@ -252,24 +316,49 @@ class AppDatabase extends _$AppDatabase {
     await transaction(() async {
       for (final row in rows) {
         final id = row.read<String>('id');
+        final rawType = row.read<int?>('type');
+        final rawChannelId = row.read<String?>('channel_id');
         final ownerAddress = row.read<String?>('owner_address');
+        final trimmedRawChannelId = rawChannelId?.trim();
+        final hasNonPersonalChannel =
+            trimmedRawChannelId != null &&
+            trimmedRawChannelId.isNotEmpty &&
+            trimmedRawChannelId != Channel.myCollectionId;
+        if (_shouldDeleteMalformedPlaylist(
+          id: id,
+          rawType: rawType,
+          rawChannelId: trimmedRawChannelId,
+          ownerAddress: ownerAddress,
+          hasNonPersonalChannel: hasNonPersonalChannel,
+        )) {
+          await _deletePlaylistAndOrphanedItems(id);
+          continue;
+        }
         final typeValue = _repairPlaylistTypeValue(
           id: id,
+          hasNonPersonalChannel: hasNonPersonalChannel,
+          rawChannelId: trimmedRawChannelId,
           ownerAddress: ownerAddress,
-          rawType: row.read<int?>('type'),
+          rawType: rawType,
         );
         final channelId = _repairPlaylistChannelId(
           id: id,
-          rawChannelId: row.read<String?>('channel_id'),
+          rawChannelId: trimmedRawChannelId,
+          rawType: rawType,
           typeValue: typeValue,
         );
         final rawCreatedAtUs = row.read<int?>('created_at_us');
         final rawUpdatedAtUs = row.read<int?>('updated_at_us');
         final createdAtUs = rawCreatedAtUs ?? rawUpdatedAtUs ?? nowUs;
         final updatedAtUs = rawUpdatedAtUs ?? createdAtUs;
-        final title = _repairPlaylistTitle(
+        final repairedOwnerAddress = _repairPlaylistOwnerAddress(
           id: id,
           ownerAddress: ownerAddress,
+          typeValue: typeValue,
+        );
+        final title = _repairPlaylistTitle(
+          id: id,
+          ownerAddress: repairedOwnerAddress,
           typeValue: typeValue,
           rawTitle: row.read<String?>('title'),
         );
@@ -280,8 +369,12 @@ class AppDatabase extends _$AppDatabase {
           rawSortMode: row.read<int?>('sort_mode'),
           typeValue: typeValue,
         );
-        final itemCount = _repairPlaylistItemCount(
-          row.read<int?>('item_count'),
+        final itemCount = await _repairPlaylistItemCount(
+          playlistId: id,
+          rawItemCount: row.read<int?>('item_count'),
+          forceRecompute:
+              id == Playlist.favoriteId ||
+              row.read<int?>('type') == PlaylistType.favorite.value,
         );
 
         await customStatement(
@@ -290,6 +383,7 @@ class AppDatabase extends _$AppDatabase {
           SET channel_id = ?,
               type = ?,
               title = ?,
+              owner_address = ?,
               created_at_us = ?,
               updated_at_us = ?,
               signatures = ?,
@@ -301,6 +395,7 @@ class AppDatabase extends _$AppDatabase {
             channelId,
             typeValue,
             title,
+            repairedOwnerAddress,
             createdAtUs,
             updatedAtUs,
             signatures,
@@ -317,19 +412,104 @@ class AppDatabase extends _$AppDatabase {
     );
   }
 
+  String? _repairPlaylistOwnerAddress({
+    required String id,
+    required String? ownerAddress,
+    required int typeValue,
+  }) {
+    if (id == Playlist.favoriteId ||
+        typeValue != PlaylistType.addressBased.value) {
+      return null;
+    }
+    final trimmed = ownerAddress?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return null;
+    }
+    return trimmed;
+  }
+
+  Future<void> _deletePlaylistAndOrphanedItems(String playlistId) async {
+    final itemRows = await customSelect(
+      '''
+      SELECT item_id
+      FROM playlist_entries
+      WHERE playlist_id = ?
+      ''',
+      variables: [Variable<String>(playlistId)],
+      readsFrom: {playlistEntries},
+    ).get();
+    final itemIds = itemRows
+        .map((row) => row.read<String>('item_id'))
+        .toList(growable: false);
+
+    await (delete(
+      playlistEntries,
+    )..where((entry) => entry.playlistId.equals(playlistId))).go();
+    await (delete(
+      playlists,
+    )..where((playlist) => playlist.id.equals(playlistId))).go();
+
+    for (final itemId in itemIds) {
+      final refRow = await customSelect(
+        '''
+        SELECT COUNT(*) AS ref_count
+        FROM playlist_entries
+        WHERE item_id = ?
+        ''',
+        variables: [Variable<String>(itemId)],
+        readsFrom: {playlistEntries},
+      ).getSingle();
+      if (refRow.read<int>('ref_count') == 0) {
+        await (delete(items)..where((item) => item.id.equals(itemId))).go();
+      }
+    }
+  }
+
+  bool _shouldDeleteMalformedPlaylist({
+    required String id,
+    required int? rawType,
+    required String? rawChannelId,
+    required String? ownerAddress,
+    required bool hasNonPersonalChannel,
+  }) {
+    if (id == Playlist.favoriteId) {
+      return false;
+    }
+    final hasOwnerAddress =
+        ownerAddress != null && ownerAddress.trim().isNotEmpty;
+    if (!hasOwnerAddress &&
+        (rawChannelId == Channel.myCollectionId ||
+            ((rawType == PlaylistType.addressBased.value ||
+                    rawType == PlaylistType.favorite.value) &&
+                !hasNonPersonalChannel))) {
+      return true;
+    }
+    return false;
+  }
+
   int _repairPlaylistTypeValue({
     required String id,
+    required bool hasNonPersonalChannel,
+    required String? rawChannelId,
     required String? ownerAddress,
     required int? rawType,
   }) {
     if (id == Playlist.favoriteId) {
       return PlaylistType.favorite.value;
     }
+    if (ownerAddress != null &&
+        ownerAddress.trim().isNotEmpty &&
+        (rawChannelId == Channel.myCollectionId || !hasNonPersonalChannel)) {
+      return PlaylistType.addressBased.value;
+    }
+    if (rawType == PlaylistType.favorite.value) {
+      return PlaylistType.dp1.value;
+    }
+    if (rawType == PlaylistType.addressBased.value) {
+      return PlaylistType.dp1.value;
+    }
     if (rawType != null && PlaylistType.values.any((t) => t.value == rawType)) {
       return rawType;
-    }
-    if (ownerAddress != null && ownerAddress.trim().isNotEmpty) {
-      return PlaylistType.addressBased.value;
     }
     return PlaylistType.dp1.value;
   }
@@ -337,11 +517,17 @@ class AppDatabase extends _$AppDatabase {
   String? _repairPlaylistChannelId({
     required String id,
     required String? rawChannelId,
+    required int? rawType,
     required int typeValue,
   }) {
     if (id == Playlist.favoriteId ||
         typeValue == PlaylistType.addressBased.value) {
       return Channel.myCollectionId;
+    }
+    if (id != Playlist.favoriteId &&
+        typeValue != PlaylistType.addressBased.value &&
+        rawChannelId == Channel.myCollectionId) {
+      return null;
     }
     return rawChannelId;
   }
@@ -352,12 +538,12 @@ class AppDatabase extends _$AppDatabase {
     required int typeValue,
     required String? rawTitle,
   }) {
+    if (id == Playlist.favoriteId) {
+      return 'Favorites';
+    }
     final trimmedTitle = rawTitle?.trim();
     if (trimmedTitle != null && trimmedTitle.isNotEmpty) {
       return trimmedTitle;
-    }
-    if (id == Playlist.favoriteId) {
-      return 'Favorites';
     }
     if (typeValue == PlaylistType.addressBased.value &&
         ownerAddress != null &&
@@ -379,23 +565,37 @@ class AppDatabase extends _$AppDatabase {
     required int? rawSortMode,
     required int typeValue,
   }) {
+    if (typeValue == PlaylistType.addressBased.value ||
+        typeValue == PlaylistType.favorite.value) {
+      return PlaylistSortMode.provenance.index;
+    }
     if (rawSortMode != null &&
         PlaylistSortMode.values.any((m) => m.index == rawSortMode)) {
       return rawSortMode;
     }
     switch (typeValue) {
-      case 1:
-      case 2:
-        return PlaylistSortMode.provenance.index;
       case 0:
       default:
         return PlaylistSortMode.position.index;
     }
   }
 
-  int _repairPlaylistItemCount(int? rawItemCount) {
-    if (rawItemCount == null || rawItemCount < 0) {
-      return 0;
+  Future<int> _repairPlaylistItemCount({
+    required String playlistId,
+    required int? rawItemCount,
+    bool forceRecompute = false,
+  }) async {
+    if (forceRecompute || rawItemCount == null || rawItemCount < 0) {
+      final row = await customSelect(
+        '''
+        SELECT COUNT(*) AS entry_count
+        FROM playlist_entries
+        WHERE playlist_id = ?
+        ''',
+        variables: [Variable<String>(playlistId)],
+        readsFrom: {playlistEntries},
+      ).getSingle();
+      return row.read<int>('entry_count');
     }
     return rawItemCount;
   }
@@ -555,6 +755,34 @@ class AppDatabase extends _$AppDatabase {
         WHERE COALESCE(json_extract(j.value, '$.name'), '') != '';
       END
     ''');
+  }
+
+  Future<bool> _hasCompleteFtsInfrastructure() async {
+    final tableRows = await customSelect(
+      '''
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'table'
+        AND name IN ('channels_fts', 'playlists_fts', 'items_fts', 'item_artists_fts')
+      ''',
+    ).get();
+    if (tableRows.length != 4) {
+      return false;
+    }
+
+    final triggerRows = await customSelect(
+      '''
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'trigger'
+        AND name IN (
+          'channels_ai', 'channels_ad', 'channels_au',
+          'playlists_ai', 'playlists_ad', 'playlists_au',
+          'items_ai', 'items_ad', 'items_au'
+        )
+      ''',
+    ).get();
+    return triggerRows.length == 9;
   }
 
   Future<void> _rebuildFtsIndexes() async {

--- a/lib/infra/database/app_database.dart
+++ b/lib/infra/database/app_database.dart
@@ -294,6 +294,8 @@ class AppDatabase extends _$AppDatabase {
           rawCreatedAtUs: row.read<int?>('created_at_us'),
           rawUpdatedAtUs: row.read<int?>('updated_at_us'),
           rawSignatures: row.read<String?>('signatures'),
+          rawDefaultsJson: row.read<String?>('defaults_json'),
+          rawDynamicQueriesJson: row.read<String?>('dynamic_queries_json'),
           ownerAddress: ownerAddress,
           rawSortMode: row.read<int?>('sort_mode'),
           rawItemCount: row.read<int?>('item_count'),
@@ -365,11 +367,15 @@ class AppDatabase extends _$AppDatabase {
         );
         final defaultsJson = _repairPlaylistDefaultsJson(
           rawDefaultsJson: row.read<String?>('defaults_json'),
+          rawChannelId: trimmedRawChannelId,
+          ownerAddress: ownerAddress,
           rawType: rawType,
           typeValue: typeValue,
         );
         final dynamicQueriesJson = _repairPlaylistDynamicQueriesJson(
           rawDynamicQueriesJson: row.read<String?>('dynamic_queries_json'),
+          rawChannelId: trimmedRawChannelId,
+          ownerAddress: ownerAddress,
           rawType: rawType,
           typeValue: typeValue,
         );
@@ -449,6 +455,8 @@ class AppDatabase extends _$AppDatabase {
     required int? rawCreatedAtUs,
     required int? rawUpdatedAtUs,
     required String? rawSignatures,
+    required String? rawDefaultsJson,
+    required String? rawDynamicQueriesJson,
     required String? ownerAddress,
     required int? rawSortMode,
     required int? rawItemCount,
@@ -475,6 +483,8 @@ class AppDatabase extends _$AppDatabase {
     if (rawItemCount < 0 || rawItemCount != entryCount) {
       return true;
     }
+    final trimmedDefaultsJson = rawDefaultsJson?.trim();
+    final trimmedDynamicQueriesJson = rawDynamicQueriesJson?.trim();
     if (ownerAddress != trimmedOwnerAddress) {
       return true;
     }
@@ -494,6 +504,13 @@ class AppDatabase extends _$AppDatabase {
         rawChannelId != null &&
         trimmedRawChannelId != rawChannelId &&
         !hasOwnerAddress) {
+      return true;
+    }
+    if (rawType == PlaylistType.dp1.value &&
+        !hasOwnerAddress &&
+        ((trimmedDefaultsJson != null && trimmedDefaultsJson.isNotEmpty) ||
+            (trimmedDynamicQueriesJson != null &&
+                trimmedDynamicQueriesJson.isNotEmpty))) {
       return true;
     }
     if (id == Playlist.favoriteId &&
@@ -771,11 +788,21 @@ class AppDatabase extends _$AppDatabase {
 
   String? _repairPlaylistDefaultsJson({
     required String? rawDefaultsJson,
+    required String? rawChannelId,
+    required String? ownerAddress,
     required int? rawType,
     required int typeValue,
   }) {
-    if (rawType == PlaylistType.addressBased.value &&
-        typeValue != PlaylistType.addressBased.value) {
+    final hasOwnerAddress = ownerAddress?.trim().isNotEmpty ?? false;
+    final hasNonPersonalChannel =
+        rawChannelId != null &&
+        rawChannelId.isNotEmpty &&
+        rawChannelId != Channel.myCollectionId;
+    if ((rawType == PlaylistType.addressBased.value &&
+            typeValue != PlaylistType.addressBased.value) ||
+        (typeValue == PlaylistType.dp1.value &&
+            !hasOwnerAddress &&
+            !hasNonPersonalChannel)) {
       return null;
     }
     final trimmed = rawDefaultsJson?.trim();
@@ -787,11 +814,21 @@ class AppDatabase extends _$AppDatabase {
 
   String? _repairPlaylistDynamicQueriesJson({
     required String? rawDynamicQueriesJson,
+    required String? rawChannelId,
+    required String? ownerAddress,
     required int? rawType,
     required int typeValue,
   }) {
-    if (rawType == PlaylistType.addressBased.value &&
-        typeValue != PlaylistType.addressBased.value) {
+    final hasOwnerAddress = ownerAddress?.trim().isNotEmpty ?? false;
+    final hasNonPersonalChannel =
+        rawChannelId != null &&
+        rawChannelId.isNotEmpty &&
+        rawChannelId != Channel.myCollectionId;
+    if ((rawType == PlaylistType.addressBased.value &&
+            typeValue != PlaylistType.addressBased.value) ||
+        (typeValue == PlaylistType.dp1.value &&
+            !hasOwnerAddress &&
+            !hasNonPersonalChannel)) {
       return null;
     }
     final trimmed = rawDynamicQueriesJson?.trim();

--- a/lib/infra/database/app_database.dart
+++ b/lib/infra/database/app_database.dart
@@ -25,6 +25,8 @@ const _maxLimitForOffset = 0x7FFFFFFF;
 const _schemaVersionV1 = 3;
 const _dbResetReindexMarkerFile = 'db_reset_requires_reindex.flag';
 const _ftsMetadataFallbackRank = 500.0;
+const _playlistRepairMarkerTable = 'internal_repair_markers';
+const _playlistRepairMarkerKey = 'playlist_repair_v1_completed';
 
 extension _SearchQueryTokens on String {
   List<String> get searchTokens {
@@ -210,6 +212,7 @@ class AppDatabase extends _$AppDatabase {
   /// should repair readable local state and keep going when the damage is local
   /// to a few playlist rows.
   Future<void> _repairMalformedPlaylistRowsIfNeeded() async {
+    await _ensureRepairMarkerTable();
     final cols = await _playlistTableColumnNames();
     const requiredCols = {
       'id',
@@ -225,7 +228,15 @@ class AppDatabase extends _$AppDatabase {
       'item_count',
       'owner_address',
     };
+    final hasRepairMarker = await _hasRepairMarker(_playlistRepairMarkerKey);
+    if (hasRepairMarker && !requiredCols.every(cols.contains)) {
+      return;
+    }
     if (!requiredCols.every(cols.contains)) {
+      await _markRepairCompleted(_playlistRepairMarkerKey);
+      return;
+    }
+    if (hasRepairMarker && !await _playlistMayNeedRepair()) {
       return;
     }
 
@@ -241,6 +252,7 @@ class AppDatabase extends _$AppDatabase {
     ).get();
 
     if (rows.isEmpty) {
+      await _markRepairCompleted(_playlistRepairMarkerKey);
       return;
     }
 
@@ -444,7 +456,147 @@ class AppDatabase extends _$AppDatabase {
           'before startup reads',
         );
       }
+      await _markRepairCompleted(_playlistRepairMarkerKey);
     });
+  }
+
+  Future<void> _ensureRepairMarkerTable() async {
+    await customStatement(
+      '''
+      CREATE TABLE IF NOT EXISTS $_playlistRepairMarkerTable (
+        key TEXT PRIMARY KEY,
+        completed_at_us INTEGER NOT NULL
+      )
+      ''',
+    );
+  }
+
+  Future<bool> _hasRepairMarker(String key) async {
+    final row = await customSelect(
+      '''
+      SELECT 1 AS present
+      FROM $_playlistRepairMarkerTable
+      WHERE key = ?
+      LIMIT 1
+      ''',
+      variables: [Variable<String>(key)],
+    ).getSingleOrNull();
+    return row != null;
+  }
+
+  Future<void> _markRepairCompleted(String key) async {
+    await customStatement(
+      '''
+      INSERT OR REPLACE INTO $_playlistRepairMarkerTable (
+        key, completed_at_us
+      ) VALUES (?, ?)
+      ''',
+      <Object?>[key, DateTime.now().microsecondsSinceEpoch],
+    );
+  }
+
+  Future<bool> _playlistMayNeedRepair() async {
+    final rows = await customSelect(
+      '''
+      SELECT id, channel_id, type, title, created_at_us, updated_at_us,
+             signatures, defaults_json, dynamic_queries_json, owner_address,
+             sort_mode, item_count
+      FROM playlists
+      ''',
+      readsFrom: {playlists},
+    ).get();
+
+    for (final row in rows) {
+      if (_playlistMayNeedRepairRow(row)) {
+        return true;
+      }
+    }
+
+    final countMismatch = await customSelect(
+      '''
+      SELECT 1 AS needs_repair
+      FROM playlists
+      WHERE item_count != (
+        SELECT COUNT(*)
+        FROM playlist_entries
+        WHERE playlist_id = playlists.id
+      )
+      LIMIT 1
+      ''',
+      readsFrom: {playlists, playlistEntries},
+    ).getSingleOrNull();
+    return countMismatch != null;
+  }
+
+  bool _playlistMayNeedRepairRow(QueryRow row) {
+    final id = row.read<String>('id');
+    final rawType = row.read<int?>('type');
+    final rawChannelId = row.read<String?>('channel_id');
+    final ownerAddress = row.read<String?>('owner_address');
+    final trimmedOwnerAddress = ownerAddress?.trim();
+    final hasOwnerAddress =
+        trimmedOwnerAddress != null && trimmedOwnerAddress.isNotEmpty;
+    final trimmedRawChannelId = rawChannelId?.trim();
+
+    if (rawType == null ||
+        row.read<String?>('title') == null ||
+        row.read<int?>('created_at_us') == null ||
+        row.read<int?>('updated_at_us') == null ||
+        row.read<String?>('signatures') == null ||
+        row.read<int?>('sort_mode') == null ||
+        row.read<int?>('item_count') == null) {
+      return true;
+    }
+    if (!_isValidPlaylistTypeValue(rawType) ||
+        !_isValidPlaylistSortModeValue(row.read<int>('sort_mode'))) {
+      return true;
+    }
+    if (ownerAddress != trimmedOwnerAddress) {
+      return true;
+    }
+    if (rawType == PlaylistType.favorite.value && id != Playlist.favoriteId) {
+      return true;
+    }
+    if (rawType == PlaylistType.addressBased.value && !hasOwnerAddress) {
+      return true;
+    }
+    if (id != Playlist.favoriteId &&
+        trimmedRawChannelId == Channel.myCollectionId &&
+        !hasOwnerAddress) {
+      return true;
+    }
+    if (id != Playlist.favoriteId &&
+        rawType == PlaylistType.dp1.value &&
+        rawChannelId != null &&
+        trimmedRawChannelId != rawChannelId &&
+        !hasOwnerAddress) {
+      return true;
+    }
+    if (id == Playlist.favoriteId &&
+        (hasOwnerAddress ||
+            rawType != PlaylistType.favorite.value ||
+            rawChannelId == null ||
+            rawChannelId != Channel.myCollectionId ||
+            row.read<int>('sort_mode') != PlaylistSortMode.provenance.index ||
+            row.read<String>('title') != 'Favorites')) {
+      return true;
+    }
+    if (hasOwnerAddress &&
+        (rawType != PlaylistType.addressBased.value ||
+            id != PlaylistExt.addressPlaylistId(trimmedOwnerAddress) ||
+            rawChannelId == null ||
+            rawChannelId != Channel.myCollectionId ||
+            row.read<int>('sort_mode') != PlaylistSortMode.provenance.index)) {
+      return true;
+    }
+    if (rawType == PlaylistType.dp1.value &&
+        !hasOwnerAddress &&
+        ((row.read<String?>('defaults_json')?.trim().isNotEmpty ?? false) ||
+            (row.read<String?>('dynamic_queries_json')?.trim().isNotEmpty ??
+                false))) {
+      return true;
+    }
+    return false;
   }
 
   bool _playlistNeedsRepair({

--- a/lib/infra/database/app_database.dart
+++ b/lib/infra/database/app_database.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:app/domain/extensions/playlist_ext.dart';
 import 'package:app/domain/models/channel.dart';
 import 'package:app/domain/models/playlist.dart';
 import 'package:app/infra/database/seed_database_gate.dart';
@@ -241,18 +242,20 @@ class AppDatabase extends _$AppDatabase {
          OR type NOT IN (0, 1, 2)
          OR sort_mode NOT IN (0, 1)
          OR item_count < 0
-         OR (type = ? AND id != ?)
-         OR (
-              id = ?
-              AND item_count != (
-                SELECT COUNT(*)
-                FROM playlist_entries
-                WHERE playlist_id = playlists.id
-              )
+         OR item_count != (
+              SELECT COUNT(*)
+              FROM playlist_entries
+              WHERE playlist_id = playlists.id
             )
+         OR (type = ? AND id != ?)
          OR (
               type = ?
               AND (owner_address IS NULL OR TRIM(owner_address) = '')
+            )
+         OR (
+              type = ?
+              AND owner_address IS NOT NULL
+              AND TRIM(owner_address) != ''
             )
          OR (
               id != ?
@@ -286,11 +289,17 @@ class AppDatabase extends _$AppDatabase {
                 OR sort_mode != ?
               )
             )
+      ORDER BY
+        CASE
+          WHEN owner_address IS NOT NULL AND TRIM(owner_address) != '' THEN 0
+          ELSE 1
+        END,
+        id
       ''',
       variables: [
         Variable<int>(PlaylistType.favorite.value),
         const Variable<String>(Playlist.favoriteId),
-        const Variable<String>(Playlist.favoriteId),
+        Variable<int>(PlaylistType.addressBased.value),
         Variable<int>(PlaylistType.addressBased.value),
         const Variable<String>(Playlist.favoriteId),
         const Variable<String>(Channel.myCollectionId),
@@ -314,8 +323,12 @@ class AppDatabase extends _$AppDatabase {
 
     final nowUs = DateTime.now().microsecondsSinceEpoch;
     await transaction(() async {
+      final supersededSnapshotIds = <String>{};
       for (final row in rows) {
         final id = row.read<String>('id');
+        if (supersededSnapshotIds.contains(id)) {
+          continue;
+        }
         final rawType = row.read<int?>('type');
         final rawChannelId = row.read<String?>('channel_id');
         final ownerAddress = row.read<String?>('owner_address');
@@ -356,8 +369,23 @@ class AppDatabase extends _$AppDatabase {
           ownerAddress: ownerAddress,
           typeValue: typeValue,
         );
-        final title = _repairPlaylistTitle(
+        final targetPlaylistId = _repairPlaylistId(
           id: id,
+          ownerAddress: repairedOwnerAddress,
+          typeValue: typeValue,
+        );
+        final canonicalization = await _canonicalizeAddressPlaylistIdIfNeeded(
+          sourcePlaylistId: id,
+          targetPlaylistId: targetPlaylistId,
+        );
+        if (canonicalization.supersededSnapshotId != null) {
+          supersededSnapshotIds.add(canonicalization.supersededSnapshotId!);
+        }
+        if (canonicalization.mergedIntoExistingCanonical) {
+          continue;
+        }
+        final title = _repairPlaylistTitle(
+          id: targetPlaylistId,
           ownerAddress: repairedOwnerAddress,
           typeValue: typeValue,
           rawTitle: row.read<String?>('title'),
@@ -372,15 +400,18 @@ class AppDatabase extends _$AppDatabase {
         final itemCount = await _repairPlaylistItemCount(
           playlistId: id,
           rawItemCount: row.read<int?>('item_count'),
-          forceRecompute:
-              id == Playlist.favoriteId ||
-              row.read<int?>('type') == PlaylistType.favorite.value,
+          // Every row in this repair batch already violated playlist
+          // invariants. Recomputing from playlist_entries keeps bootstrap
+          // healing aligned with downstream sync code that resumes from the
+          // stored item_count.
+          forceRecompute: true,
         );
 
         await customStatement(
           '''
           UPDATE playlists
-          SET channel_id = ?,
+          SET id = ?,
+              channel_id = ?,
               type = ?,
               title = ?,
               owner_address = ?,
@@ -392,6 +423,7 @@ class AppDatabase extends _$AppDatabase {
           WHERE id = ?
           ''',
           <Object?>[
+            targetPlaylistId,
             channelId,
             typeValue,
             title,
@@ -404,6 +436,16 @@ class AppDatabase extends _$AppDatabase {
             id,
           ],
         );
+        if (targetPlaylistId != id) {
+          await customStatement(
+            '''
+            UPDATE playlist_entries
+            SET playlist_id = ?
+            WHERE playlist_id = ?
+            ''',
+            <Object?>[targetPlaylistId, id],
+          );
+        }
       }
     });
 
@@ -426,6 +468,98 @@ class AppDatabase extends _$AppDatabase {
       return null;
     }
     return trimmed;
+  }
+
+  String _repairPlaylistId({
+    required String id,
+    required String? ownerAddress,
+    required int typeValue,
+  }) {
+    if (typeValue != PlaylistType.addressBased.value || ownerAddress == null) {
+      return id;
+    }
+    return PlaylistExt.addressPlaylistId(ownerAddress);
+  }
+
+  Future<({bool mergedIntoExistingCanonical, String? supersededSnapshotId})>
+  _canonicalizeAddressPlaylistIdIfNeeded({
+    required String sourcePlaylistId,
+    required String targetPlaylistId,
+  }) async {
+    if (sourcePlaylistId == targetPlaylistId) {
+      return (mergedIntoExistingCanonical: false, supersededSnapshotId: null);
+    }
+
+    final existingCanonical = await customSelect(
+      '''
+      SELECT id, owner_address
+      FROM playlists
+      WHERE id = ?
+      ''',
+      variables: [Variable<String>(targetPlaylistId)],
+      readsFrom: {playlists},
+    ).getSingleOrNull();
+    if (existingCanonical == null) {
+      return (mergedIntoExistingCanonical: false, supersededSnapshotId: null);
+    }
+
+    final canonicalOwnerAddress = existingCanonical
+        .read<String?>('owner_address')
+        ?.trim();
+    if (canonicalOwnerAddress == null || canonicalOwnerAddress.isEmpty) {
+      await _movePlaylistEntries(
+        sourcePlaylistId: targetPlaylistId,
+        targetPlaylistId: sourcePlaylistId,
+      );
+      await customStatement(
+        'DELETE FROM playlists WHERE id = ?',
+        <Object?>[targetPlaylistId],
+      );
+      return (
+        mergedIntoExistingCanonical: false,
+        supersededSnapshotId: targetPlaylistId,
+      );
+    }
+
+    await _movePlaylistEntries(
+      sourcePlaylistId: sourcePlaylistId,
+      targetPlaylistId: targetPlaylistId,
+    );
+    await customStatement(
+      'DELETE FROM playlists WHERE id = ?',
+      <Object?>[sourcePlaylistId],
+    );
+    final itemCount = await _repairPlaylistItemCount(
+      playlistId: targetPlaylistId,
+      rawItemCount: null,
+      forceRecompute: true,
+    );
+    await customStatement(
+      'UPDATE playlists SET item_count = ? WHERE id = ?',
+      <Object?>[itemCount, targetPlaylistId],
+    );
+    return (mergedIntoExistingCanonical: true, supersededSnapshotId: null);
+  }
+
+  Future<void> _movePlaylistEntries({
+    required String sourcePlaylistId,
+    required String targetPlaylistId,
+  }) async {
+    await customStatement(
+      '''
+      INSERT OR IGNORE INTO playlist_entries (
+        playlist_id, item_id, position, sort_key_us, updated_at_us
+      )
+      SELECT ?, item_id, position, sort_key_us, updated_at_us
+      FROM playlist_entries
+      WHERE playlist_id = ?
+      ''',
+      <Object?>[targetPlaylistId, sourcePlaylistId],
+    );
+    await customStatement(
+      'DELETE FROM playlist_entries WHERE playlist_id = ?',
+      <Object?>[sourcePlaylistId],
+    );
   }
 
   Future<void> _deletePlaylistAndOrphanedItems(String playlistId) async {
@@ -477,11 +611,7 @@ class AppDatabase extends _$AppDatabase {
     }
     final hasOwnerAddress =
         ownerAddress != null && ownerAddress.trim().isNotEmpty;
-    if (!hasOwnerAddress &&
-        (rawChannelId == Channel.myCollectionId ||
-            ((rawType == PlaylistType.addressBased.value ||
-                    rawType == PlaylistType.favorite.value) &&
-                !hasNonPersonalChannel))) {
+    if (!hasOwnerAddress && rawChannelId == Channel.myCollectionId) {
       return true;
     }
     return false;
@@ -497,9 +627,13 @@ class AppDatabase extends _$AppDatabase {
     if (id == Playlist.favoriteId) {
       return PlaylistType.favorite.value;
     }
-    if (ownerAddress != null &&
-        ownerAddress.trim().isNotEmpty &&
-        (rawChannelId == Channel.myCollectionId || !hasNonPersonalChannel)) {
+    final trimmedOwnerAddress = ownerAddress?.trim();
+    final hasOwnerAddress =
+        trimmedOwnerAddress != null && trimmedOwnerAddress.isNotEmpty;
+    if (hasOwnerAddress &&
+        (rawType == PlaylistType.addressBased.value ||
+            rawChannelId == Channel.myCollectionId ||
+            !hasNonPersonalChannel)) {
       return PlaylistType.addressBased.value;
     }
     if (rawType == PlaylistType.favorite.value) {

--- a/lib/infra/database/app_database.dart
+++ b/lib/infra/database/app_database.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:app/domain/models/channel.dart';
 import 'package:app/domain/models/playlist.dart';
 import 'package:app/infra/database/seed_database_gate.dart';
 import 'package:app/infra/database/tables.dart';
@@ -77,6 +78,7 @@ class AppDatabase extends _$AppDatabase {
         // Repair DBs where user_version already advanced but `signatures_json`
         // remains (failed migration, copied file, or pre-release builds).
         await _migratePlaylistsSignaturesJsonIfNeeded();
+        await _repairMalformedPlaylistRowsIfNeeded();
         await _createIndexes();
         await _createFtsInfrastructure();
         if (details.wasCreated || details.hadUpgrade) {
@@ -190,6 +192,209 @@ class AppDatabase extends _$AppDatabase {
         );
       }
     }
+  }
+
+  /// Repairs malformed playlist rows before Drift maps them into
+  /// `PlaylistData`.
+  ///
+  /// Why this exists:
+  /// - Older copied DBs and partially-migrated local files can still contain
+  ///   playlist rows where required columns are null or enum values drifted.
+  /// - Drift's generated row mapper force-unwraps those required fields, so one
+  ///   bad row can crash startup bootstrap and every playlist list/watch query.
+  ///
+  /// We heal rows on open instead of scattering defensive fallback logic across
+  /// providers and services. This preserves the offline-first contract: the app
+  /// should repair readable local state and keep going when the damage is local
+  /// to a few playlist rows.
+  Future<void> _repairMalformedPlaylistRowsIfNeeded() async {
+    final cols = await _playlistTableColumnNames();
+    const requiredCols = {
+      'id',
+      'channel_id',
+      'type',
+      'title',
+      'created_at_us',
+      'updated_at_us',
+      'signatures',
+      'sort_mode',
+      'item_count',
+      'owner_address',
+    };
+    if (!requiredCols.every(cols.contains)) {
+      return;
+    }
+
+    final rows = await customSelect(
+      '''
+      SELECT id, channel_id, type, title, created_at_us, updated_at_us,
+             signatures, owner_address, sort_mode, item_count
+      FROM playlists
+      WHERE type IS NULL
+         OR title IS NULL
+         OR created_at_us IS NULL
+         OR updated_at_us IS NULL
+         OR signatures IS NULL
+         OR sort_mode IS NULL
+         OR item_count IS NULL
+         OR type NOT IN (0, 1, 2)
+         OR sort_mode NOT IN (0, 1)
+         OR item_count < 0
+      ''',
+      readsFrom: {playlists},
+    ).get();
+
+    if (rows.isEmpty) {
+      return;
+    }
+
+    final nowUs = DateTime.now().microsecondsSinceEpoch;
+    await transaction(() async {
+      for (final row in rows) {
+        final id = row.read<String>('id');
+        final channelId = _repairPlaylistChannelId(
+          id: id,
+          rawChannelId: row.read<String?>('channel_id'),
+        );
+        final ownerAddress = row.read<String?>('owner_address');
+        final typeValue = _repairPlaylistTypeValue(
+          id: id,
+          ownerAddress: ownerAddress,
+          rawType: row.read<int?>('type'),
+        );
+        final rawCreatedAtUs = row.read<int?>('created_at_us');
+        final rawUpdatedAtUs = row.read<int?>('updated_at_us');
+        final createdAtUs = rawCreatedAtUs ?? rawUpdatedAtUs ?? nowUs;
+        final updatedAtUs = rawUpdatedAtUs ?? createdAtUs;
+        final title = _repairPlaylistTitle(
+          id: id,
+          ownerAddress: ownerAddress,
+          typeValue: typeValue,
+          rawTitle: row.read<String?>('title'),
+        );
+        final signatures = _repairPlaylistSignaturesJson(
+          row.read<String?>('signatures'),
+        );
+        final sortMode = _repairPlaylistSortModeValue(
+          rawSortMode: row.read<int?>('sort_mode'),
+          typeValue: typeValue,
+        );
+        final itemCount = _repairPlaylistItemCount(
+          row.read<int?>('item_count'),
+        );
+
+        await customStatement(
+          '''
+          UPDATE playlists
+          SET channel_id = ?,
+              type = ?,
+              title = ?,
+              created_at_us = ?,
+              updated_at_us = ?,
+              signatures = ?,
+              sort_mode = ?,
+              item_count = ?
+          WHERE id = ?
+          ''',
+          <Object?>[
+            channelId,
+            typeValue,
+            title,
+            createdAtUs,
+            updatedAtUs,
+            signatures,
+            sortMode,
+            itemCount,
+            id,
+          ],
+        );
+      }
+    });
+
+    _log.warning(
+      'Repaired ${rows.length} malformed playlist row(s) before startup reads',
+    );
+  }
+
+  int _repairPlaylistTypeValue({
+    required String id,
+    required String? ownerAddress,
+    required int? rawType,
+  }) {
+    if (rawType != null && PlaylistType.values.any((t) => t.value == rawType)) {
+      return rawType;
+    }
+    if (id == Playlist.favoriteId) {
+      return PlaylistType.favorite.value;
+    }
+    if (ownerAddress != null && ownerAddress.trim().isNotEmpty) {
+      return PlaylistType.addressBased.value;
+    }
+    return PlaylistType.dp1.value;
+  }
+
+  String? _repairPlaylistChannelId({
+    required String id,
+    required String? rawChannelId,
+  }) {
+    if (id == Playlist.favoriteId) {
+      return Channel.myCollectionId;
+    }
+    return rawChannelId;
+  }
+
+  String _repairPlaylistTitle({
+    required String id,
+    required String? ownerAddress,
+    required int typeValue,
+    required String? rawTitle,
+  }) {
+    final trimmedTitle = rawTitle?.trim();
+    if (trimmedTitle != null && trimmedTitle.isNotEmpty) {
+      return trimmedTitle;
+    }
+    if (id == Playlist.favoriteId) {
+      return 'Favorites';
+    }
+    if (typeValue == PlaylistType.addressBased.value &&
+        ownerAddress != null &&
+        ownerAddress.trim().isNotEmpty) {
+      return ownerAddress.trim();
+    }
+    return id;
+  }
+
+  String _repairPlaylistSignaturesJson(String? rawSignatures) {
+    final trimmed = rawSignatures?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return '[]';
+    }
+    return trimmed;
+  }
+
+  int _repairPlaylistSortModeValue({
+    required int? rawSortMode,
+    required int typeValue,
+  }) {
+    if (rawSortMode != null &&
+        PlaylistSortMode.values.any((m) => m.index == rawSortMode)) {
+      return rawSortMode;
+    }
+    switch (typeValue) {
+      case 1:
+      case 2:
+        return PlaylistSortMode.provenance.index;
+      case 0:
+      default:
+        return PlaylistSortMode.position.index;
+    }
+  }
+
+  int _repairPlaylistItemCount(int? rawItemCount) {
+    if (rawItemCount == null || rawItemCount < 0) {
+      return 0;
+    }
+    return rawItemCount;
   }
 
   /// Creates performance indexes.

--- a/test/unit/infra/database/app_database_playlist_repair_test.dart
+++ b/test/unit/infra/database/app_database_playlist_repair_test.dart
@@ -1,0 +1,269 @@
+import 'dart:io';
+
+import 'package:app/domain/models/channel.dart';
+import 'package:app/domain/models/playlist.dart';
+import 'package:app/infra/database/app_database.dart';
+import 'package:app/infra/database/database_service.dart';
+import 'package:app/infra/services/bootstrap_service.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+void main() {
+  group('AppDatabase malformed playlist repair', () {
+    test('repairs malformed favorite row before bootstrap reads it', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'ff_playlist_repair_',
+      );
+      final dbFile = File(p.join(tempDir.path, 'favorite-malformed.sqlite'));
+
+      try {
+        _createMalformedPlaylistDatabase(
+          file: dbFile,
+          rows: const [
+            _RawPlaylistRow(
+              id: Playlist.favoriteId,
+              title: null,
+              type: null,
+              createdAtUs: null,
+              updatedAtUs: null,
+              signatures: null,
+              sortMode: null,
+              itemCount: null,
+            ),
+          ],
+        );
+
+        final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+        final service = DatabaseService(db);
+
+        try {
+          await BootstrapService(databaseService: service).bootstrap();
+
+          final favorite = await service.getPlaylistById(Playlist.favoriteId);
+          expect(favorite, isNotNull);
+          expect(favorite!.name, 'Favorites');
+          expect(favorite.type, PlaylistType.favorite);
+          expect(favorite.sortMode, PlaylistSortMode.provenance);
+          expect(favorite.itemCount, 0);
+          expect(favorite.channelId, Channel.myCollectionId);
+        } finally {
+          await db.close();
+        }
+      } finally {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test(
+      'repairs malformed address playlists before list queries map rows',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(p.join(tempDir.path, 'address-malformed.sqlite'));
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_addr',
+                ownerAddress: '0xABCDEF',
+                title: null,
+                type: 9,
+                createdAtUs: null,
+                updatedAtUs: 55,
+                signatures: '',
+                sortMode: 99,
+                itemCount: -4,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_addr');
+            expect(playlists.single.name, '0xABCDEF');
+            expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.sortMode, PlaylistSortMode.provenance);
+            expect(playlists.single.itemCount, 0);
+            expect(playlists.single.createdAt!.microsecondsSinceEpoch, 55);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+  });
+}
+
+class _RawPlaylistRow {
+  const _RawPlaylistRow({
+    required this.id,
+    this.channelId,
+    this.type,
+    this.baseUrl,
+    this.dpVersion,
+    this.slug,
+    this.title,
+    this.createdAtUs,
+    this.updatedAtUs,
+    this.signature,
+    this.signatures,
+    this.defaultsJson,
+    this.dynamicQueriesJson,
+    this.ownerAddress,
+    this.ownerChain,
+    this.sortMode,
+    this.itemCount,
+  });
+
+  final String id;
+  final String? channelId;
+  final int? type;
+  final String? baseUrl;
+  final String? dpVersion;
+  final String? slug;
+  final String? title;
+  final int? createdAtUs;
+  final int? updatedAtUs;
+  final String? signature;
+  final String? signatures;
+  final String? defaultsJson;
+  final String? dynamicQueriesJson;
+  final String? ownerAddress;
+  final String? ownerChain;
+  final int? sortMode;
+  final int? itemCount;
+}
+
+void _createMalformedPlaylistDatabase({
+  required File file,
+  required List<_RawPlaylistRow> rows,
+}) {
+  final db = sqlite3.sqlite3.open(file.path);
+  try {
+    db.execute('PRAGMA foreign_keys = ON;');
+    db.execute('PRAGMA user_version = 3;');
+
+    db.execute('''
+      CREATE TABLE publishers (
+        id INTEGER PRIMARY KEY,
+        title TEXT NOT NULL,
+        created_at_us INTEGER NOT NULL,
+        updated_at_us INTEGER NOT NULL
+      )
+    ''');
+
+    db.execute('''
+      CREATE TABLE channels (
+        id TEXT PRIMARY KEY,
+        type INTEGER NOT NULL,
+        base_url TEXT,
+        slug TEXT,
+        publisher_id INTEGER,
+        title TEXT NOT NULL,
+        curator TEXT,
+        summary TEXT,
+        cover_image_uri TEXT,
+        created_at_us INTEGER NOT NULL,
+        updated_at_us INTEGER NOT NULL,
+        sort_order INTEGER
+      )
+    ''');
+
+    db.execute('''
+      CREATE TABLE playlists (
+        id TEXT PRIMARY KEY,
+        channel_id TEXT,
+        type INTEGER,
+        base_url TEXT,
+        dp_version TEXT,
+        slug TEXT,
+        title TEXT,
+        created_at_us INTEGER,
+        updated_at_us INTEGER,
+        signature TEXT,
+        signatures TEXT,
+        defaults_json TEXT,
+        dynamic_queries_json TEXT,
+        owner_address TEXT,
+        owner_chain TEXT,
+        sort_mode INTEGER,
+        item_count INTEGER
+      )
+    ''');
+
+    db.execute('''
+      CREATE TABLE items (
+        id TEXT PRIMARY KEY,
+        kind INTEGER NOT NULL,
+        title TEXT,
+        thumbnail_uri TEXT,
+        duration_sec INTEGER,
+        provenance_json TEXT,
+        source_uri TEXT,
+        ref_uri TEXT,
+        license TEXT,
+        repro_json TEXT,
+        override_json TEXT,
+        display_json TEXT,
+        list_artist_json TEXT,
+        enrichment_status INTEGER NOT NULL DEFAULT 0,
+        updated_at_us INTEGER NOT NULL
+      )
+    ''');
+
+    db.execute('''
+      CREATE TABLE playlist_entries (
+        playlist_id TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        position INTEGER,
+        sort_key_us INTEGER NOT NULL,
+        updated_at_us INTEGER NOT NULL
+      )
+    ''');
+
+    for (final row in rows) {
+      db.execute(
+        '''
+        INSERT INTO playlists (
+          id, channel_id, type, base_url, dp_version, slug, title,
+          created_at_us, updated_at_us, signature, signatures,
+          defaults_json, dynamic_queries_json, owner_address, owner_chain,
+          sort_mode, item_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''',
+        <Object?>[
+          row.id,
+          row.channelId,
+          row.type,
+          row.baseUrl,
+          row.dpVersion,
+          row.slug,
+          row.title,
+          row.createdAtUs,
+          row.updatedAtUs,
+          row.signature,
+          row.signatures,
+          row.defaultsJson,
+          row.dynamicQueriesJson,
+          row.ownerAddress,
+          row.ownerChain,
+          row.sortMode,
+          row.itemCount,
+        ],
+      );
+    }
+  } finally {
+    db.dispose();
+  }
+}

--- a/test/unit/infra/database/app_database_playlist_repair_test.dart
+++ b/test/unit/infra/database/app_database_playlist_repair_test.dart
@@ -22,16 +22,10 @@ void main() {
         _createMalformedPlaylistDatabase(
           file: dbFile,
           rows: const [
-            _RawPlaylistRow(
-              id: Playlist.favoriteId,
-              title: null,
-              type: null,
-              createdAtUs: null,
-              updatedAtUs: null,
-              signatures: null,
-              sortMode: null,
-              itemCount: null,
-            ),
+              _RawPlaylistRow(
+                id: Playlist.favoriteId,
+                type: 0,
+              ),
           ],
         );
 
@@ -71,9 +65,7 @@ void main() {
               _RawPlaylistRow(
                 id: 'playlist_addr',
                 ownerAddress: '0xABCDEF',
-                title: null,
                 type: 9,
-                createdAtUs: null,
                 updatedAtUs: 55,
                 signatures: '',
                 sortMode: 99,
@@ -91,6 +83,7 @@ void main() {
             expect(playlists.single.id, 'playlist_addr');
             expect(playlists.single.name, '0xABCDEF');
             expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.channelId, Channel.myCollectionId);
             expect(playlists.single.sortMode, PlaylistSortMode.provenance);
             expect(playlists.single.itemCount, 0);
             expect(playlists.single.createdAt!.microsecondsSinceEpoch, 55);
@@ -108,39 +101,19 @@ void main() {
 class _RawPlaylistRow {
   const _RawPlaylistRow({
     required this.id,
-    this.channelId,
     this.type,
-    this.baseUrl,
-    this.dpVersion,
-    this.slug,
-    this.title,
-    this.createdAtUs,
     this.updatedAtUs,
-    this.signature,
     this.signatures,
-    this.defaultsJson,
-    this.dynamicQueriesJson,
     this.ownerAddress,
-    this.ownerChain,
     this.sortMode,
     this.itemCount,
   });
 
   final String id;
-  final String? channelId;
   final int? type;
-  final String? baseUrl;
-  final String? dpVersion;
-  final String? slug;
-  final String? title;
-  final int? createdAtUs;
   final int? updatedAtUs;
-  final String? signature;
   final String? signatures;
-  final String? defaultsJson;
-  final String? dynamicQueriesJson;
   final String? ownerAddress;
-  final String? ownerChain;
   final int? sortMode;
   final int? itemCount;
 }
@@ -151,19 +124,18 @@ void _createMalformedPlaylistDatabase({
 }) {
   final db = sqlite3.sqlite3.open(file.path);
   try {
-    db.execute('PRAGMA foreign_keys = ON;');
-    db.execute('PRAGMA user_version = 3;');
-
-    db.execute('''
+    final setupStatements = <String>[
+      'PRAGMA foreign_keys = ON;',
+      'PRAGMA user_version = 3;',
+      '''
       CREATE TABLE publishers (
         id INTEGER PRIMARY KEY,
         title TEXT NOT NULL,
         created_at_us INTEGER NOT NULL,
         updated_at_us INTEGER NOT NULL
       )
-    ''');
-
-    db.execute('''
+      ''',
+      '''
       CREATE TABLE channels (
         id TEXT PRIMARY KEY,
         type INTEGER NOT NULL,
@@ -178,9 +150,8 @@ void _createMalformedPlaylistDatabase({
         updated_at_us INTEGER NOT NULL,
         sort_order INTEGER
       )
-    ''');
-
-    db.execute('''
+      ''',
+      '''
       CREATE TABLE playlists (
         id TEXT PRIMARY KEY,
         channel_id TEXT,
@@ -200,9 +171,8 @@ void _createMalformedPlaylistDatabase({
         sort_mode INTEGER,
         item_count INTEGER
       )
-    ''');
-
-    db.execute('''
+      ''',
+      '''
       CREATE TABLE items (
         id TEXT PRIMARY KEY,
         kind INTEGER NOT NULL,
@@ -220,9 +190,8 @@ void _createMalformedPlaylistDatabase({
         enrichment_status INTEGER NOT NULL DEFAULT 0,
         updated_at_us INTEGER NOT NULL
       )
-    ''');
-
-    db.execute('''
+      ''',
+      '''
       CREATE TABLE playlist_entries (
         playlist_id TEXT NOT NULL,
         item_id TEXT NOT NULL,
@@ -230,7 +199,10 @@ void _createMalformedPlaylistDatabase({
         sort_key_us INTEGER NOT NULL,
         updated_at_us INTEGER NOT NULL
       )
-    ''');
+      ''',
+    ];
+    void executeStatement(String statement) => db.execute(statement);
+    setupStatements.forEach(executeStatement);
 
     for (final row in rows) {
       db.execute(
@@ -244,20 +216,20 @@ void _createMalformedPlaylistDatabase({
         ''',
         <Object?>[
           row.id,
-          row.channelId,
+          null,
           row.type,
-          row.baseUrl,
-          row.dpVersion,
-          row.slug,
-          row.title,
-          row.createdAtUs,
+          null,
+          null,
+          null,
+          null,
+          null,
           row.updatedAtUs,
-          row.signature,
+          null,
           row.signatures,
-          row.defaultsJson,
-          row.dynamicQueriesJson,
+          null,
+          null,
           row.ownerAddress,
-          row.ownerChain,
+          null,
           row.sortMode,
           row.itemCount,
         ],

--- a/test/unit/infra/database/app_database_playlist_repair_test.dart
+++ b/test/unit/infra/database/app_database_playlist_repair_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:app/domain/extensions/playlist_ext.dart';
 import 'package:app/domain/models/channel.dart';
 import 'package:app/domain/models/playlist.dart';
 import 'package:app/infra/database/app_database.dart';
@@ -12,6 +13,10 @@ import 'package:sqlite3/sqlite3.dart' as sqlite3;
 
 void main() {
   group('AppDatabase malformed playlist repair', () {
+    final canonicalAddressPlaylistId = PlaylistExt.addressPlaylistId(
+      '0xABCDEF',
+    );
+
     test(
       'repairs favorite rows when sort mode is the only wrong field',
       () async {
@@ -100,8 +105,8 @@ void main() {
     );
 
     test(
-      'keeps dp1 playlists on their original channel '
-      'when type drifted to address and owner is stray',
+      'restores personal playlists when type drifted to address '
+      'but channel drifted to a dp1 channel',
       () async {
         final tempDir = await Directory.systemTemp.createTemp(
           'ff_playlist_repair_',
@@ -135,11 +140,12 @@ void main() {
             expect(playlists, hasLength(1));
             expect(
               playlists.single.id,
-              'playlist_dp1_address_type_stray_owner',
+              PlaylistExt.addressPlaylistId('0xABCDEF'),
             );
-            expect(playlists.single.type, PlaylistType.dp1);
-            expect(playlists.single.channelId, 'channel_dp1');
-            expect(playlists.single.ownerAddress, isNull);
+            expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.channelId, Channel.myCollectionId);
+            expect(playlists.single.ownerAddress, '0xABCDEF');
+            expect(playlists.single.sortMode, PlaylistSortMode.provenance);
           } finally {
             await db.close();
           }
@@ -263,7 +269,7 @@ void main() {
           try {
             final playlists = await service.getAllPlaylists();
             expect(playlists, hasLength(1));
-            expect(playlists.single.id, 'playlist_addr');
+            expect(playlists.single.id, canonicalAddressPlaylistId);
             expect(playlists.single.type, PlaylistType.addressBased);
             expect(playlists.single.channelId, Channel.myCollectionId);
             expect(playlists.single.sortMode, PlaylistSortMode.provenance);
@@ -310,7 +316,7 @@ void main() {
           try {
             final playlists = await service.getAllPlaylists();
             expect(playlists, hasLength(1));
-            expect(playlists.single.id, 'playlist_addr_owner_only');
+            expect(playlists.single.id, canonicalAddressPlaylistId);
             expect(playlists.single.type, PlaylistType.addressBased);
             expect(playlists.single.channelId, Channel.myCollectionId);
             expect(playlists.single.ownerAddress, '0xABCDEF');
@@ -359,7 +365,7 @@ void main() {
           try {
             final playlists = await service.getAllPlaylists();
             expect(playlists, hasLength(1));
-            expect(playlists.single.id, 'playlist_addr_owner_favorite_type');
+            expect(playlists.single.id, canonicalAddressPlaylistId);
             expect(playlists.single.type, PlaylistType.addressBased);
             expect(playlists.single.channelId, Channel.myCollectionId);
             expect(playlists.single.ownerAddress, '0xABCDEF');
@@ -405,7 +411,7 @@ void main() {
           try {
             final playlists = await service.getAllPlaylists();
             expect(playlists, hasLength(1));
-            expect(playlists.single.id, 'playlist_addr_owner_dp1_type');
+            expect(playlists.single.id, canonicalAddressPlaylistId);
             expect(playlists.single.type, PlaylistType.addressBased);
             expect(playlists.single.channelId, Channel.myCollectionId);
             expect(playlists.single.ownerAddress, '0xABCDEF');
@@ -451,7 +457,7 @@ void main() {
           try {
             final playlists = await service.getAllPlaylists();
             expect(playlists, hasLength(1));
-            expect(playlists.single.id, 'playlist_addr_blank_channel');
+            expect(playlists.single.id, canonicalAddressPlaylistId);
             expect(playlists.single.type, PlaylistType.addressBased);
             expect(playlists.single.channelId, Channel.myCollectionId);
             expect(playlists.single.ownerAddress, '0xABCDEF');
@@ -496,7 +502,7 @@ void main() {
           try {
             final playlists = await service.getAllPlaylists();
             expect(playlists, hasLength(1));
-            expect(playlists.single.id, 'playlist_addr_favorite_type');
+            expect(playlists.single.id, canonicalAddressPlaylistId);
             expect(playlists.single.type, PlaylistType.addressBased);
             expect(playlists.single.channelId, Channel.myCollectionId);
             expect(playlists.single.sortMode, PlaylistSortMode.provenance);
@@ -538,7 +544,7 @@ void main() {
           try {
             final playlists = await service.getAllPlaylists();
             expect(playlists, hasLength(1));
-            expect(playlists.single.id, 'playlist_addr');
+            expect(playlists.single.id, canonicalAddressPlaylistId);
             expect(playlists.single.type, PlaylistType.addressBased);
             expect(playlists.single.channelId, Channel.myCollectionId);
             expect(playlists.single.sortMode, PlaylistSortMode.provenance);
@@ -860,6 +866,299 @@ void main() {
     );
 
     test(
+      'recomputes stale positive item counts for address playlists',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-stale-positive-count.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_addr_stale_count',
+                channelId: Channel.myCollectionId,
+                ownerAddress: '0xABCDEF',
+                type: 1,
+                sortMode: 1,
+                itemCount: 5,
+                entryCount: 2,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlist = await service.getPlaylistById(
+              canonicalAddressPlaylistId,
+            );
+            expect(playlist, isNotNull);
+            expect(playlist!.type, PlaylistType.addressBased);
+            expect(playlist.itemCount, 2);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'merges repaired address playlists into the canonical wallet playlist id',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-duplicate-canonicalization.sqlite'),
+        );
+        final canonicalId = canonicalAddressPlaylistId;
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: [
+              _RawPlaylistRow(
+                id: canonicalId,
+                channelId: Channel.myCollectionId,
+                ownerAddress: '0xABCDEF',
+                type: 1,
+                sortMode: 1,
+                itemCount: 1,
+                entryCount: 1,
+                itemIds: const ['shared_item'],
+              ),
+              const _RawPlaylistRow(
+                id: 'playlist_addr_duplicate',
+                channelId: 'channel_dp1',
+                ownerAddress: '0xABCDEF',
+                type: 1,
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 2,
+                itemIds: ['shared_item', 'unique_item'],
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAddressPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, canonicalId);
+            expect(playlists.single.ownerAddress, '0xABCDEF');
+            expect(playlists.single.itemCount, 2);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'canonicalizes address playlists even when id is the only wrong field',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-non-canonical-id-only.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'legacy_address_playlist',
+                channelId: Channel.myCollectionId,
+                ownerAddress: '0xABCDEF',
+                type: 1,
+                sortMode: 1,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAddressPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, canonicalAddressPlaylistId);
+            expect(playlists.single.ownerAddress, '0xABCDEF');
+            expect(playlists.single.itemCount, 1);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'replaces malformed canonical address rows with recoverable duplicates',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-malformed-canonical-replaced.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: [
+              _RawPlaylistRow(
+                id: canonicalAddressPlaylistId,
+                channelId: Channel.myCollectionId,
+                type: 1,
+                sortMode: 1,
+                itemCount: 1,
+                entryCount: 1,
+                itemIds: const ['stale_item'],
+              ),
+              const _RawPlaylistRow(
+                id: 'playlist_addr_recoverable_duplicate',
+                channelId: 'channel_dp1',
+                ownerAddress: '0xABCDEF',
+                type: 1,
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+                itemIds: ['good_item'],
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAddressPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, canonicalAddressPlaylistId);
+            expect(playlists.single.ownerAddress, '0xABCDEF');
+            expect(playlists.single.itemCount, 2);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs non-canonical favorite-typed rows without personal signals '
+      'instead of deleting them',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'favorite-typed-null-channel.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_favorite_drifted',
+                channelId: '   ',
+                type: 2,
+                title: 'Recovered Playlist',
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_favorite_drifted');
+            expect(playlists.single.type, PlaylistType.dp1);
+            expect(playlists.single.ownerAddress, isNull);
+            expect(playlists.single.itemCount, 1);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs blank-owner address-typed rows without my-collection signal '
+      'back to dp1 instead of deleting them',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-typed-blank-owner-null-channel.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_address_drifted',
+                channelId: '   ',
+                type: 1,
+                title: 'Recovered DP1 Playlist',
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_address_drifted');
+            expect(playlists.single.type, PlaylistType.dp1);
+            expect(playlists.single.ownerAddress, isNull);
+            expect(playlists.single.itemCount, 1);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
       'repairs null required fields before bootstrap reads favorite rows',
       () async {
         final tempDir = await Directory.systemTemp.createTemp(
@@ -1014,6 +1313,7 @@ class _RawPlaylistRow {
     this.sortMode,
     this.itemCount,
     this.entryCount = 0,
+    this.itemIds,
   });
 
   final String id;
@@ -1027,6 +1327,7 @@ class _RawPlaylistRow {
   final int? sortMode;
   final int? itemCount;
   final int entryCount;
+  final List<String>? itemIds;
 }
 
 void _createMalformedPlaylistDatabase({
@@ -1108,7 +1409,8 @@ void _createMalformedPlaylistDatabase({
         item_id TEXT NOT NULL,
         position INTEGER,
         sort_key_us INTEGER NOT NULL,
-        updated_at_us INTEGER NOT NULL
+        updated_at_us INTEGER NOT NULL,
+        PRIMARY KEY (playlist_id, item_id)
       )
       ''',
     ];
@@ -1149,11 +1451,19 @@ void _createMalformedPlaylistDatabase({
         ],
       );
 
-      for (var i = 0; i < row.entryCount; i++) {
-        final itemId = '${row.id}_item_$i';
+      final itemIds =
+          row.itemIds ??
+          List<String>.generate(
+            row.entryCount,
+            (i) => '${row.id}_item_$i',
+          );
+      for (var i = 0; i < itemIds.length; i++) {
+        final itemId = itemIds[i];
         executeStatement(
           '''
-          INSERT INTO items (id, kind, updated_at_us, enrichment_status)
+          INSERT OR IGNORE INTO items (
+            id, kind, updated_at_us, enrichment_status
+          )
           VALUES (?, ?, ?, ?)
           ''',
           <Object?>[itemId, 0, 1, 0],

--- a/test/unit/infra/database/app_database_playlist_repair_test.dart
+++ b/test/unit/infra/database/app_database_playlist_repair_test.dart
@@ -1668,16 +1668,133 @@ void main() {
         try {
           _createPlaylistDatabaseWithoutJsonColumns(file: dbFile);
 
-          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final firstOpenDb = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final firstOpenService = DatabaseService(firstOpenDb);
 
           try {
-            // Opening should succeed even though the repair path now knows how
-            // to scrub these columns on demotion. The preflight column guard
-            // must bail out before touching a legacy schema copy that lacks
-            // them.
+            await firstOpenService.getAllPlaylists();
+          } finally {
+            await firstOpenDb.close();
+          }
+
+          expect(_hasPlaylistRepairMarker(file: dbFile), isTrue);
+
+          final secondOpenDb = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final secondOpenService = DatabaseService(secondOpenDb);
+          try {
+            await secondOpenService.getAllPlaylists();
+          } finally {
+            await secondOpenDb.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'writes the playlist repair marker after first successful open',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'playlist-repair-marker.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_marker_target',
+                channelId: 'channel_dp1',
+                type: 0,
+                title: 'Recovered DP1 Playlist',
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            await service.getAllPlaylists();
           } finally {
             await db.close();
           }
+
+          expect(_hasPlaylistRepairMarker(file: dbFile), isTrue);
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'reruns repair on later opens when a marked db becomes malformed again',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'playlist-repair-marker-reopen.sqlite'),
+        );
+        final personalPlaylistId = canonicalAddressPlaylistId;
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: [
+              _RawPlaylistRow(
+                id: personalPlaylistId,
+                channelId: Channel.myCollectionId,
+                ownerAddress: '0xABCDEF',
+                type: PlaylistType.addressBased.value,
+                title: 'Recovered Personal Playlist',
+                sortMode: PlaylistSortMode.provenance.index,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
+
+          final firstOpenDb = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final firstOpenService = DatabaseService(firstOpenDb);
+          try {
+            await firstOpenService.getAllPlaylists();
+          } finally {
+            await firstOpenDb.close();
+          }
+          expect(_hasPlaylistRepairMarker(file: dbFile), isTrue);
+
+          _updatePlaylistIdentity(
+            file: dbFile,
+            playlistId: personalPlaylistId,
+            channelId: 'channel_dp1',
+            title: 'Recovered Personal Playlist',
+          );
+
+          final secondOpenDb = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final secondOpenService = DatabaseService(secondOpenDb);
+          try {
+            await secondOpenService.getAllPlaylists();
+          } finally {
+            await secondOpenDb.close();
+          }
+
+          expect(
+            _readPlaylistChannelId(
+              file: dbFile,
+              playlistId: personalPlaylistId,
+            ),
+            Channel.myCollectionId,
+          );
         } finally {
           await tempDir.delete(recursive: true);
         }
@@ -2127,6 +2244,66 @@ void _createPlaylistDatabaseWithoutJsonColumns({required File file}) {
         0,
       ],
     );
+  } finally {
+    db.dispose();
+  }
+}
+
+bool _hasPlaylistRepairMarker({required File file}) {
+  final db = sqlite3.sqlite3.open(file.path);
+  try {
+    final rows = db.select(
+      '''
+      SELECT 1
+      FROM internal_repair_markers
+      WHERE key = 'playlist_repair_v1_completed'
+      LIMIT 1
+      ''',
+    );
+    return rows.isNotEmpty;
+  } finally {
+    db.dispose();
+  }
+}
+
+void _updatePlaylistIdentity({
+  required File file,
+  required String playlistId,
+  String? ownerAddress,
+  String? channelId,
+  String? title,
+}) {
+  final db = sqlite3.sqlite3.open(file.path);
+  try {
+    db.execute(
+      '''
+      UPDATE playlists
+      SET owner_address = COALESCE(?, owner_address),
+          channel_id = COALESCE(?, channel_id),
+          title = COALESCE(?, title)
+      WHERE id = ?
+      ''',
+      <Object?>[ownerAddress, channelId, title, playlistId],
+    );
+  } finally {
+    db.dispose();
+  }
+}
+
+String? _readPlaylistChannelId({
+  required File file,
+  required String playlistId,
+}) {
+  final db = sqlite3.sqlite3.open(file.path);
+  try {
+    final rows = db.select(
+      'SELECT channel_id FROM playlists WHERE id = ?',
+      <Object?>[playlistId],
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return rows.first.columnAt(0) as String?;
   } finally {
     db.dispose();
   }

--- a/test/unit/infra/database/app_database_playlist_repair_test.dart
+++ b/test/unit/infra/database/app_database_playlist_repair_test.dart
@@ -743,6 +743,54 @@ void main() {
     );
 
     test(
+      'restores canonical address playlists when only channel id drifted',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'canonical-address-channel-drift.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: [
+              _RawPlaylistRow(
+                id: canonicalAddressPlaylistId,
+                channelId: 'channel_dp1',
+                ownerAddress: '0xABCDEF',
+                type: 0,
+                title: 'My Collection',
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAddressPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, canonicalAddressPlaylistId);
+            expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.channelId, Channel.myCollectionId);
+            expect(playlists.single.ownerAddress, '0xABCDEF');
+            expect(playlists.single.sortMode, PlaylistSortMode.provenance);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
       'deletes blank-owner address playlists from my collection',
       () async {
         final tempDir = await Directory.systemTemp.createTemp(
@@ -1229,6 +1277,8 @@ void main() {
                 channelId: '   ',
                 type: 1,
                 title: 'Recovered DP1 Playlist',
+                defaultsJson: '{"layout":"wallet"}',
+                dynamicQueriesJson: '[{"field":"ownerAddress"}]',
                 sortMode: 0,
                 itemCount: 1,
                 entryCount: 1,
@@ -1246,6 +1296,12 @@ void main() {
             expect(playlists.single.type, PlaylistType.dp1);
             expect(playlists.single.ownerAddress, isNull);
             expect(playlists.single.itemCount, 1);
+            final repaired = await service.getPlaylistById(
+              'playlist_address_drifted',
+            );
+            expect(repaired, isNotNull);
+            expect(repaired!.defaults, isNull);
+            expect(repaired.dynamicQueries, isNull);
           } finally {
             await db.close();
           }
@@ -1549,6 +1605,35 @@ void main() {
     );
 
     test(
+      'skips playlist repair safely when legacy db is missing json columns',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'playlist-missing-json-columns.sqlite'),
+        );
+
+        try {
+          _createPlaylistDatabaseWithoutJsonColumns(file: dbFile);
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+
+          try {
+            // Opening should succeed even though the repair path now knows how
+            // to scrub these columns on demotion. The preflight column guard
+            // must bail out before touching a legacy schema copy that lacks
+            // them.
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
       'rebuilds playlist search when an existing database '
       'is missing fts tables',
       () async {
@@ -1651,6 +1736,8 @@ class _RawPlaylistRow {
     this.createdAtUs = 1,
     this.updatedAtUs = 1,
     this.signatures = '[]',
+    this.defaultsJson,
+    this.dynamicQueriesJson,
     this.ownerAddress,
     this.sortMode,
     this.itemCount,
@@ -1665,6 +1752,8 @@ class _RawPlaylistRow {
   final int? createdAtUs;
   final int? updatedAtUs;
   final String? signatures;
+  final String? defaultsJson;
+  final String? dynamicQueriesJson;
   final String? ownerAddress;
   final int? sortMode;
   final int? itemCount;
@@ -1784,8 +1873,8 @@ void _createMalformedPlaylistDatabase({
           row.updatedAtUs,
           null,
           row.signatures,
-          null,
-          null,
+          row.defaultsJson,
+          row.dynamicQueriesJson,
           row.ownerAddress,
           null,
           row.sortMode,
@@ -1879,6 +1968,113 @@ void _insertChannelRow({
       ) VALUES (?, ?, ?, ?, ?)
       ''',
       <Object?>[id, 0, 'Channel', 1, 1],
+    );
+  } finally {
+    db.dispose();
+  }
+}
+
+void _createPlaylistDatabaseWithoutJsonColumns({required File file}) {
+  final db = sqlite3.sqlite3.open(file.path);
+  try {
+    void executeStatement(
+      String statement, [
+      List<Object?> params = const [],
+    ]) => db.execute(statement, params);
+
+    executeStatement('PRAGMA foreign_keys = ON;');
+    executeStatement('PRAGMA user_version = 3;');
+    executeStatement('''
+      CREATE TABLE publishers (
+        id INTEGER PRIMARY KEY,
+        title TEXT NOT NULL,
+        created_at_us INTEGER NOT NULL,
+        updated_at_us INTEGER NOT NULL
+      )
+    ''');
+    executeStatement('''
+      CREATE TABLE channels (
+        id TEXT PRIMARY KEY,
+        type INTEGER NOT NULL,
+        base_url TEXT,
+        slug TEXT,
+        publisher_id INTEGER,
+        title TEXT NOT NULL,
+        curator TEXT,
+        summary TEXT,
+        cover_image_uri TEXT,
+        created_at_us INTEGER NOT NULL,
+        updated_at_us INTEGER NOT NULL,
+        sort_order INTEGER
+      )
+    ''');
+    executeStatement('''
+      CREATE TABLE playlists (
+        id TEXT PRIMARY KEY,
+        channel_id TEXT,
+        type INTEGER,
+        base_url TEXT,
+        dp_version TEXT,
+        slug TEXT,
+        title TEXT,
+        created_at_us INTEGER,
+        updated_at_us INTEGER,
+        signature TEXT,
+        signatures TEXT,
+        owner_address TEXT,
+        owner_chain TEXT,
+        sort_mode INTEGER,
+        item_count INTEGER
+      )
+    ''');
+    executeStatement('''
+      CREATE TABLE items (
+        id TEXT PRIMARY KEY,
+        kind INTEGER NOT NULL,
+        title TEXT,
+        thumbnail_uri TEXT,
+        duration_sec INTEGER,
+        provenance_json TEXT,
+        source_uri TEXT,
+        ref_uri TEXT,
+        license TEXT,
+        repro_json TEXT,
+        override_json TEXT,
+        display_json TEXT,
+        list_artist_json TEXT,
+        enrichment_status INTEGER NOT NULL DEFAULT 0,
+        updated_at_us INTEGER NOT NULL
+      )
+    ''');
+    executeStatement('''
+      CREATE TABLE playlist_entries (
+        playlist_id TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        position INTEGER,
+        sort_key_us INTEGER NOT NULL,
+        updated_at_us INTEGER NOT NULL,
+        PRIMARY KEY (playlist_id, item_id)
+      )
+    ''');
+    executeStatement(
+      '''
+      INSERT INTO playlists (
+        id, channel_id, type, title, created_at_us, updated_at_us, signatures,
+        owner_address, sort_mode, item_count
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ''',
+      <Object?>[
+        Playlist.favoriteId,
+        Channel.myCollectionId,
+        PlaylistType.favorite.value,
+        'Favorites',
+        1,
+        1,
+        '[]',
+        null,
+        PlaylistSortMode.provenance.index,
+        0,
+      ],
     );
   } finally {
     db.dispose();

--- a/test/unit/infra/database/app_database_playlist_repair_test.dart
+++ b/test/unit/infra/database/app_database_playlist_repair_test.dart
@@ -648,6 +648,101 @@ void main() {
     );
 
     test(
+      'clears whitespace-only owner addresses from otherwise valid '
+      'dp1 playlists',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'dp1-control-whitespace-owner.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_dp1_whitespace_owner',
+                channelId: 'channel_dp1',
+                ownerAddress: '\t',
+                type: 0,
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_dp1_whitespace_owner');
+            expect(playlists.single.type, PlaylistType.dp1);
+            expect(playlists.single.channelId, 'channel_dp1');
+            expect(playlists.single.ownerAddress, isNull);
+            expect(playlists.single.itemCount, 1);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'keeps healthy address playlists intact',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'healthy-address-playlist.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: [
+              _RawPlaylistRow(
+                id: canonicalAddressPlaylistId,
+                channelId: Channel.myCollectionId,
+                ownerAddress: '0xABCDEF',
+                type: 1,
+                title: 'My Collection',
+                sortMode: 1,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAddressPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, canonicalAddressPlaylistId);
+            expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.channelId, Channel.myCollectionId);
+            expect(playlists.single.ownerAddress, '0xABCDEF');
+            expect(playlists.single.itemCount, 1);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
       'deletes blank-owner address playlists from my collection',
       () async {
         final tempDir = await Directory.systemTemp.createTemp(
@@ -1056,7 +1151,9 @@ void main() {
             expect(playlists, hasLength(1));
             expect(playlists.single.id, canonicalAddressPlaylistId);
             expect(playlists.single.ownerAddress, '0xABCDEF');
-            expect(playlists.single.itemCount, 2);
+            expect(playlists.single.itemCount, 1);
+            final items = await service.getItems();
+            expect(items.map((item) => item.id), ['good_item']);
           } finally {
             await db.close();
           }
@@ -1149,6 +1246,251 @@ void main() {
             expect(playlists.single.type, PlaylistType.dp1);
             expect(playlists.single.ownerAddress, isNull);
             expect(playlists.single.itemCount, 1);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs dp1 playlists when channel id drifted to whitespace only',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'dp1-whitespace-channel-only-drift.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_dp1_whitespace_channel',
+                channelId: '   ',
+                type: 0,
+                title: 'Recovered DP1 Playlist',
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_dp1_whitespace_channel');
+            expect(playlists.single.type, PlaylistType.dp1);
+            expect(playlists.single.channelId, isNull);
+            expect(playlists.single.ownerAddress, isNull);
+            expect(playlists.single.itemCount, 1);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs dp1 playlists when a real channel id has surrounding whitespace',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'dp1-surrounding-whitespace-channel.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_dp1_trimmed_channel',
+                channelId: ' channel_dp1 ',
+                type: 0,
+                title: 'Recovered DP1 Playlist',
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_dp1_trimmed_channel');
+            expect(playlists.single.type, PlaylistType.dp1);
+            expect(playlists.single.channelId, 'channel_dp1');
+            expect(playlists.single.ownerAddress, isNull);
+            expect(playlists.single.itemCount, 1);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs dp1 playlists when a real channel id has tab and newline drift',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'dp1-control-whitespace-channel.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_dp1_control_whitespace_channel',
+                channelId: '\tchannel_dp1\n',
+                type: 0,
+                title: 'Recovered DP1 Playlist',
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(
+              playlists.single.id,
+              'playlist_dp1_control_whitespace_channel',
+            );
+            expect(playlists.single.type, PlaylistType.dp1);
+            expect(playlists.single.channelId, 'channel_dp1');
+            expect(playlists.single.ownerAddress, isNull);
+            expect(playlists.single.itemCount, 1);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs dp1 playlists when a real channel id has '
+      'unicode whitespace drift',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'dp1-unicode-whitespace-channel.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_dp1_unicode_whitespace_channel',
+                channelId: '\u00A0channel_dp1\u00A0',
+                type: 0,
+                title: 'Recovered DP1 Playlist',
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(
+              playlists.single.id,
+              'playlist_dp1_unicode_whitespace_channel',
+            );
+            expect(playlists.single.type, PlaylistType.dp1);
+            expect(playlists.single.channelId, 'channel_dp1');
+            expect(playlists.single.ownerAddress, isNull);
+            expect(playlists.single.itemCount, 1);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'deletes blank-owner my-collection playlists when owner has '
+      'control whitespace',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(
+            tempDir.path,
+            'my-collection-control-whitespace-owner.sqlite',
+          ),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_my_collection_control_owner',
+                channelId: '\u00A0my_collection\u00A0',
+                ownerAddress: '\t',
+                type: 0,
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, isEmpty);
+            final deleted = await service.getPlaylistById(
+              'playlist_my_collection_control_owner',
+            );
+            expect(deleted, isNull);
+            final items = await service.getItems();
+            expect(items, isEmpty);
           } finally {
             await db.close();
           }

--- a/test/unit/infra/database/app_database_playlist_repair_test.dart
+++ b/test/unit/infra/database/app_database_playlist_repair_test.dart
@@ -602,8 +602,7 @@ void main() {
     );
 
     test(
-      'keeps dp1 playlists on their original channel '
-      'when owner address is stray',
+      'restores owner-bearing dp1 playlists back to the personal collection',
       () async {
         final tempDir = await Directory.systemTemp.createTemp(
           'ff_playlist_repair_',
@@ -634,10 +633,10 @@ void main() {
           try {
             final playlists = await service.getAllPlaylists();
             expect(playlists, hasLength(1));
-            expect(playlists.single.id, 'playlist_dp1_stray_owner');
-            expect(playlists.single.type, PlaylistType.dp1);
-            expect(playlists.single.channelId, 'channel_dp1');
-            expect(playlists.single.ownerAddress, isNull);
+            expect(playlists.single.id, canonicalAddressPlaylistId);
+            expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.channelId, Channel.myCollectionId);
+            expect(playlists.single.ownerAddress, '0xABCDEF');
           } finally {
             await db.close();
           }
@@ -1736,6 +1735,76 @@ void main() {
     );
 
     test(
+      'reuses the playlist repair sidecar on an untouched reopen',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'playlist-repair-sidecar-reuse.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_marker_sidecar_reuse',
+                channelId: 'channel_dp1',
+                type: 0,
+                title: 'Recovered DP1 Playlist',
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
+
+          final firstOpenDb = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final firstOpenService = DatabaseService(firstOpenDb);
+          try {
+            await firstOpenService.getAllPlaylists();
+          } finally {
+            await firstOpenDb.close();
+          }
+
+          final sidecarFile = File('${dbFile.path}.playlist_repair_state.json');
+          final firstModifiedAtUs = sidecarFile
+              .statSync()
+              .modified
+              .microsecondsSinceEpoch;
+          var hashFallbackCount = 0;
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+
+          final secondOpenDb = AppDatabase.forTesting(
+            NativeDatabase(dbFile),
+            onPlaylistRepairHashFallback: () => hashFallbackCount++,
+          );
+          final secondOpenService = DatabaseService(secondOpenDb);
+          try {
+            await secondOpenService.getAllPlaylists();
+          } finally {
+            await secondOpenDb.close();
+          }
+
+          expect(
+            hashFallbackCount,
+            0,
+            reason:
+                'untouched reopens should stay on the metadata-only fast path',
+          );
+          expect(
+            sidecarFile.statSync().modified.microsecondsSinceEpoch,
+            firstModifiedAtUs,
+          );
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
       'reruns repair on later opens when a marked db becomes malformed again',
       () async {
         final tempDir = await Directory.systemTemp.createTemp(
@@ -1776,9 +1845,303 @@ void main() {
           _updatePlaylistIdentity(
             file: dbFile,
             playlistId: personalPlaylistId,
+            updatedPlaylistId: 'playlist_marker_reopen_noncanonical',
             channelId: 'channel_dp1',
             title: 'Recovered Personal Playlist',
+            bumpUpdatedAtUs: false,
           );
+
+          final secondOpenDb = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final secondOpenService = DatabaseService(secondOpenDb);
+          try {
+            await secondOpenService.getAllPlaylists();
+          } finally {
+            await secondOpenDb.close();
+          }
+
+          expect(
+            _readPlaylistChannelId(
+              file: dbFile,
+              playlistId: personalPlaylistId,
+            ),
+            Channel.myCollectionId,
+          );
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'reruns repair for copied malformed snapshots even when marker '
+      'generation still looks current',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final originalDbFile = File(
+          p.join(tempDir.path, 'playlist-repair-marker-original.sqlite'),
+        );
+        final copiedDbFile = File(
+          p.join(tempDir.path, 'playlist-repair-marker-copied.sqlite'),
+        );
+        final personalPlaylistId = canonicalAddressPlaylistId;
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: originalDbFile,
+            rows: [
+              _RawPlaylistRow(
+                id: personalPlaylistId,
+                channelId: Channel.myCollectionId,
+                ownerAddress: '0xABCDEF',
+                type: PlaylistType.addressBased.value,
+                title: 'Recovered Personal Playlist',
+                sortMode: PlaylistSortMode.provenance.index,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final firstOpenDb = AppDatabase.forTesting(
+            NativeDatabase(originalDbFile),
+          );
+          final firstOpenService = DatabaseService(firstOpenDb);
+          try {
+            await firstOpenService.getAllPlaylists();
+          } finally {
+            await firstOpenDb.close();
+          }
+
+          await originalDbFile.copy(copiedDbFile.path);
+          _copyPlaylistRepairSidecar(
+            originalFile: originalDbFile,
+            copiedFile: copiedDbFile,
+          );
+          _updatePlaylistIdentity(
+            file: copiedDbFile,
+            playlistId: personalPlaylistId,
+            updatedPlaylistId: 'playlist_marker_copied_noncanonical',
+            channelId: 'channel_dp1',
+            title: 'Recovered Personal Playlist',
+            bumpUpdatedAtUs: false,
+          );
+          _forgePlaylistRepairMarkersAsCurrent(file: copiedDbFile);
+
+          final secondOpenDb = AppDatabase.forTesting(
+            NativeDatabase(copiedDbFile),
+          );
+          final secondOpenService = DatabaseService(secondOpenDb);
+          try {
+            await secondOpenService.getAllPlaylists();
+          } finally {
+            await secondOpenDb.close();
+          }
+
+          expect(
+            _readPlaylistChannelId(
+              file: copiedDbFile,
+              playlistId: personalPlaylistId,
+            ),
+            Channel.myCollectionId,
+          );
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'falls back to repair when the playlist repair sidecar is corrupted',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'playlist-repair-sidecar-corrupted.sqlite'),
+        );
+        final personalPlaylistId = canonicalAddressPlaylistId;
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: [
+              _RawPlaylistRow(
+                id: personalPlaylistId,
+                channelId: Channel.myCollectionId,
+                ownerAddress: '0xABCDEF',
+                type: PlaylistType.addressBased.value,
+                title: 'Recovered Personal Playlist',
+                sortMode: PlaylistSortMode.provenance.index,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final firstOpenDb = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final firstOpenService = DatabaseService(firstOpenDb);
+          try {
+            await firstOpenService.getAllPlaylists();
+          } finally {
+            await firstOpenDb.close();
+          }
+
+          File('${dbFile.path}.playlist_repair_state.json').writeAsStringSync(
+            '{not-json',
+          );
+          _updatePlaylistIdentity(
+            file: dbFile,
+            playlistId: personalPlaylistId,
+            updatedPlaylistId: 'playlist_marker_sidecar_corrupted',
+            channelId: 'channel_dp1',
+            title: 'Recovered Personal Playlist',
+            bumpUpdatedAtUs: false,
+          );
+
+          final secondOpenDb = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final secondOpenService = DatabaseService(secondOpenDb);
+          try {
+            await secondOpenService.getAllPlaylists();
+          } finally {
+            await secondOpenDb.close();
+          }
+
+          expect(
+            _readPlaylistChannelId(
+              file: dbFile,
+              playlistId: personalPlaylistId,
+            ),
+            Channel.myCollectionId,
+          );
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'falls back to repair when writing the playlist repair sidecar fails',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'playlist-repair-sidecar-write-fails.sqlite'),
+        );
+        final personalPlaylistId = canonicalAddressPlaylistId;
+        final tempSidecarDir = Directory(
+          '${dbFile.path}.playlist_repair_state.json.tmp',
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: [
+              _RawPlaylistRow(
+                id: personalPlaylistId,
+                channelId: Channel.myCollectionId,
+                ownerAddress: '0xABCDEF',
+                type: PlaylistType.addressBased.value,
+                title: 'Recovered Personal Playlist',
+                sortMode: PlaylistSortMode.provenance.index,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final firstOpenDb = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final firstOpenService = DatabaseService(firstOpenDb);
+          try {
+            await firstOpenService.getAllPlaylists();
+          } finally {
+            await firstOpenDb.close();
+          }
+
+          await File('${dbFile.path}.playlist_repair_state.json').delete();
+          await tempSidecarDir.create();
+          _updatePlaylistIdentity(
+            file: dbFile,
+            playlistId: personalPlaylistId,
+            updatedPlaylistId: 'playlist_marker_sidecar_write_fails',
+            channelId: 'channel_dp1',
+            title: 'Recovered Personal Playlist',
+            bumpUpdatedAtUs: false,
+          );
+
+          final secondOpenDb = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final secondOpenService = DatabaseService(secondOpenDb);
+          try {
+            await secondOpenService.getAllPlaylists();
+          } finally {
+            await secondOpenDb.close();
+          }
+
+          expect(
+            _readPlaylistChannelId(
+              file: dbFile,
+              playlistId: personalPlaylistId,
+            ),
+            Channel.myCollectionId,
+          );
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'falls back to repair when sidecar fingerprint collection fails',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(
+            tempDir.path,
+            'playlist-repair-sidecar-fingerprint-fails.sqlite',
+          ),
+        );
+        final personalPlaylistId = canonicalAddressPlaylistId;
+        final shmDir = Directory('${dbFile.path}-shm');
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: [
+              _RawPlaylistRow(
+                id: personalPlaylistId,
+                channelId: Channel.myCollectionId,
+                ownerAddress: '0xABCDEF',
+                type: PlaylistType.addressBased.value,
+                title: 'Recovered Personal Playlist',
+                sortMode: PlaylistSortMode.provenance.index,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final firstOpenDb = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final firstOpenService = DatabaseService(firstOpenDb);
+          try {
+            await firstOpenService.getAllPlaylists();
+          } finally {
+            await firstOpenDb.close();
+          }
+
+          await File('${dbFile.path}.playlist_repair_state.json').delete();
+          _updatePlaylistIdentity(
+            file: dbFile,
+            playlistId: personalPlaylistId,
+            updatedPlaylistId: 'playlist_marker_sidecar_fingerprint_fails',
+            channelId: 'channel_dp1',
+            title: 'Recovered Personal Playlist',
+            bumpUpdatedAtUs: false,
+          );
+          await shmDir.create();
 
           final secondOpenDb = AppDatabase.forTesting(NativeDatabase(dbFile));
           final secondOpenService = DatabaseService(secondOpenDb);
@@ -2269,22 +2632,58 @@ bool _hasPlaylistRepairMarker({required File file}) {
 void _updatePlaylistIdentity({
   required File file,
   required String playlistId,
+  String? updatedPlaylistId,
   String? ownerAddress,
   String? channelId,
   String? title,
+  bool bumpUpdatedAtUs = true,
 }) {
   final db = sqlite3.sqlite3.open(file.path);
   try {
+    final updatedAtUs = DateTime.now().microsecondsSinceEpoch;
+    final bumpUpdatedAtUsFlag = bumpUpdatedAtUs ? 1 : 0;
     db.execute(
       '''
       UPDATE playlists
-      SET owner_address = COALESCE(?, owner_address),
+      SET id = COALESCE(?, id),
+          owner_address = COALESCE(?, owner_address),
           channel_id = COALESCE(?, channel_id),
-          title = COALESCE(?, title)
+          title = COALESCE(?, title),
+          updated_at_us = CASE
+            WHEN ? THEN ?
+            ELSE updated_at_us
+          END
       WHERE id = ?
       ''',
-      <Object?>[ownerAddress, channelId, title, playlistId],
+      <Object?>[
+        updatedPlaylistId,
+        ownerAddress,
+        channelId,
+        title,
+        bumpUpdatedAtUsFlag,
+        updatedAtUs,
+        playlistId,
+      ],
     );
+    if (updatedPlaylistId != null && updatedPlaylistId != playlistId) {
+      db.execute(
+        '''
+        UPDATE playlist_entries
+        SET playlist_id = ?,
+            updated_at_us = CASE
+              WHEN ? THEN ?
+              ELSE updated_at_us
+            END
+        WHERE playlist_id = ?
+        ''',
+        <Object?>[
+          updatedPlaylistId,
+          bumpUpdatedAtUsFlag,
+          updatedAtUs,
+          playlistId,
+        ],
+      );
+    }
   } finally {
     db.dispose();
   }
@@ -2307,4 +2706,59 @@ String? _readPlaylistChannelId({
   } finally {
     db.dispose();
   }
+}
+
+void _forgePlaylistRepairMarkersAsCurrent({required File file}) {
+  final db = sqlite3.sqlite3.open(file.path);
+  try {
+    void execute(String statement, [List<Object?> params = const []]) =>
+        db.execute(statement, params);
+    final generationRows = db.select(
+      '''
+      SELECT completed_at_us
+      FROM internal_repair_markers
+      WHERE key = 'playlist_repair_v1_generation'
+      LIMIT 1
+      ''',
+    );
+    final generation = generationRows.isEmpty
+        ? 0
+        : generationRows.first.columnAt(0) as int;
+    execute(
+      '''
+      INSERT OR REPLACE INTO internal_repair_markers (key, completed_at_us)
+      VALUES ('playlist_repair_v1_completed_generation', ?)
+      ''',
+      <Object?>[generation],
+    );
+    execute(
+      '''
+      INSERT OR REPLACE INTO internal_repair_markers (key, completed_at_us)
+      VALUES ('playlist_repair_v1_completed', ?)
+      ''',
+      <Object?>[generation],
+    );
+    execute(
+      '''
+      INSERT OR REPLACE INTO internal_repair_markers (key, completed_at_us)
+      VALUES ('playlist_repair_v1_completed_at_us', ?)
+      ''',
+      <Object?>[1],
+    );
+  } finally {
+    db.dispose();
+  }
+}
+
+void _copyPlaylistRepairSidecar({
+  required File originalFile,
+  required File copiedFile,
+}) {
+  final originalSidecar = File(
+    '${originalFile.path}.playlist_repair_state.json',
+  );
+  if (!originalSidecar.existsSync()) {
+    return;
+  }
+  originalSidecar.copySync('${copiedFile.path}.playlist_repair_state.json');
 }

--- a/test/unit/infra/database/app_database_playlist_repair_test.dart
+++ b/test/unit/infra/database/app_database_playlist_repair_test.dart
@@ -1312,6 +1312,57 @@ void main() {
     );
 
     test(
+      'clears stale personal json from already-dp1 rows left by prior repairs',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'dp1-stale-personal-json.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_dp1_stale_personal_json',
+                type: 0,
+                title: 'Recovered DP1 Playlist',
+                defaultsJson: '{"layout":"wallet"}',
+                dynamicQueriesJson: '[{"field":"ownerAddress"}]',
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_dp1_stale_personal_json');
+            expect(playlists.single.type, PlaylistType.dp1);
+            expect(playlists.single.ownerAddress, isNull);
+            final repaired = await service.getPlaylistById(
+              'playlist_dp1_stale_personal_json',
+            );
+            expect(repaired, isNotNull);
+            expect(repaired!.defaults, isNull);
+            expect(repaired.dynamicQueries, isNull);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
       'repairs dp1 playlists when channel id drifted to whitespace only',
       () async {
         final tempDir = await Directory.systemTemp.createTemp(

--- a/test/unit/infra/database/app_database_playlist_repair_test.dart
+++ b/test/unit/infra/database/app_database_playlist_repair_test.dart
@@ -12,46 +12,231 @@ import 'package:sqlite3/sqlite3.dart' as sqlite3;
 
 void main() {
   group('AppDatabase malformed playlist repair', () {
-    test('repairs malformed favorite row before bootstrap reads it', () async {
-      final tempDir = await Directory.systemTemp.createTemp(
-        'ff_playlist_repair_',
-      );
-      final dbFile = File(p.join(tempDir.path, 'favorite-malformed.sqlite'));
-
-      try {
-        _createMalformedPlaylistDatabase(
-          file: dbFile,
-          rows: const [
-              _RawPlaylistRow(
-                id: Playlist.favoriteId,
-                type: 0,
-              ),
-          ],
+    test(
+      'repairs favorite rows when sort mode is the only wrong field',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
         );
-
-        final db = AppDatabase.forTesting(NativeDatabase(dbFile));
-        final service = DatabaseService(db);
+        final dbFile = File(p.join(tempDir.path, 'favorite-malformed.sqlite'));
 
         try {
-          await BootstrapService(databaseService: service).bootstrap();
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: Playlist.favoriteId,
+                channelId: Channel.myCollectionId,
+                type: 2,
+                sortMode: 0,
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
 
-          final favorite = await service.getPlaylistById(Playlist.favoriteId);
-          expect(favorite, isNotNull);
-          expect(favorite!.name, 'Favorites');
-          expect(favorite.type, PlaylistType.favorite);
-          expect(favorite.sortMode, PlaylistSortMode.provenance);
-          expect(favorite.itemCount, 0);
-          expect(favorite.channelId, Channel.myCollectionId);
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            await BootstrapService(databaseService: service).bootstrap();
+
+            final favorite = await service.getPlaylistById(Playlist.favoriteId);
+            expect(favorite, isNotNull);
+            expect(favorite!.id, Playlist.favoriteId);
+            expect(favorite.type, PlaylistType.favorite);
+            expect(favorite.channelId, Channel.myCollectionId);
+            expect(favorite.sortMode, PlaylistSortMode.provenance);
+            expect(favorite.itemCount, 0);
+          } finally {
+            await db.close();
+          }
         } finally {
-          await db.close();
+          await tempDir.delete(recursive: true);
         }
-      } finally {
-        await tempDir.delete(recursive: true);
-      }
-    });
+      },
+    );
 
     test(
-      'repairs malformed address playlists before list queries map rows',
+      'clears stray owner address from canonical favorite rows',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'favorite-stray-owner.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: Playlist.favoriteId,
+                channelId: Channel.myCollectionId,
+                ownerAddress: '0xABCDEF',
+                type: 2,
+                sortMode: 1,
+                itemCount: 0,
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final favorite = await service.getPlaylistById(Playlist.favoriteId);
+            expect(favorite, isNotNull);
+            expect(favorite!.type, PlaylistType.favorite);
+            expect(favorite.ownerAddress, isNull);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'keeps dp1 playlists on their original channel '
+      'when type drifted to address and owner is stray',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'dp1-address-type-with-stray-owner.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_dp1_address_type_stray_owner',
+                channelId: 'channel_dp1',
+                ownerAddress: '0xABCDEF',
+                type: 1,
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+          _insertChannelRow(file: dbFile, id: 'channel_dp1');
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(
+              playlists.single.id,
+              'playlist_dp1_address_type_stray_owner',
+            );
+            expect(playlists.single.type, PlaylistType.dp1);
+            expect(playlists.single.channelId, 'channel_dp1');
+            expect(playlists.single.ownerAddress, isNull);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'restores the canonical favorite title '
+      'even when a wrong title is present',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'favorite-wrong-title.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: Playlist.favoriteId,
+                channelId: Channel.myCollectionId,
+                type: 2,
+                title: 'My Playlist',
+                sortMode: 1,
+                itemCount: 0,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final favorite = await service.getPlaylistById(Playlist.favoriteId);
+            expect(favorite, isNotNull);
+            expect(favorite!.name, 'Favorites');
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'deletes non-canonical favorite rows',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'non-canonical-favorite.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_fake_favorite',
+                channelId: Channel.myCollectionId,
+                type: 2,
+                sortMode: 1,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, isEmpty);
+            final deleted = await service.getPlaylistById(
+              'playlist_fake_favorite',
+            );
+            expect(deleted, isNull);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs address playlists when type is the only wrong field',
       () async {
         final tempDir = await Directory.systemTemp.createTemp(
           'ff_playlist_repair_',
@@ -64,12 +249,10 @@ void main() {
             rows: const [
               _RawPlaylistRow(
                 id: 'playlist_addr',
+                channelId: Channel.myCollectionId,
                 ownerAddress: '0xABCDEF',
-                type: 9,
-                updatedAtUs: 55,
-                signatures: '',
-                sortMode: 99,
-                itemCount: -4,
+                type: 0,
+                sortMode: 1,
               ),
             ],
           );
@@ -81,12 +264,732 @@ void main() {
             final playlists = await service.getAllPlaylists();
             expect(playlists, hasLength(1));
             expect(playlists.single.id, 'playlist_addr');
-            expect(playlists.single.name, '0xABCDEF');
             expect(playlists.single.type, PlaylistType.addressBased);
             expect(playlists.single.channelId, Channel.myCollectionId);
             expect(playlists.single.sortMode, PlaylistSortMode.provenance);
             expect(playlists.single.itemCount, 0);
-            expect(playlists.single.createdAt!.microsecondsSinceEpoch, 55);
+            expect(playlists.single.createdAt, isNotNull);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs address playlists when owner address '
+      'is the only surviving signal',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-owner-only-signal.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_addr_owner_only',
+                ownerAddress: '0xABCDEF',
+                title: null,
+                createdAtUs: null,
+                updatedAtUs: null,
+                signatures: null,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_addr_owner_only');
+            expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.channelId, Channel.myCollectionId);
+            expect(playlists.single.ownerAddress, '0xABCDEF');
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs address playlists when owner address is present '
+      'and the stored type drifted to favorite',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(
+            tempDir.path,
+            'address-owner-favorite-type-null-channel.sqlite',
+          ),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_addr_owner_favorite_type',
+                ownerAddress: '0xABCDEF',
+                type: 2,
+                title: null,
+                createdAtUs: null,
+                updatedAtUs: null,
+                signatures: null,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_addr_owner_favorite_type');
+            expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.channelId, Channel.myCollectionId);
+            expect(playlists.single.ownerAddress, '0xABCDEF');
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs address playlists when owner address is present '
+      'and the stored type drifted to dp1 with no channel',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-owner-dp1-type-null-channel.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_addr_owner_dp1_type',
+                ownerAddress: '0xABCDEF',
+                type: 0,
+                title: null,
+                createdAtUs: null,
+                updatedAtUs: null,
+                signatures: null,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_addr_owner_dp1_type');
+            expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.channelId, Channel.myCollectionId);
+            expect(playlists.single.ownerAddress, '0xABCDEF');
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs address playlists when channel id is blank whitespace',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-owner-blank-channel.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_addr_blank_channel',
+                channelId: '   ',
+                ownerAddress: '0xABCDEF',
+                type: 0,
+                title: null,
+                createdAtUs: null,
+                updatedAtUs: null,
+                signatures: null,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_addr_blank_channel');
+            expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.channelId, Channel.myCollectionId);
+            expect(playlists.single.ownerAddress, '0xABCDEF');
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs address playlists when the stored type drifted to favorite',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-typed-as-favorite.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_addr_favorite_type',
+                channelId: Channel.myCollectionId,
+                ownerAddress: '0xABCDEF',
+                type: 2,
+                sortMode: 1,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_addr_favorite_type');
+            expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.channelId, Channel.myCollectionId);
+            expect(playlists.single.sortMode, PlaylistSortMode.provenance);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs address playlists when channel is the only wrong field',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-wrong-channel.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_addr',
+                ownerAddress: '0xABCDEF',
+                type: 1,
+                sortMode: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_addr');
+            expect(playlists.single.type, PlaylistType.addressBased);
+            expect(playlists.single.channelId, Channel.myCollectionId);
+            expect(playlists.single.sortMode, PlaylistSortMode.provenance);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs normal channel playlists when stored type drifted to address',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'dp1-typed-as-address.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_dp1_address_type',
+                channelId: 'channel_dp1',
+                type: 1,
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_dp1_address_type');
+            expect(playlists.single.type, PlaylistType.dp1);
+            expect(playlists.single.channelId, 'channel_dp1');
+            expect(playlists.single.sortMode, PlaylistSortMode.position);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'keeps dp1 playlists on their original channel '
+      'when owner address is stray',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'dp1-with-stray-owner.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_dp1_stray_owner',
+                channelId: 'channel_dp1',
+                ownerAddress: '0xABCDEF',
+                type: 0,
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, hasLength(1));
+            expect(playlists.single.id, 'playlist_dp1_stray_owner');
+            expect(playlists.single.type, PlaylistType.dp1);
+            expect(playlists.single.channelId, 'channel_dp1');
+            expect(playlists.single.ownerAddress, isNull);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'deletes blank-owner address playlists from my collection',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-blank-owner.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_addr',
+                channelId: Channel.myCollectionId,
+                type: 1,
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, isEmpty);
+            final deleted = await service.getPlaylistById('playlist_addr');
+            expect(deleted, isNull);
+            final items = await service.getItems();
+            expect(items, isEmpty);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'deletes blank-owner my-collection playlists with invalid type',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-invalid-type-blank-owner.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_invalid_type',
+                channelId: Channel.myCollectionId,
+                type: 9,
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, isEmpty);
+            final deleted = await service.getPlaylistById(
+              'playlist_invalid_type',
+            );
+            expect(deleted, isNull);
+            final items = await service.getItems();
+            expect(items, isEmpty);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'deletes blank-owner my-collection playlists with dp1 type',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'address-dp1-type-blank-owner.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_dp1_my_collection',
+                channelId: Channel.myCollectionId,
+                type: 0,
+                sortMode: 0,
+                itemCount: 1,
+                entryCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final playlists = await service.getAllPlaylists();
+            expect(playlists, isEmpty);
+            final deleted = await service.getPlaylistById(
+              'playlist_dp1_my_collection',
+            );
+            expect(deleted, isNull);
+            final items = await service.getItems();
+            expect(items, isEmpty);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'recomputes item count from playlist entries '
+      'when stored count is invalid',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'favorite-invalid-count.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: Playlist.favoriteId,
+                channelId: Channel.myCollectionId,
+                type: 2,
+                sortMode: 1,
+                itemCount: -1,
+                entryCount: 2,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final favorite = await service.getPlaylistById(Playlist.favoriteId);
+            expect(favorite, isNotNull);
+            expect(favorite!.itemCount, 2);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'recomputes stale favorite item counts from playlist entries',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'favorite-stale-positive-count.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: Playlist.favoriteId,
+                channelId: Channel.myCollectionId,
+                type: 2,
+                sortMode: 1,
+                itemCount: 1,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final favorite = await service.getPlaylistById(Playlist.favoriteId);
+            expect(favorite, isNotNull);
+            expect(favorite!.itemCount, 0);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'repairs null required fields before bootstrap reads favorite rows',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'favorite-null-required-fields.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: Playlist.favoriteId,
+                title: null,
+                createdAtUs: null,
+                updatedAtUs: null,
+                signatures: null,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            await BootstrapService(databaseService: service).bootstrap();
+
+            final favorite = await service.getPlaylistById(Playlist.favoriteId);
+            expect(favorite, isNotNull);
+            expect(favorite!.id, Playlist.favoriteId);
+            expect(favorite.type, PlaylistType.favorite);
+            expect(favorite.name, 'Favorites');
+            expect(favorite.channelId, Channel.myCollectionId);
+            expect(favorite.sortMode, PlaylistSortMode.provenance);
+            expect(favorite.itemCount, 0);
+            expect(favorite.createdAt, isNotNull);
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'rebuilds playlist search when an existing database '
+      'is missing fts tables',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(tempDir.path, 'missing-fts-searchable-playlist.sqlite'),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_searchable',
+                channelId: 'channel_dp1',
+                type: 0,
+                title: 'Searchable Playlist',
+                sortMode: 0,
+                itemCount: 0,
+              ),
+            ],
+          );
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final results = await service.searchPlaylists('Searchable');
+            expect(
+              results.map((playlist) => playlist.id),
+              contains('playlist_searchable'),
+            );
+          } finally {
+            await db.close();
+          }
+        } finally {
+          await tempDir.delete(recursive: true);
+        }
+      },
+    );
+
+    test(
+      'rebuilds playlist search when fts tables exist '
+      'but triggers are missing',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'ff_playlist_repair_',
+        );
+        final dbFile = File(
+          p.join(
+            tempDir.path,
+            'missing-fts-triggers-searchable-playlist.sqlite',
+          ),
+        );
+
+        try {
+          _createMalformedPlaylistDatabase(
+            file: dbFile,
+            rows: const [
+              _RawPlaylistRow(
+                id: 'playlist_searchable_triggerless',
+                channelId: 'channel_dp1',
+                type: 0,
+                title: 'Triggerless Playlist',
+                sortMode: 0,
+                itemCount: 0,
+              ),
+            ],
+          );
+          _createFtsTablesWithoutTriggers(file: dbFile);
+
+          final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+          final service = DatabaseService(db);
+
+          try {
+            final results = await service.searchPlaylists('Triggerless');
+            expect(
+              results.map((playlist) => playlist.id),
+              contains('playlist_searchable_triggerless'),
+            );
           } finally {
             await db.close();
           }
@@ -101,21 +1004,29 @@ void main() {
 class _RawPlaylistRow {
   const _RawPlaylistRow({
     required this.id,
+    this.channelId,
     this.type,
-    this.updatedAtUs,
-    this.signatures,
+    this.title = 'Playlist',
+    this.createdAtUs = 1,
+    this.updatedAtUs = 1,
+    this.signatures = '[]',
     this.ownerAddress,
     this.sortMode,
     this.itemCount,
+    this.entryCount = 0,
   });
 
   final String id;
+  final String? channelId;
   final int? type;
+  final String? title;
+  final int? createdAtUs;
   final int? updatedAtUs;
   final String? signatures;
   final String? ownerAddress;
   final int? sortMode;
   final int? itemCount;
+  final int entryCount;
 }
 
 void _createMalformedPlaylistDatabase({
@@ -201,7 +1112,10 @@ void _createMalformedPlaylistDatabase({
       )
       ''',
     ];
-    void executeStatement(String statement) => db.execute(statement);
+    void executeStatement(
+      String statement, [
+      List<Object?> params = const [],
+    ]) => db.execute(statement, params);
     setupStatements.forEach(executeStatement);
 
     for (final row in rows) {
@@ -216,13 +1130,13 @@ void _createMalformedPlaylistDatabase({
         ''',
         <Object?>[
           row.id,
-          null,
+          row.channelId,
           row.type,
           null,
           null,
           null,
-          null,
-          null,
+          row.title,
+          row.createdAtUs,
           row.updatedAtUs,
           null,
           row.signatures,
@@ -234,7 +1148,86 @@ void _createMalformedPlaylistDatabase({
           row.itemCount,
         ],
       );
+
+      for (var i = 0; i < row.entryCount; i++) {
+        final itemId = '${row.id}_item_$i';
+        executeStatement(
+          '''
+          INSERT INTO items (id, kind, updated_at_us, enrichment_status)
+          VALUES (?, ?, ?, ?)
+          ''',
+          <Object?>[itemId, 0, 1, 0],
+        );
+        executeStatement(
+          '''
+          INSERT INTO playlist_entries (
+            playlist_id, item_id, position, sort_key_us, updated_at_us
+          ) VALUES (?, ?, ?, ?, ?)
+          ''',
+          <Object?>[row.id, itemId, i, i, 1],
+        );
+      }
     }
+  } finally {
+    db.dispose();
+  }
+}
+
+void _createFtsTablesWithoutTriggers({required File file}) {
+  final db = sqlite3.sqlite3.open(file.path);
+  try {
+    void executeStatement(String statement) => db.execute(statement);
+    executeStatement('''
+      CREATE VIRTUAL TABLE IF NOT EXISTS channels_fts
+      USING fts5(
+        id UNINDEXED,
+        title,
+        tokenize = 'unicode61 remove_diacritics 2'
+      )
+    ''');
+    executeStatement('''
+      CREATE VIRTUAL TABLE IF NOT EXISTS playlists_fts
+      USING fts5(
+        id UNINDEXED,
+        title,
+        tokenize = 'unicode61 remove_diacritics 2'
+      )
+    ''');
+    executeStatement('''
+      CREATE VIRTUAL TABLE IF NOT EXISTS items_fts
+      USING fts5(
+        id UNINDEXED,
+        title,
+        tokenize = 'unicode61 remove_diacritics 2'
+      )
+    ''');
+    executeStatement('''
+      CREATE VIRTUAL TABLE IF NOT EXISTS item_artists_fts
+      USING fts5(
+        id UNINDEXED,
+        artist_name,
+        tokenize = 'unicode61 remove_diacritics 2'
+      )
+    ''');
+  } finally {
+    db.dispose();
+  }
+}
+
+void _insertChannelRow({
+  required File file,
+  required String id,
+}) {
+  final db = sqlite3.sqlite3.open(file.path);
+  try {
+    db.execute(
+      '''
+      INSERT INTO channels (
+        id, type, title, created_at_us, updated_at_us
+      ) VALUES (?, ?, ?, ?, ?)
+      ''',
+      <Object?>[id, 0, 'Channel', 1, 1],
+    );
   } finally {
     db.dispose();
   }


### PR DESCRIPTION
## Problem
Startup can crash while bootstrap reads playlists from the local Drift database if copied or partially migrated rows violate playlist invariants. The existing issue analysis is directionally correct about null-required fields, but the actual failure class is broader: malformed favorite/address playlist rows with drifted type, channel, owner, title, sort mode, or stale counts can still break startup and playlist loading.

## Why It Matters
One malformed local playlist row can take down `_ensureFavoritePlaylists()` during bootstrap and also poison playlist list/watch queries, which turns a recoverable local-data problem into a home-screen startup failure.

## What Changed
- Repair malformed playlist rows during database open before Drift maps them.
- Re-canonicalize the favorite playlist and address-based playlists, clear stray owner addresses from DP-1 playlists, and delete impossible My Collection rows with no owner.
- Recompute favorite item counts from `playlist_entries` and rebuild playlist FTS when older databases are missing FTS tables or triggers.
- Add coverage for null required fields, canonical favorite drift, address playlist drift, blank-owner deletion, stale counts, and missing FTS infrastructure.

## Acceptance Checks
- `flutter test test/unit/infra/database/app_database_playlist_repair_test.dart`
- `scripts/agent-helpers/post-implementation-checks.sh HEAD`

Closes #354
