### PR TITLE
fix(ff1): WiFi→BLE fallback must connect BLE before BLE commands

### DIFF
--- a/lib/app/providers/ff1_wifi_ble_fallback.dart
+++ b/lib/app/providers/ff1_wifi_ble_fallback.dart
@@ -1,0 +1,40 @@
+import 'package:app/app/ff1/ff1_ble_device_connect.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger('FF1WifiBleFallback');
+
+/// Runs a WiFi-first command flow with a BLE fallback that is guaranteed to
+/// connect and discover services before the BLE command runs.
+///
+/// Why: FF1 BLE commands require a live BLE session and cached command
+/// characteristic. The caller must not invoke BLE fallback directly without
+/// first establishing readiness, or the fallback will fail on disconnected
+/// devices.
+Future<bool> runWifiThenBleFallback({
+  required Future<bool> Function() wifiAttempt,
+  required Future<void> Function() bleAttempt,
+  required Ff1BleConnectPort bleConnectPort,
+  required BluetoothDevice blDevice,
+  String actionName = 'FF1 command',
+}) async {
+  var success = false;
+
+  try {
+    success = await wifiAttempt();
+  } on Object catch (e) {
+    _log.warning('[$actionName] WiFi attempt failed: $e, falling back to BLE');
+  }
+
+  if (!success) {
+    _log.info('[$actionName] Ensuring BLE readiness before fallback');
+    await connectFf1BleDeviceWithRiverpodRetries(
+      control: bleConnectPort,
+      blDevice: blDevice,
+    );
+    await bleAttempt();
+    success = true;
+  }
+
+  return success;
+}

--- a/lib/app/providers/send_log_provider.dart
+++ b/lib/app/providers/send_log_provider.dart
@@ -1,4 +1,5 @@
 import 'package:app/app/providers/ff1_providers.dart';
+import 'package:app/app/providers/ff1_wifi_ble_fallback.dart';
 import 'package:app/app/providers/ff1_wifi_providers.dart';
 import 'package:app/domain/models/ff1_device.dart';
 import 'package:app/infra/config/app_config.dart';
