### PR TITLE
feat(ff1): refresh artwork on FF1 from work detail

### DIFF
--- a/docs/app_flows.md
+++ b/docs/app_flows.md
@@ -177,6 +177,7 @@
   - collapsed now-playing row: shuffle and repeat are shown only when the live `player_status` includes the corresponding capability—shuffle when the `shuffle` key is present, repeat when `loopMode` parses to a known value (`none`, `playlist`, `one`); the two gates are independent so a future unknown `loopMode` string does not drop the whole status parse and does not suppress shuffle
   - when the playing list has only one work (length from `player_status.items` when present, else the visible now-displaying item window), shuffle and repeat controls are not shown
   - optional: user opens Interact screen for keyboard/touchpad control
+  - from Work Detail, when the open work matches current FF1 playback, the overflow menu can send the relayer `refreshArtwork` command so the device reloads the current display URL (same visibility rule as the back-layer playing controls)
 - success state: active playback visible and controllable from app
 - failure/edge states:
   - no paired device -> bar hidden (invisible, no guidance shown)
@@ -239,8 +240,8 @@
 
 - role in the flow: work-level media preview and metadata/provenance view
 - route / entry point: `/works/:workId`
-- important actions: cast single work, open external market links, rebuild work metadata
-- dependencies: `workDetailStateProvider`, indexer/DB enrichment, canvas client
+- important actions: cast single work, open external market links, rebuild work metadata; refresh the work on FF1 via overflow (`refreshArtwork` over the relayer) when this work is currently playing on the device
+- dependencies: `workDetailStateProvider`, indexer/DB enrichment, canvas client, `nowDisplayingProvider`, `FF1WifiControl`
 - notes / caveats: token enrichment is optional; UI supports item-only fallback
 
 ## Screen: FF1DeviceScanPage

--- a/docs/project_spec.md
+++ b/docs/project_spec.md
@@ -226,9 +226,9 @@
 
 - Purpose: detailed work view with back-layer media preview and metadata/provenance sections.
 - Entry points: `/works/:workId` from tabs/search/details.
-- Key actions: play on FF1, open external links, rebuild metadata for work, expand info panel.
+- Key actions: play on FF1, open external links, rebuild metadata for work, expand info panel; when this work is the one currently playing on FF1 (same condition as back-layer controls vs preview), the artwork overflow menu can send the relayer `refreshArtwork` command so FF1 reloads the displayed work (mitigates stale Chromium cache after metadata or asset updates).
 - Important data: playlist item core data plus optional indexer token enrichment.
-- Related modules: `workDetailStateProvider`, `IndexerService`, DB converters, FF display button.
+- Related modules: `workDetailStateProvider`, `IndexerService`, DB converters, FF display button, `FF1WifiControl.refreshArtwork`.
 
 ### Screen group: Onboarding (Introduce, OnboardingAddAddress, OnboardingSetupFf1)
 

--- a/lib/app/now_displaying/dp1_now_displaying_if_playing_this_work.dart
+++ b/lib/app/now_displaying/dp1_now_displaying_if_playing_this_work.dart
@@ -1,0 +1,18 @@
+import 'package:app/app/providers/now_displaying_provider.dart';
+import 'package:app/domain/models/now_displaying_object.dart';
+
+/// When FF1 is playing [workId] (not sleeping), returns the active
+/// [DP1NowDisplayingObject]. Otherwise null.
+///
+/// Same rules as the work-detail back layer (thumbnail + controls vs preview).
+DP1NowDisplayingObject? dp1NowDisplayingIfPlayingThisWork({
+  required NowDisplayingStatus nowDisplaying,
+  required String workId,
+}) {
+  if (nowDisplaying is! NowDisplayingSuccess) return null;
+  final obj = nowDisplaying.object;
+  if (obj is! DP1NowDisplayingObject) return null;
+  if (obj.isSleeping) return null;
+  if (obj.currentItem.id != workId) return null;
+  return obj;
+}

