### PR TITLE
fix(ci): monotonic Play versionCode when versionName is new

### DIFF
--- a/scripts/fetch_latest_play_build.sh
+++ b/scripts/fetch_latest_play_build.sh
@@ -6,6 +6,10 @@ usage() {
 Usage:
   scripts/fetch_latest_play_build.sh <service-account-json> <package-name> [version]
 
+Optional [version] is the Play versionName being built. versionCode must increase on every
+upload; if that versionName is not on the internal track yet, the script falls back to the
+highest versionCode already on internal (same as when [version] is omitted).
+
 Example:
   scripts/fetch_latest_play_build.sh ~/Downloads/service-account.json com.feralfile.app
   scripts/fetch_latest_play_build.sh ~/Downloads/service-account.json com.feralfile.app 1.0.8
@@ -111,53 +115,13 @@ TRACKS_RESPONSE="$(curl -sS "$BASE_URL/edits/$EDIT_ID/tracks" \
 # best-effort cleanup of edit; ignore failure
 curl -sS -X DELETE "$BASE_URL/edits/$EDIT_ID" -H "Authorization: Bearer $ACCESS_TOKEN" >/dev/null 2>&1 || true
 
-printf '%s' "$TRACKS_RESPONSE" | jq -r --arg targetVersion "$TARGET_VERSION" '
-  def to_release_entries($track):
-    [
-      (($track.releases // [])[]? | {
-        version: (.name // ""),
-        status: (.status // ""),
-        track: ($track.track // ""),
-        codes: [(.versionCodes // [])[]? | tonumber?] | map(select(. != null))
-      })
-      | .max_code = (if (.codes | length) == 0 then null else (.codes | max) end)
-    ];
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QUERY_FILE="$SCRIPT_DIR/fetch_latest_play_build_query.jq"
+if [[ ! -f "$QUERY_FILE" ]]; then
+  echo "Error: missing jq query file: $QUERY_FILE" >&2
+  exit 1
+fi
 
-  def to_code_entries($releases):
-    [
-      $releases[] as $r
-      | $r.codes[]? as $c
-      | {
-          code: $c,
-          track: $r.track,
-          version: $r.version,
-          status: $r.status
-        }
-    ];
-
-  (
-    (.tracks // []) | map(select(.track == "internal")) | .[0]
-  ) as $internal_track
-  | if $internal_track == null then
-      "latest_version=0\nlatest_build_number=0\nlatest_version_code=0\nlatest_track=internal\nlatest_release_status="
-    else
-      (to_release_entries($internal_track)) as $releases
-      | if ($targetVersion | length) > 0 then
-          (to_code_entries($releases | map(select(.version == $targetVersion)))) as $entries
-          | if ($entries | length) == 0 then
-              "latest_version=\($targetVersion)\nlatest_build_number=0\nlatest_version_code=0\nlatest_track=internal\nlatest_release_status="
-            else
-              ($entries | max_by(.code)) as $latest
-              | "latest_version=\($targetVersion)\nlatest_build_number=\($latest.code)\nlatest_version_code=\($latest.code)\nlatest_track=\($latest.track)\nlatest_release_status=\($latest.status)"
-            end
-        else
-          ($releases | map(select(.max_code != null))) as $with_codes
-          | if ($with_codes | length) == 0 then
-              "latest_version=0\nlatest_build_number=0\nlatest_version_code=0\nlatest_track=internal\nlatest_release_status="
-            else
-              ($with_codes | max_by(.max_code)) as $latest_release
-              | "latest_version=\(if ($latest_release.version | length) > 0 then $latest_release.version else "0" end)\nlatest_build_number=\($latest_release.max_code)\nlatest_version_code=\($latest_release.max_code)\nlatest_track=\($latest_release.track)\nlatest_release_status=\($latest_release.status)"
-            end
-        end
-    end
-'
+# latest_build_number is the max versionCode on internal for the requested versionName when it
+# exists; otherwise the global max on internal so CI can use (max + 1) monotonically.
+printf '%s' "$TRACKS_RESPONSE" | jq -r --arg targetVersion "$TARGET_VERSION" -f "$QUERY_FILE"

--- a/scripts/fetch_latest_play_build_query.jq
+++ b/scripts/fetch_latest_play_build_query.jq
@@ -1,0 +1,54 @@
+def to_release_entries($track):
+  [
+    (($track.releases // [])[]? | {
+      version: (.name // ""),
+      status: (.status // ""),
+      track: ($track.track // ""),
+      codes: [(.versionCodes // [])[]? | tonumber?] | map(select(. != null))
+    })
+    | .max_code = (if (.codes | length) == 0 then null else (.codes | max) end)
+  ];
+
+def to_code_entries($releases):
+  [
+    $releases[] as $r
+    | $r.codes[]? as $c
+    | {
+        code: $c,
+        track: $r.track,
+        version: $r.version,
+        status: $r.status
+      }
+  ];
+
+(
+  (.tracks // []) | map(select(.track == "internal")) | .[0]
+) as $internal_track
+| if $internal_track == null then
+    "latest_version=0\nlatest_build_number=0\nlatest_version_code=0\nlatest_track=internal\nlatest_release_status="
+  else
+    (to_release_entries($internal_track)) as $releases
+    | if ($targetVersion | length) > 0 then
+        (to_code_entries($releases | map(select(.version == $targetVersion)))) as $entries
+        | if ($entries | length) > 0 then
+            ($entries | max_by(.code)) as $latest
+            | "latest_version=\($targetVersion)\nlatest_build_number=\($latest.code)\nlatest_version_code=\($latest.code)\nlatest_track=\($latest.track)\nlatest_release_status=\($latest.status)"
+          else
+            ($releases | map(select(.max_code != null))) as $with_codes
+            | if ($with_codes | length) == 0 then
+                "latest_version=\($targetVersion)\nlatest_build_number=0\nlatest_version_code=0\nlatest_track=internal\nlatest_release_status="
+              else
+                ($with_codes | max_by(.max_code)) as $latest_release
+                | "latest_version=\($targetVersion)\nlatest_build_number=\($latest_release.max_code)\nlatest_version_code=\($latest_release.max_code)\nlatest_track=\($latest_release.track)\nlatest_release_status=\($latest_release.status)"
+              end
+          end
+      else
+        ($releases | map(select(.max_code != null))) as $with_codes
+        | if ($with_codes | length) == 0 then
+            "latest_version=0\nlatest_build_number=0\nlatest_version_code=0\nlatest_track=internal\nlatest_release_status="
+          else
+            ($with_codes | max_by(.max_code)) as $latest_release
+            | "latest_version=\(if ($latest_release.version | length) > 0 then $latest_release.version else "0" end)\nlatest_build_number=\($latest_release.max_code)\nlatest_version_code=\($latest_release.max_code)\nlatest_track=\($latest_release.track)\nlatest_release_status=\($latest_release.status)"
+          end
+      end
+  end

--- a/scripts/test_fetch_latest_play_build_query.sh
+++ b/scripts/test_fetch_latest_play_build_query.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Unit tests for fetch_latest_play_build_query.jq (no Play API calls).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JQ="$ROOT/fetch_latest_play_build_query.jq"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required" >&2
+  exit 1
+fi
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "FAIL: $msg" >&2
+    echo "Expected substring: $needle" >&2
+    echo "Got: $haystack" >&2
+    exit 1
+  fi
+}
+
+# Internal track only; prior release 1.1.0 with versionCode 7 (API may return strings).
+SAMPLE='{"tracks":[{"track":"internal","releases":[{"name":"1.1.0","status":"completed","versionCodes":["7"]}]}]}'
+
+out=$(printf '%s' "$SAMPLE" | jq -r --arg targetVersion '1.1.1' -f "$JQ")
+assert_contains "$out" "latest_version=1.1.1" "new versionName: output version is requested name"
+assert_contains "$out" "latest_build_number=7" "new versionName: fallback to global max versionCode on internal"
+
+out=$(printf '%s' "$SAMPLE" | jq -r --arg targetVersion '1.1.0' -f "$JQ")
+assert_contains "$out" "latest_build_number=7" "existing versionName: max code for that release"
+
+out=$(printf '%s' "$SAMPLE" | jq -r --arg targetVersion '' -f "$JQ")
+assert_contains "$out" "latest_version=1.1.0" "empty targetVersion: latest_version from max-code release"
+assert_contains "$out" "latest_build_number=7" "empty targetVersion: global max"
+
+echo "ok fetch_latest_play_build_query"


### PR DESCRIPTION
## Summary
Updates `scripts/fetch_latest_play_build.sh` so Android **versionCode** stays monotonic when bumping **versionName** (e.g. after `1.1.0 (7)`, new `1.1.1` uses `8`, not `1`).

When the requested version name is not on the **internal** track yet, the script now falls back to the **global max versionCode** on internal (same as omitting the version argument).

## Changes
- Extract jq to `scripts/fetch_latest_play_build_query.jq`
- Add `scripts/test_fetch_latest_play_build_query.sh` (no Play API)

## Verification
- `bash scripts/test_fetch_latest_play_build_query.sh`

Made with [Cursor](https://cursor.com)