@@ -68,7 +69,7 @@ class SendLogNotifier extends Notifier<void> {
   ///    immediately — without touching the device — if missing.
   /// 2. Try WiFi when `device.topicId` is available. Treat any non-ok response
   ///    or thrown exception as a signal to fall back to BLE.
-  /// 3. Fall back to BLE. Treat any thrown exception as [SendLogFailure].
+  /// 3. Fall back to BLE. Treat any thrown error/object as [SendLogFailure].
   Future<SendLogOutcome> send(FF1Device device) async {
     final apiKey = ref.read(supportApiKeyProvider);
     if (apiKey.isEmpty) {
@@ -81,10 +82,12 @@ class SendLogNotifier extends Notifier<void> {
     const userId = 'user-id';
 
     try {
-      var success = false;
+      final success = await runWifiThenBleFallback(
+        wifiAttempt: () async {
+          if (device.topicId.isEmpty) {
+            return false;
+          }
 
-      if (device.topicId.isNotEmpty) {
-        try {
           _log.info('[SendLog] Attempting via WiFi');
           final wifiControl = ref.read(ff1WifiControlProvider);
           final response = await wifiControl.sendLog(
@@ -97,31 +100,31 @@ class SendLogNotifier extends Notifier<void> {
           // status string so the result is consistent with all other WiFi
           // command checks in this codebase.
           final okFlag = ff1CommandResponseOkFlag(response);
-          success = okFlag ?? ff1CommandResponseIsOk(response);
-          if (!success) {
+          final ok = okFlag ?? ff1CommandResponseIsOk(response);
+          if (!ok) {
             _log.warning(
               '[SendLog] WiFi returned non-ok response, falling back to BLE',
             );
           }
-        } on Exception catch (e) {
-          _log.warning('[SendLog] WiFi error: $e, falling back to BLE');
-        }
-      }
-
-      if (!success) {
-        _log.info('[SendLog] Attempting via BLE');
-        final bleControl = ref.read(ff1ControlProvider);
-        await bleControl.sendLog(
-          blDevice: device.toBluetoothDevice(),
-          userId: userId,
-          title: device.name,
-          apiKey: apiKey,
-        );
-        success = true;
-      }
+          return ok;
+        },
+        bleAttempt: () async {
+          _log.info('[SendLog] Attempting via BLE');
+          final bleControl = ref.read(ff1ControlProvider);
+          await bleControl.sendLog(
+            blDevice: device.toBluetoothDevice(),
+            userId: userId,
+            title: device.name,
+            apiKey: apiKey,
+          );
+        },
+        bleConnectPort: ref.read(ff1ControlProvider),
+        blDevice: device.toBluetoothDevice(),
+        actionName: 'SendLog',
+      );
 
       return success ? const SendLogSuccess() : const SendLogFailure('unknown');
-    } on Exception catch (e) {
+    } on Object catch (e) {
       _log.warning('[SendLog] Failed: $e');
       return SendLogFailure(e);
     }

--- a/lib/widgets/device_configuration/options_button.dart
+++ b/lib/widgets/device_configuration/options_button.dart
@@ -4,6 +4,7 @@ import 'package:app/app/ff1/ff1_firmware_update_prompt_service.dart';
 import 'package:app/app/ff1/ff1_relayer_firmware_update_service.dart';
 import 'package:app/app/providers/ff1_bluetooth_device_providers.dart';
 import 'package:app/app/providers/ff1_providers.dart';
+import 'package:app/app/providers/ff1_wifi_ble_fallback.dart';
 import 'package:app/app/providers/ff1_wifi_providers.dart';
 import 'package:app/app/providers/send_log_provider.dart';
 import 'package:app/app/routing/navigation_extensions.dart';
@@ -411,42 +412,43 @@ class OptionsButton extends ConsumerWidget {
                   color: Colors.transparent,
                   onTap: () async {
                     try {
-                      var success = false;
+                      final success = await runWifiThenBleFallback(
+                        wifiAttempt: () async {
+                          if (device.topicId.isEmpty) {
+                            return false;
+                          }
 
-                      if (device.topicId.isNotEmpty) {
-                        try {
                           _log.info('[Factory Reset] Attempting via WiFi');
                           final response = await control.factoryReset(
                             topicId: device.topicId,
                           );
                           final okFlag = ff1CommandResponseOkFlag(response);
-                          success = okFlag ?? ff1CommandResponseIsOk(response);
-                          if (!success) {
+                          final ok = okFlag ?? ff1CommandResponseIsOk(response);
+                          if (!ok) {
                             _log.warning(
                               '[Factory Reset] WiFi returned unsuccessful '
                               'response, fallback to BLE',
                             );
                           }
-                        } on Exception catch (e) {
-                          _log.warning(
-                            '[Factory Reset] WiFi error: $e, '
-                            'falling back to BLE',
-                          );
-                        }
-                      }
-
-                      if (!success) {
-                        _log.info('[Factory Reset] Attempting via Bluetooth');
-                        await ref
-                            .read(ff1ControlProvider)
-                            .factoryReset(blDevice: device.toBluetoothDevice());
-                        success = true;
-                      }
+                          return ok;
+                        },
+                        bleAttempt: () async {
+                          _log.info('[Factory Reset] Attempting via Bluetooth');
+                          await ref
+                              .read(ff1ControlProvider)
+                              .factoryReset(
+                                blDevice: device.toBluetoothDevice(),
+                              );
+                        },
+                        bleConnectPort: ref.read(ff1ControlProvider),
+                        blDevice: device.toBluetoothDevice(),
+                        actionName: 'Factory Reset',
+                      );
 
                       if (context.mounted) {
                         Navigator.pop(context, success);
                       }
-                    } on Exception catch (e) {
+                    } on Object catch (e) {
                       _log.warning('[Factory Reset] Failed: $e');
                       if (context.mounted) {
                         Navigator.pop(context, e);

--- a/test/unit/app/providers/ff1_wifi_ble_fallback_test.dart
+++ b/test/unit/app/providers/ff1_wifi_ble_fallback_test.dart
@@ -1,0 +1,97 @@
+import 'package:app/app/ff1/ff1_ble_device_connect.dart';
+import 'package:app/app/providers/ff1_wifi_ble_fallback.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('runWifiThenBleFallback', () {
+    test('short-circuits BLE when WiFi succeeds', () async {
+      final port = _RecordingPort();
+      var bleCalled = false;
+
+      final success = await runWifiThenBleFallback(
+        wifiAttempt: () async => true,
+        bleAttempt: () async {
+          bleCalled = true;
+        },
+        bleConnectPort: port,
+        blDevice: BluetoothDevice.fromId('00:11'),
+        actionName: 'TestAction',
+      );
+
+      expect(success, isTrue);
+      expect(port.connectCalls, 0);
+      expect(bleCalled, isFalse);
+    });
+
+    test('connects before BLE command when WiFi fails', () async {
+      final port = _RecordingPort();
+      final callOrder = <String>[];
+
+      final success = await runWifiThenBleFallback(
+        wifiAttempt: () async => false,
+        bleAttempt: () async {
+          callOrder.add('ble');
+        },
+        bleConnectPort: port,
+        blDevice: BluetoothDevice.fromId('00:11'),
+        actionName: 'TestAction',
+      );
+
+      expect(success, isTrue);
+      expect(port.connectCalls, 1);
+      expect(callOrder, ['ble']);
+    });
+
+    test('connect failure stops BLE command dispatch', () async {
+      final port = _FailsWithErrorPort();
+      var bleCalled = false;
+
+      final future = runWifiThenBleFallback(
+        wifiAttempt: () async => false,
+        bleAttempt: () async {
+          bleCalled = true;
+        },
+        bleConnectPort: port,
+        blDevice: BluetoothDevice.fromId('00:11'),
+        actionName: 'TestAction',
+      );
+
+      await expectLater(
+        future,
+        throwsA(isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'connect failed',
+        )),
+      );
+      expect(bleCalled, isFalse);
+    });
+  });
+}
+
+class _RecordingPort implements Ff1BleConnectPort {
+  int connectCalls = 0;
+
+  @override
+  Future<void> connect({
+    required BluetoothDevice blDevice,
+    Duration timeout = const Duration(seconds: 30),
+    int maxRetries = 3,
+    bool Function()? shouldContinue,
+  }) async {
+    connectCalls++;
+  }
+}
+
+class _FailsWithErrorPort implements Ff1BleConnectPort {
+  @override
+  Future<void> connect({
+    required BluetoothDevice blDevice,
+    Duration timeout = const Duration(seconds: 30),
+    int maxRetries = 3,
+    bool Function()? shouldContinue,
+  }) async {
+    throw StateError('connect failed');
+  }
+}

--- a/test/unit/app/providers/send_log_provider_test.dart
+++ b/test/unit/app/providers/send_log_provider_test.dart
@@ -68,8 +68,8 @@ void main() {
       test(
         'passes key to WiFi when topicId is available and WiFi succeeds',
         () async {
-          // Regression: the support API key must reach the WiFi transport so the
-          // device can authenticate with the backend.
+          // Regression: the support API key must reach the WiFi transport so
+          // the device can authenticate with the backend.
           const testKey = 'test-support-key-123';
           final wifiSpy = _SpyWifiControl(
             response: FF1CommandResponse(status: 'ok'),
@@ -120,6 +120,7 @@ void main() {
         // BLE fallback must carry the same key so auth is consistent.
         expect(bleTransport.sendLogCalled, isTrue);
         expect(bleTransport.capturedApiKey, testKey);
+        expect(bleTransport.callOrder, ['connect', 'sendCommand']);
       });
 
       test('falls back to BLE when WiFi returns non-ok status', () async {
@@ -145,6 +146,7 @@ void main() {
         expect(outcome, isA<SendLogSuccess>());
         expect(bleTransport.sendLogCalled, isTrue);
         expect(bleTransport.capturedApiKey, testKey);
+        expect(bleTransport.callOrder, ['connect', 'sendCommand']);
       });
 
       test('goes directly to BLE when device has no topicId', () async {
@@ -192,8 +194,60 @@ void main() {
             .read(sendLogProvider.notifier)
             .send(wifiDevice);
 
-        expect(outcome, isA<SendLogFailure>());
+        expect(
+          outcome,
+          isA<SendLogFailure>().having(
+            (result) => result.error,
+            'error',
+            isA<Exception>().having(
+              (error) => error.toString(),
+              'toString()',
+              contains('BLE sendLog error'),
+            ),
+          ),
+        );
       });
+
+      test(
+        'returns SendLogFailure when BLE connect throws a StateError',
+        () async {
+          const testKey = 'test-support-key-connect-error';
+          final wifiSpy = _SpyWifiControl(
+            sendLogError: Exception('wifi error'),
+          );
+          final bleTransport = _SpyBleTransport(
+            throwStateErrorOnConnect: true,
+          );
+
+          final container = ProviderContainer.test(
+            overrides: [
+              supportApiKeyProvider.overrideWithValue(testKey),
+              ff1WifiControlProvider.overrideWithValue(wifiSpy),
+              ff1TransportProvider.overrideWithValue(bleTransport),
+            ],
+          );
+          addTearDown(container.dispose);
+
+          final outcome = await container
+              .read(sendLogProvider.notifier)
+              .send(wifiDevice);
+
+          expect(
+            outcome,
+            isA<SendLogFailure>().having(
+              (result) => result.error,
+              'error',
+              isA<StateError>().having(
+                (error) => error.message,
+                'message',
+                'BLE connect failed',
+              ),
+            ),
+          );
+          // Guard rail: when connect fails, command dispatch must not happen.
+          expect(bleTransport.sendLogCalled, isFalse);
+        },
+      );
     });
   });
 }
@@ -231,13 +285,19 @@ class _SpyWifiControl extends FakeWifiControl {
 // BLE transport spy
 // ============================================================================
 
-/// Minimal [FF1BleTransport] implementation that records [sendLog] calls
-/// (via [sendCommand]) and allows simulating failures.
+/// Minimal FF1 BLE transport spy that records send-log calls and allows
+/// simulating failures.
 class _SpyBleTransport implements FF1BleTransport {
-  _SpyBleTransport({this.throwOnSendLog = false});
+  _SpyBleTransport({
+    this.throwOnSendLog = false,
+    this.throwStateErrorOnConnect = false,
+  });
 
   final bool throwOnSendLog;
+  final bool throwStateErrorOnConnect;
 
+  final List<String> callOrder = <String>[];
+  bool connectCalled = false;
   bool sendLogCalled = false;
   String? capturedApiKey;
 
@@ -258,6 +318,10 @@ class _SpyBleTransport implements FF1BleTransport {
     required FF1BleRequest request,
     Duration timeout = const Duration(seconds: 10),
   }) async {
+    callOrder.add('sendCommand');
+    if (!connectCalled) {
+      throw StateError('BLE command sent before connect');
+    }
     if (command == FF1BleCommand.sendLog) {
       sendLogCalled = true;
       if (request is SendLogRequest) {
@@ -289,7 +353,13 @@ class _SpyBleTransport implements FF1BleTransport {
     Duration timeout = const Duration(seconds: 30),
     int maxRetries = 3,
     bool Function()? shouldContinue,
-  }) async {}
+  }) async {
+    callOrder.add('connect');
+    if (throwStateErrorOnConnect) {
+      throw StateError('BLE connect failed');
+    }
+    connectCalled = true;
+  }
 
   @override
   Future<void> disconnect(BluetoothDevice device) async {}


### PR DESCRIPTION
## Summary

Ensures Wi‑Fi→BLE fallback paths establish BLE (connect + characteristic readiness) before calling `FF1BleTransport.sendCommand`, so fallback works when the relayer path fails.

Fixes https://github.com/feral-file/ff-app/issues/369

## Changes

- `ff1_wifi_ble_fallback`: shared helper to run BLE commands after connection/readiness.
- `send_log_provider` / `options_button`: use the helper for send-log and factory-reset fallback paths.
- Unit tests for fallback behavior and related providers.

## Testing

- Unit tests updated/added for affected providers.

Made with [Cursor](https://cursor.com)