--- a/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
+++ b/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
@@ -1039,6 +1039,34 @@ transport reconnected — waiting for device connection notification''',
     }
   }
 
+  /// Ask FF1 to reload the currently displayed work from the same URL
+  /// (best-effort; no URL rewrite or cache-busting on the app side).
+  ///
+  /// [topicId] — device identifier on the relayer
+  Future<FF1CommandResponse> refreshArtwork({required String topicId}) async {
+    if (_restClient == null) {
+      throw StateError('REST client not available');
+    }
+
+    try {
+      _log.info('Sending refreshArtwork command to device');
+
+      const request = FF1WifiRefreshArtworkRequest();
+      final response =
+          await _restClient.sendCommand(
+                topicId: topicId,
+                command: request.command,
+                params: request.params,
+              )
+              as Map<String, dynamic>;
+
+      return FF1CommandResponse.fromJson(response);
+    } catch (e) {
+      _log.severe('Failed to send refreshArtwork command: $e');
+      rethrow;
+    }
+  }
+
   /// Move to artwork at [index] in the playlist (jump to item).
   ///
   /// [topicId] — device identifier on the relayer

--- a/lib/infra/ff1/wifi_protocol/ff1_wifi_messages.dart
+++ b/lib/infra/ff1/wifi_protocol/ff1_wifi_messages.dart
@@ -497,6 +497,19 @@ class FF1WifiPreviousArtworkRequest extends FF1WifiCommandRequest {
   Map<String, dynamic> get params => {};
 }
 
+/// Reload the current work from its URL without changing the URL (relayer
+/// clears browser cache for that fetch; best-effort on FF1).
+class FF1WifiRefreshArtworkRequest extends FF1WifiCommandRequest {
+  /// Creates a refresh-artwork request.
+  const FF1WifiRefreshArtworkRequest();
+
+  @override
+  String get command => 'refreshArtwork';
+
+  @override
+  Map<String, dynamic> get params => {};
+}
+
 /// Move to artwork at index (jump to item in playlist).
 class FF1WifiMoveToArtworkRequest extends FF1WifiCommandRequest {
   /// Creates a move to artwork request.

--- a/lib/ui/screens/work_detail_back_layer.dart
+++ b/lib/ui/screens/work_detail_back_layer.dart
@@ -6,13 +6,13 @@
 
 import 'dart:math';
 
+import 'package:app/app/now_displaying/dp1_now_displaying_if_playing_this_work.dart';
 import 'package:app/app/providers/me_section_playlists_provider.dart';
 import 'package:app/app/providers/now_displaying_provider.dart';
 import 'package:app/app/routing/navigation_extensions.dart';
 import 'package:app/app/routing/routes.dart';
 import 'package:app/design/layout_constants.dart';
 import 'package:app/domain/extensions/playlist_item_ext.dart';
-import 'package:app/domain/models/now_displaying_object.dart';
 import 'package:app/domain/models/playlist.dart';
 import 'package:app/domain/models/playlist_item.dart';
 import 'package:app/domain/utils/work_detail_favorite_playlist_row.dart';
@@ -63,17 +63,10 @@ class WorkDetailBackLayer extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final nowDisplaying = ref.watch(nowDisplayingProvider);
 
-    // Determine if this specific work is currently playing on FF1.
-    DP1NowDisplayingObject? playingObject;
-    if (nowDisplaying is NowDisplayingSuccess) {
-      final obj = nowDisplaying.object;
-      if (obj is DP1NowDisplayingObject &&
-          !obj.isSleeping &&
-          obj.currentItem.id == item.id) {
-        playingObject = obj;
-      }
-    }
-
+    final playingObject = dp1NowDisplayingIfPlayingThisWork(
+      nowDisplaying: nowDisplaying,
+      workId: item.id,
+    );
     final isPlayingOnFF1 = playingObject != null;
 
     final isWorkFavoriteAsync = ref.watch(

--- a/lib/ui/screens/work_detail_screen.dart
+++ b/lib/ui/screens/work_detail_screen.dart
@@ -455,6 +455,7 @@ class _WorkDetailScreenState extends ConsumerState<WorkDetailScreen>
                   },
                 ),
                 IconButton(
+                  key: const ValueKey('work_detail_overflow_menu'),
                   padding: EdgeInsets.zero,
                   onPressed: () => _showArtworkOptionsDialog(
                     context,
@@ -490,6 +491,16 @@ class _WorkDetailScreenState extends ConsumerState<WorkDetailScreen>
   ) async {
     if (!context.mounted) return;
     _focusNode.unfocus();
+
+    // Same closure pattern as Rebuild metadata: values used in onTap are taken
+    // from the snapshot available when the menu is built (rebuild closes over
+    // `item`; here we close over topicId from the same now-displaying read).
+    final refreshFf1Playing = dp1NowDisplayingIfPlayingThisWork(
+      nowDisplaying: ref.read(nowDisplayingProvider),
+      workId: item.id,
+    );
+    final refreshFf1TopicId =
+        refreshFf1Playing?.connectedDevice.topicId ?? '';
 
     // Match old artwork_detail_page: same order, same icon sizes (pixel-exact).
     final options = <OptionItem>[
@@ -633,11 +644,7 @@ class _WorkDetailScreenState extends ConsumerState<WorkDetailScreen>
           }
         },
       ),
-      if (dp1NowDisplayingIfPlayingThisWork(
-            nowDisplaying: ref.read(nowDisplayingProvider),
-            workId: item.id,
-          ) !=
-          null)
+      if (refreshFf1Playing != null && refreshFf1TopicId.isNotEmpty)
         OptionItem(
           title: 'Refresh artwork on FF1',
           icon: SvgPicture.asset(
@@ -647,16 +654,10 @@ class _WorkDetailScreenState extends ConsumerState<WorkDetailScreen>
           ),
           onTap: () async {
             Navigator.of(context).pop();
-            final playing = dp1NowDisplayingIfPlayingThisWork(
-              nowDisplaying: ref.read(nowDisplayingProvider),
-              workId: item.id,
-            );
-            final topicId = playing?.connectedDevice.topicId ?? '';
-            if (topicId.isEmpty) return;
             try {
               await ref
                   .read(ff1WifiControlProvider)
-                  .refreshArtwork(topicId: topicId);
+                  .refreshArtwork(topicId: refreshFf1TopicId);
             } catch (e) {
               if (context.mounted) {
                 await UIHelper.showInfoDialog(

--- a/lib/ui/screens/work_detail_screen.dart
+++ b/lib/ui/screens/work_detail_screen.dart
@@ -3,8 +3,11 @@
 import 'dart:async';
 
 import 'package:after_layout/after_layout.dart';
+import 'package:app/app/now_displaying/dp1_now_displaying_if_playing_this_work.dart';
 import 'package:app/app/providers/app_overlay_provider.dart';
+import 'package:app/app/providers/ff1_wifi_providers.dart';
 import 'package:app/app/providers/me_section_playlists_provider.dart';
+import 'package:app/app/providers/now_displaying_provider.dart';
 import 'package:app/app/providers/now_displaying_visibility_provider.dart';
 import 'package:app/app/providers/services_provider.dart';
 import 'package:app/app/providers/works_provider.dart';
@@ -630,6 +633,42 @@ class _WorkDetailScreenState extends ConsumerState<WorkDetailScreen>
           }
         },
       ),
+      if (dp1NowDisplayingIfPlayingThisWork(
+            nowDisplaying: ref.read(nowDisplayingProvider),
+            workId: item.id,
+          ) !=
+          null)
+        OptionItem(
+          title: 'Refresh artwork on FF1',
+          icon: SvgPicture.asset(
+            'assets/images/ff1.svg',
+            width: 20,
+            height: 20,
+          ),
+          onTap: () async {
+            Navigator.of(context).pop();
+            final playing = dp1NowDisplayingIfPlayingThisWork(
+              nowDisplaying: ref.read(nowDisplayingProvider),
+              workId: item.id,
+            );
+            final topicId = playing?.connectedDevice.topicId ?? '';
+            if (topicId.isEmpty) return;
+            try {
+              await ref
+                  .read(ff1WifiControlProvider)
+                  .refreshArtwork(topicId: topicId);
+            } catch (e) {
+              if (context.mounted) {
+                await UIHelper.showInfoDialog(
+                  context,
+                  'Refresh failed',
+                  'Could not send the refresh request. Try again.',
+                  closeButton: 'OK',
+                );
+              }
+            }
+          },
+        ),
     ];
 
     unawaited(UIHelper.showCenterMenu(context, options: options));

--- a/test/integration/infra/services/ff1_device_actions_integration_test.dart
+++ b/test/integration/infra/services/ff1_device_actions_integration_test.dart
@@ -188,6 +188,9 @@ void main() {
 
         final nextResponse = await control.nextArtwork(topicId: topicId);
         expect(ff1CommandResponseHasOkFlag(nextResponse), isTrue);
+
+        final refreshResponse = await control.refreshArtwork(topicId: topicId);
+        expect(ff1CommandResponseHasOkFlag(refreshResponse), isTrue);
       },
       timeout: const Timeout(Duration(minutes: 10)),
     );

--- a/test/unit/app/now_displaying/dp1_now_displaying_if_playing_this_work_test.dart
+++ b/test/unit/app/now_displaying/dp1_now_displaying_if_playing_this_work_test.dart
@@ -1,0 +1,79 @@
+import 'package:app/app/now_displaying/dp1_now_displaying_if_playing_this_work.dart';
+import 'package:app/app/providers/now_displaying_provider.dart';
+import 'package:app/domain/models/ff1_device.dart';
+import 'package:app/domain/models/now_displaying_object.dart';
+import 'package:app/domain/models/playlist_item.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const device = FF1Device(
+    name: 'FF1',
+    remoteId: 'r',
+    deviceId: 'd',
+    topicId: 'topic-1',
+  );
+
+  PlaylistItem item(String id) => PlaylistItem(
+    id: id,
+    kind: PlaylistItemKind.dp1Item,
+    title: 'T',
+  );
+
+  test('null when status is not success', () {
+    expect(
+      dp1NowDisplayingIfPlayingThisWork(
+        nowDisplaying: const InitialNowDisplayingStatus(),
+        workId: 'w1',
+      ),
+      isNull,
+    );
+  });
+
+  test('null when sleeping', () {
+    final status = NowDisplayingSuccess(
+      DP1NowDisplayingObject(
+        connectedDevice: device,
+        index: 0,
+        items: [item('w1')],
+        isSleeping: true,
+      ),
+    );
+    expect(
+      dp1NowDisplayingIfPlayingThisWork(nowDisplaying: status, workId: 'w1'),
+      isNull,
+    );
+  });
+
+  test('null when workId does not match', () {
+    final status = NowDisplayingSuccess(
+      DP1NowDisplayingObject(
+        connectedDevice: device,
+        index: 0,
+        items: [item('w1')],
+        isSleeping: false,
+      ),
+    );
+    expect(
+      dp1NowDisplayingIfPlayingThisWork(nowDisplaying: status, workId: 'w2'),
+      isNull,
+    );
+  });
+
+  test('returns object when this work is playing', () {
+    final status = NowDisplayingSuccess(
+      DP1NowDisplayingObject(
+        connectedDevice: device,
+        index: 1,
+        items: [item('w0'), item('w1')],
+        isSleeping: false,
+      ),
+    );
+    final playing = dp1NowDisplayingIfPlayingThisWork(
+      nowDisplaying: status,
+      workId: 'w1',
+    );
+    expect(playing, isNotNull);
+    expect(playing!.connectedDevice.topicId, 'topic-1');
+    expect(playing.currentItem.id, 'w1');
+  });
+}

--- a/test/unit/infra/ff1/ff1_wifi_control_test.dart
+++ b/test/unit/infra/ff1/ff1_wifi_control_test.dart
@@ -216,6 +216,23 @@ void main() {
     );
   });
 
+  group('FF1WifiControl.refreshArtwork', () {
+    test('sends refreshArtwork via REST client', () async {
+      final restClient = _RecordingRestClient();
+      final control = FF1WifiControl(
+        transport: _FakeWifiTransport(),
+        restClient: restClient,
+      );
+
+      addTearDown(control.dispose);
+
+      await control.refreshArtwork(topicId: 'topic_z');
+
+      expect(restClient.lastTopicId, 'topic_z');
+      expect(restClient.lastCommand, 'refreshArtwork');
+    });
+  });
+
   group('FF1WifiControl.getDeviceRealtimeMetrics', () {
     test(
       'uses default 6 second timeout for realtime metrics request',

--- a/test/unit/infra/ff1/wifi_protocol/ff1_wifi_messages_test.dart
+++ b/test/unit/infra/ff1/wifi_protocol/ff1_wifi_messages_test.dart
@@ -403,4 +403,19 @@ void main() {
       expect(response.data?['message'], isNotNull);
     });
   });
+
+  group('FF1WifiRefreshArtworkRequest', () {
+    test('uses refreshArtwork command with empty params', () {
+      const request = FF1WifiRefreshArtworkRequest();
+      expect(request.command, 'refreshArtwork');
+      expect(request.params, isEmpty);
+      expect(
+        request.toJson(),
+        <String, dynamic>{
+          'command': 'refreshArtwork',
+          'params': <String, dynamic>{},
+        },
+      );
+    });
+  });
 }

--- a/test/unit/ui/screens/work_detail_refresh_ff1_menu_test.dart
+++ b/test/unit/ui/screens/work_detail_refresh_ff1_menu_test.dart
@@ -1,0 +1,194 @@
+import 'package:app/app/providers/ff1_bluetooth_device_providers.dart';
+import 'package:app/app/providers/ff1_wifi_providers.dart';
+import 'package:app/app/providers/now_displaying_provider.dart';
+import 'package:app/app/providers/seed_database_ready_provider.dart';
+import 'package:app/app/providers/works_provider.dart';
+import 'package:app/domain/models/ff1_device.dart';
+import 'package:app/domain/models/now_displaying_object.dart';
+import 'package:app/domain/models/playlist_item.dart';
+import 'package:app/infra/config/app_state_service.dart';
+import 'package:app/infra/ff1/wifi_protocol/ff1_wifi_messages.dart';
+import 'package:app/ui/screens/work_detail_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../app/providers/provider_test_helpers.dart';
+
+const _workId = 'work_refresh_menu_test';
+const _ff1Device = FF1Device(
+  name: 'Test FF1',
+  remoteId: 'remote-1',
+  deviceId: 'device-1',
+  topicId: 'topic-refresh-test',
+);
+
+final _playlistItem = PlaylistItem(
+  id: _workId,
+  kind: PlaylistItemKind.dp1Item,
+  title: 'Refresh menu test work',
+);
+
+NowDisplayingSuccess _nowPlayingThisWork() {
+  return NowDisplayingSuccess(
+    DP1NowDisplayingObject(
+      connectedDevice: _ff1Device,
+      index: 0,
+      items: [_playlistItem],
+      isSleeping: false,
+    ),
+  );
+}
+
+NowDisplayingSuccess _nowPlayingOtherWork() {
+  return NowDisplayingSuccess(
+    DP1NowDisplayingObject(
+      connectedDevice: _ff1Device,
+      index: 0,
+      items: [
+        PlaylistItem(
+          id: 'other_work_id',
+          kind: PlaylistItemKind.dp1Item,
+          title: 'Other',
+        ),
+      ],
+      isSleeping: false,
+    ),
+  );
+}
+
+class _SeedNotReadyNotifier extends SeedDatabaseReadyNotifier {
+  @override
+  bool build() => false;
+}
+
+class _StaticWorkDetailNotifier extends WorkDetailNotifier {
+  // ignore: matching_super_parameters
+  _StaticWorkDetailNotifier(super.itemId, this._state);
+
+  final AsyncValue<WorkDetailData?> _state;
+
+  @override
+  AsyncValue<WorkDetailData?> build() => _state;
+}
+
+class _StaticNowDisplayingNotifier extends NowDisplayingNotifier {
+  _StaticNowDisplayingNotifier(this._status);
+
+  final NowDisplayingStatus _status;
+
+  @override
+  NowDisplayingStatus build() => _status;
+}
+
+class _RefreshCapturingWifiControl extends FakeWifiControl {
+  String? lastRefreshTopicId;
+
+  @override
+  Future<FF1CommandResponse> refreshArtwork({required String topicId}) async {
+    lastRefreshTopicId = topicId;
+    return FF1CommandResponse(status: 'ok');
+  }
+}
+
+/// Minimal fake so [FFDisplayButton] tooltip logic does not touch ObjectBox.
+class _WorkDetailTestAppState implements AppStateService {
+  @override
+  Future<bool> hasSeenPlayToFf1Tooltip() async => true;
+
+  @override
+  Future<void> setHasSeenPlayToFf1Tooltip({required bool hasSeen}) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('Work detail overflow — Refresh artwork on FF1', () {
+    testWidgets(
+      'shows the action when this work is playing on FF1 and sends refreshArtwork',
+      (tester) async {
+        final wifi = _RefreshCapturingWifiControl();
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              appStateServiceProvider.overrideWithValue(_WorkDetailTestAppState()),
+              activeFF1BluetoothDeviceProvider.overrideWith(
+                (ref) => Stream<FF1Device?>.value(null),
+              ),
+              isSeedDatabaseReadyProvider.overrideWith(_SeedNotReadyNotifier.new),
+              workDetailStateProvider(_workId).overrideWith(
+                () => _StaticWorkDetailNotifier(
+                  _workId,
+                  AsyncValue.data(WorkDetailData(item: _playlistItem)),
+                ),
+              ),
+              nowDisplayingProvider.overrideWith(
+                () => _StaticNowDisplayingNotifier(_nowPlayingThisWork()),
+              ),
+              ff1WifiControlProvider.overrideWithValue(wifi),
+              ownerAddressesProvider.overrideWith((ref) async => []),
+            ],
+            child: const MaterialApp(
+              home: WorkDetailScreen(workId: _workId),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const ValueKey('work_detail_overflow_menu')));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Refresh artwork on FF1'), findsOneWidget);
+
+        await tester.tap(find.text('Refresh artwork on FF1'));
+        await tester.pumpAndSettle();
+
+        expect(wifi.lastRefreshTopicId, _ff1Device.topicId);
+      },
+    );
+
+    testWidgets(
+      'hides the action when another work is playing on FF1',
+      (tester) async {
+        final wifi = _RefreshCapturingWifiControl();
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              appStateServiceProvider.overrideWithValue(_WorkDetailTestAppState()),
+              activeFF1BluetoothDeviceProvider.overrideWith(
+                (ref) => Stream<FF1Device?>.value(null),
+              ),
+              isSeedDatabaseReadyProvider.overrideWith(_SeedNotReadyNotifier.new),
+              workDetailStateProvider(_workId).overrideWith(
+                () => _StaticWorkDetailNotifier(
+                  _workId,
+                  AsyncValue.data(WorkDetailData(item: _playlistItem)),
+                ),
+              ),
+              nowDisplayingProvider.overrideWith(
+                () => _StaticNowDisplayingNotifier(_nowPlayingOtherWork()),
+              ),
+              ff1WifiControlProvider.overrideWithValue(wifi),
+              ownerAddressesProvider.overrideWith((ref) async => []),
+            ],
+            child: const MaterialApp(
+              home: WorkDetailScreen(workId: _workId),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const ValueKey('work_detail_overflow_menu')));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Refresh artwork on FF1'), findsNothing);
+        expect(wifi.lastRefreshTopicId, isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Send relayer command `refreshArtwork` (same REST shape as other WiFi commands).
- **Work detail** overflow menu: **Refresh artwork on FF1** after **Rebuild metadata**, only when this work is currently playing on FF1 (same condition as preview vs controls on the back layer).
- Extract `dp1NowDisplayingIfPlayingThisWork` for shared playback matching.

## Linked tracking
- Issue: [feral-file/ffos-user#148](https://github.com/feral-file/ffos-user/issues/148)
- Project card: [Known Issues board](https://github.com/orgs/feral-file/projects/2/views/1?pane=issue&itemId=172776889&issue=feral-file%7Cffos-user%7C148)

## Tests
- Unit: `FF1WifiRefreshArtworkRequest`, `FF1WifiControl.refreshArtwork`, `dp1NowDisplayingIfPlayingThisWork`
- Integration: device actions flow calls `refreshArtwork` after `nextArtwork` (requires device support)


Made with [Cursor](https://cursor.com)