### PR TITLE
feat(touchpad): FF1 Wi‑Fi touchpad gestures (tap, drag, click-and-drag, zoom)

### DIFF
--- a/docs/app_flows.md
+++ b/docs/app_flows.md
@@ -179,7 +179,8 @@
   - user taps bar to navigate to current work detail (or already there)
   - collapsed now-playing row: shuffle and repeat are shown only when the live `player_status` includes the corresponding capability—shuffle when the `shuffle` key is present, repeat when `loopMode` parses to a known value (`none`, `playlist`, `one`); the two gates are independent so a future unknown `loopMode` string does not drop the whole status parse and does not suppress shuffle
   - when the playing list has only one work (length from `player_status.items` when present, else the visible now-displaying item window), shuffle and repeat controls are not shown
-  - optional: user opens Interact screen for keyboard/touchpad control
+  - optional: user opens Interact screen for keyboard input and touchpad
+    gesture control
 - success state: active playback visible and controllable from app
 - failure/edge states:
   - no paired device -> bar hidden (invisible, no guidance shown)
@@ -309,11 +310,15 @@
 
 ## Screen: KeyboardControlScreen
 
-- role in the flow: send keyboard/touchpad events to currently connected FF1
+- role in the flow: send keyboard input and touchpad gesture events to the
+  currently connected FF1
 - route / entry point: `/keyboard-control`
-- important actions: type keys, use touchpad
+- important actions: type keys, use touchpad gestures
 - dependencies: now-displaying success state, `ff1WifiControlProvider`
-- notes / caveats: exits when keyboard closes and screen is not expanded
+- notes / caveats: exits when keyboard closes and screen is not expanded; the
+  touchpad forwards single tap, double tap, long press, move-only drag,
+  click-and-drag, and pinch zoom gestures through `TouchPad` /
+  `FfMouseGestureDetector`, batching deltas before they are sent to FF1
 
 ## Screen: SettingsPage
 

--- a/docs/mouse_events_spec.md
+++ b/docs/mouse_events_spec.md
@@ -6,18 +6,41 @@ Each call uses HTTP body `{ "command": "<name>", "request": { ... } }` (`FF1Wifi
 
 **Pointer position:** Do **not** send absolute coordinates (`x`, `y`) in these commands. The **player** applies pointer gestures at the **current synthetic mouse position** (it maintains cursor state). `dragGesture` updates that position with `dx` / `dy`; discrete pointer commands use the cursor as-is.
 
-**`dragGesture` vs click-and-drag (player semantics):**
+---
 
-| Client pattern | Player meaning |
-| -------------- | -------------- |
-| Only `dragGesture` (pan / move without a prior `doubleTapGesture` in this interaction) | **Mouse move only** — update cursor with `dx` / `dy`; primary button **not** pressed. |
-| `doubleTapGesture` then `dragGesture` while the user performs a press-and-drag | **Primary-button drag** (“kéo thả”) — movement with the button **held** (click-and-drag). |
+## 1. Client recognition (`FfMouseGestureDetector`)
 
-The client sends `doubleTapGesture` to **arm** drag mode; the **following** `dragGesture` stream for that touch (until release) is interpreted as dragging. A new touch that only pans should send **only** `dragGesture` so the player keeps move-only behavior.
+The mobile touchpad uses Flutter’s **`TapAndPanGestureRecognizer`** (touch only). It exposes:
+
+| Callback        | When it runs |
+| --------------- | ------------ |
+| `onTap`         | **Single tap** — first tap in a series; `onTap` is deferred until Flutter’s `kDoubleTapTimeout` so a second tap in time can become a double-tap instead of two singles. |
+| `onDoubleTap`   | **Double-click (discrete)** — user completes **two tap-ups in place** in the double-tap window (second `TapDragUp` has `consecutiveTapCount == 2`). The user **lifts the finger** after the second tap; no drag. |
+| `onMove`        | **Move-only pan** — a drag where **`onDragStart` has `consecutiveTapCount == 1`**: one finger down, then movement past pan slop (like moving the cursor without a prior “second tap hold”). |
+| `onClickAndDrag` | **Double-tap-hold then drag (click-and-drag)** — a drag where **`onDragStart` has `consecutiveTapCount == 2`**: user has already done a first tap, **second contact** is part of the same consecutive-tap series, and the user **holds and drags** (does not release for a second quick tap). Same pattern as *double-tap to drag* on many laptop trackpads. |
+| `onLongPress`   | **`LongPressGestureRecognizer`** won the arena; drag/tap for that contact is cancelled. |
+
+**Important:** `onDoubleTap` and `onClickAndDrag` are **mutually exclusive** for the same second tap: if the user drags, the second tap does **not** complete as a double-tap *up* → `onDoubleTap` is not called; the gesture is classified as `onClickAndDrag` after drag starts.
 
 ---
 
-## 1. `MouseButton`
+## 2. FF1 / relayer mapping (example: `TouchPad`)
+
+Discrete clicks map 1:1 to gesture commands. Drags are batched with `dx` / `dy` in `cursorOffsets` (2 decimal places in wire form).
+
+| UI callback / path | Relayer pattern |
+| ------------------ | --------------- |
+| `onTap` | `tapGesture` |
+| `onDoubleTap` | `doubleTapGesture` (double-click only) |
+| `onLongPress` | `longPressGesture` |
+| `onMove` | Batched `dragGesture` with `cursorOffsets` (move-only / pan) via the app’s `drag` control call. |
+| `onClickAndDrag` | Batched `dragGesture` with the same `request` shape via the app’s `clickAndDrag` control call. **This client does not** send a preceding `doubleTapGesture` in this path. |
+
+**Player effect (FF1) / note:** The relayer `command` and `request` for batches from `onMove` and `onClickAndDrag` are both **`dragGesture`**. The app only separates them in its own API for clarity and logging. How the **player** distinguishes **double-tap-hold drag** (primary button held) from **move-only** when no separate `doubleTapGesture` is sent in the `onClickAndDrag` path is **player-defined** (or may require a future `request` extension).
+
+---
+
+## 3. `MouseButton`
 
 Used in `tapGesture`, `longPressGesture`, and `doubleTapGesture` `request` objects (and may be reused for future pointer fields).
 
@@ -31,9 +54,9 @@ Wire format: **string** — one of `left`, `right`, `middle` (lowercase).
 
 ---
 
-## 2. Single gestures
+## 4. Single gestures (wire)
 
-### 2.1 `tapGesture`
+### 4.1 `tapGesture`
 
 **`request`:**
 
@@ -43,13 +66,13 @@ Wire format: **string** — one of `left`, `right`, `middle` (lowercase).
 }
 ```
 
-- `button`: **string**, `MouseButton`. **Default:** `left` if the key is omitted (`{}` is still valid and means `left`).
+- `button`: **string**, `MouseButton`. **Default:** `left` if omitted (`{}` means `left`).
 
 **Player effect:** **Single click** at the current cursor for `button`.
 
 ---
 
-### 2.2 `longPressGesture`
+### 4.2 `longPressGesture`
 
 **`request`:**
 
@@ -65,7 +88,7 @@ Wire format: **string** — one of `left`, `right`, `middle` (lowercase).
 
 ---
 
-### 2.3 `doubleTapGesture`
+### 4.3 `doubleTapGesture`
 
 **`request`:**
 
@@ -77,11 +100,11 @@ Wire format: **string** — one of `left`, `right`, `middle` (lowercase).
 
 - `button`: **string**, `MouseButton`. **Default:** `left` if omitted (`{}` means `left`).
 
-**Player effect:** **Double-click** at the current cursor for `button`, and (when followed by `dragGesture` on the same interaction) **arms** click-and-drag per the table at the top of this document.
+**Player effect:** **Double-click** at the current cursor for `button` (discrete; maps to `onDoubleTap` in **§1**).
 
 ---
 
-### 2.4 `dragGesture` (move-only or drag deltas)
+### 4.4 `dragGesture` (move-only or primary-button drag)
 
 **`request`:**
 
@@ -92,11 +115,11 @@ Wire format: **string** — one of `left`, `right`, `middle` (lowercase).
 ```
 
 - `cursorOffsets`: array of steps; each `dx` / `dy` is a **number** rounded to **2** decimal places.
-- Player interpretation: **move-only** vs **click-and-drag** is defined by the table at the top of this document.
+- **Semantic:** **move-only** vs **primary-button drag** is decided by the **player**; this client’s `TouchPad` uses separate app APIs for `onMove` vs `onClickAndDrag` but the same `dragGesture` wire, per **§2**.
 
 ---
 
-### 2.5 `sendKeyboardEvent`
+### 4.5 `sendKeyboardEvent`
 
 **`request`:**
 
@@ -109,14 +132,3 @@ Wire format: **string** — one of `left`, `right`, `middle` (lowercase).
 - `code`: **int** — character code (e.g. `String.codeUnitAt(0)` from the typed character).
 
 **Player effect:** Delivers a **keyboard** input to the focused target.
-
----
-
-## 3. Click-and-drag (`doubleTapGesture` + `dragGesture`)
-
-| Step | Command | Role |
-| ---- | ------- | ---- |
-| 3.1 | `doubleTapGesture` | **Double-click** at the current cursor **and** **arms** click-and-drag for the ongoing touch. |
-| 3.2 | `dragGesture` (one or more messages) | Same `request` shape as move-only (`cursorOffsets`); player applies deltas as **primary-button drag** when armed by **3.1**. |
-
-**Client rule:** For press-and-drag, send **3.1** then **3.2** until finger up. For pan-only, send **only** `dragGesture` (no **3.1** in that interaction) so the player uses move-only behavior.

--- a/docs/mouse_events_spec.md
+++ b/docs/mouse_events_spec.md
@@ -4,7 +4,7 @@ Each call uses HTTP body `{ "command": "<name>", "request": { ... } }` (`FF1Wifi
 
 **Extensions (new FF1, optional):** keep the same `command` strings; add keys only inside `request`. Old FF1 should ignore unknown keys.
 
-**Pointer position:** Do **not** send absolute coordinates (`x`, `y`) in these commands. The **player** applies pointer gestures at the **current synthetic mouse position** (it maintains cursor state). `dragGesture` updates that position with `dx` / `dy`; discrete pointer commands use the cursor as-is.
+**Pointer position:** Do **not** send absolute coordinates (`x`, `y`) in these commands. The **player** applies pointer gestures at the **current synthetic mouse position** (it maintains cursor state). `dragGesture` and `clickAndDragGesture` update that position with `dx` / `dy`; discrete pointer commands use the cursor as-is.
 
 ---
 
@@ -34,9 +34,7 @@ Discrete clicks map 1:1 to gesture commands. Drags are batched with `dx` / `dy` 
 | `onDoubleTap` | `doubleTapGesture` (double-click only) |
 | `onLongPress` | `longPressGesture` |
 | `onMove` | Batched `dragGesture` with `cursorOffsets` (move-only / pan) via the app’s `drag` control call. |
-| `onClickAndDrag` | Batched `dragGesture` with the same `request` shape via the app’s `clickAndDrag` control call. **This client does not** send a preceding `doubleTapGesture` in this path. |
-
-**Player effect (FF1) / note:** The relayer `command` and `request` for batches from `onMove` and `onClickAndDrag` are both **`dragGesture`**. The app only separates them in its own API for clarity and logging. How the **player** distinguishes **double-tap-hold drag** (primary button held) from **move-only** when no separate `doubleTapGesture` is sent in the `onClickAndDrag` path is **player-defined** (or may require a future `request` extension).
+| `onClickAndDrag` | Batched `clickAndDragGesture` with the same `request` shape (`cursorOffsets`) via the app’s `clickAndDrag` control call. **This client does not** send a preceding `doubleTapGesture` in this path. |
 
 ---
 
@@ -104,7 +102,7 @@ Wire format: **string** — one of `left`, `right`, `middle` (lowercase).
 
 ---
 
-### 4.4 `dragGesture` (move-only or primary-button drag)
+### 4.4 `dragGesture` (move-only / pan)
 
 **`request`:**
 
@@ -115,11 +113,19 @@ Wire format: **string** — one of `left`, `right`, `middle` (lowercase).
 ```
 
 - `cursorOffsets`: array of steps; each `dx` / `dy` is a **number** rounded to **2** decimal places.
-- **Semantic:** **move-only** vs **primary-button drag** is decided by the **player**; this client’s `TouchPad` uses separate app APIs for `onMove` vs `onClickAndDrag` but the same `dragGesture` wire, per **§2**.
+- **Semantic:** Move-only pan (`onMove` in **§1** / **§2**). Primary-button drag uses **`clickAndDragGesture`** (4.5).
 
 ---
 
-### 4.5 `sendKeyboardEvent`
+### 4.5 `clickAndDragGesture` (double-tap-hold then drag)
+
+Same **`request`** shape and rounding rules as **`dragGesture`** (4.4); distinct **`command`** so the player can apply primary-button drag without inferring it from the same `dragGesture` name.
+
+**`request`:** same as **§4.4** (`cursorOffsets` only).
+
+---
+
+### 4.6 `sendKeyboardEvent`
 
 **`request`:**
 

--- a/docs/mouse_events_spec.md
+++ b/docs/mouse_events_spec.md
@@ -4,7 +4,7 @@ Each call uses HTTP body `{ "command": "<name>", "request": { ... } }` (`FF1Wifi
 
 **Extensions (new FF1, optional):** keep the same `command` strings; add keys only inside `request`. Old FF1 should ignore unknown keys.
 
-**Pointer position:** Do **not** send absolute coordinates (`x`, `y`) in these commands. The **player** applies pointer gestures at the **current synthetic mouse position** (it maintains cursor state). `dragGesture` and `clickAndDragGesture` update that position with `dx` / `dy`; discrete pointer commands use the cursor as-is.
+**Pointer position:** Do **not** send absolute coordinates (`x`, `y`) in these commands. The **player** applies pointer gestures at the **current synthetic mouse position** (it maintains cursor state). `dragGesture` and `clickAndDragGesture` update that position with `dx` / `dy`; discrete pointer commands use the cursor as-is. `zoomGesture` does not send cursor deltas; it carries multiplicative `scaleSteps` only (**§4.6**).
 
 ---
 
@@ -19,6 +19,7 @@ The mobile touchpad uses Flutter’s **`TapAndPanGestureRecognizer`** (touch onl
 | `onMove`        | **Move-only pan** — a drag where **`onDragStart` has `consecutiveTapCount == 1`**: one finger down, then movement past pan slop (like moving the cursor without a prior “second tap hold”). |
 | `onClickAndDrag` | **Double-tap-hold then drag (click-and-drag)** — a drag where **`onDragStart` has `consecutiveTapCount == 2`**: user has already done a first tap, **second contact** is part of the same consecutive-tap series, and the user **holds and drags** (does not release for a second quick tap). Same pattern as *double-tap to drag* on many laptop trackpads. |
 | `onLongPress`   | **`LongPressGestureRecognizer`** won the arena; drag/tap for that contact is cancelled. |
+| `onZoomGesture` | **Two-finger pinch** — when this callback is non-null, a **`Listener`** tracks global positions of active pointers (touch only). With **exactly two** contacts, each move reports a **multiplicative scale step** from the change in distance between the two touches (`> 1` spread / zoom in, `< 1` pinch / zoom out). This avoids registering **`ScaleGestureRecognizer`** alongside **`TapAndPanGestureRecognizer`**, which broke single-finger taps (arena / `eagerVictoryOnDrag` interaction). |
 
 **Important:** `onDoubleTap` and `onClickAndDrag` are **mutually exclusive** for the same second tap: if the user drags, the second tap does **not** complete as a double-tap *up* → `onDoubleTap` is not called; the gesture is classified as `onClickAndDrag` after drag starts.
 
@@ -26,7 +27,7 @@ The mobile touchpad uses Flutter’s **`TapAndPanGestureRecognizer`** (touch onl
 
 ## 2. FF1 / relayer mapping (example: `TouchPad`)
 
-Discrete clicks map 1:1 to gesture commands. Drags are batched with `dx` / `dy` in `cursorOffsets` (2 decimal places in wire form).
+Discrete clicks map 1:1 to gesture commands. Drags are batched with `dx` / `dy` in `cursorOffsets` (2 decimal places in wire form). Pinch steps are batched as `scaleSteps` (4 decimal places in wire form).
 
 | UI callback / path | Relayer pattern |
 | ------------------ | --------------- |
@@ -35,6 +36,7 @@ Discrete clicks map 1:1 to gesture commands. Drags are batched with `dx` / `dy` 
 | `onLongPress` | `longPressGesture` |
 | `onMove` | Batched `dragGesture` with `cursorOffsets` (move-only / pan) via the app’s `drag` control call. |
 | `onClickAndDrag` | Batched `clickAndDragGesture` with the same `request` shape (`cursorOffsets`) via the app’s `clickAndDrag` control call. **This client does not** send a preceding `doubleTapGesture` in this path. |
+| `onZoomGesture` | Batched `zoomGesture` with `scaleSteps` via the app’s `zoomGesture` control call. Does **not** move the synthetic cursor; the player applies zoom at the current pointer / view semantics. |
 
 ---
 
@@ -125,7 +127,22 @@ Same **`request`** shape and rounding rules as **`dragGesture`** (4.4); distinct
 
 ---
 
-### 4.6 `sendKeyboardEvent`
+### 4.6 `zoomGesture` (pinch)
+
+**`request`:**
+
+```json
+{
+  "scaleSteps": [1.0523, 1.0102]
+}
+```
+
+- `scaleSteps`: array of **multiplicative** per-update ratios from the client (`onZoomGesture` in **§1**), each step derived from successive **inter-touch distance** on the screen (not from Flutter `ScaleUpdateDetails`). Each value is a **number** rounded to **4** decimal places on the wire. The player composes them in order for the pinch session (product of steps, or equivalent).
+- **Semantic:** Two-finger pinch on the touchpad (`onZoomGesture` in **§2**). Not used for absolute coordinates.
+
+---
+
+### 4.7 `sendKeyboardEvent`
 
 **`request`:**
 

--- a/docs/mouse_events_spec.md
+++ b/docs/mouse_events_spec.md
@@ -1,0 +1,122 @@
+# FF1 interact: relayer commands and `request` data
+
+Each call uses HTTP body `{ "command": "<name>", "request": { ... } }` (`FF1WifiRestClient.sendCommand`).
+
+**Extensions (new FF1, optional):** keep the same `command` strings; add keys only inside `request`. Old FF1 should ignore unknown keys.
+
+**Pointer position:** Do **not** send absolute coordinates (`x`, `y`) in these commands. The **player** applies pointer gestures at the **current synthetic mouse position** (it maintains cursor state). `dragGesture` updates that position with `dx` / `dy`; discrete pointer commands use the cursor as-is.
+
+**`dragGesture` vs click-and-drag (player semantics):**
+
+| Client pattern | Player meaning |
+| -------------- | -------------- |
+| Only `dragGesture` (pan / move without a prior `doubleTapGesture` in this interaction) | **Mouse move only** — update cursor with `dx` / `dy`; primary button **not** pressed. |
+| `doubleTapGesture` then `dragGesture` while the user performs a press-and-drag | **Primary-button drag** (“kéo thả”) — movement with the button **held** (click-and-drag). |
+
+The client sends `doubleTapGesture` to **arm** drag mode; the **following** `dragGesture` stream for that touch (until release) is interpreted as dragging. A new touch that only pans should send **only** `dragGesture` so the player keeps move-only behavior.
+
+---
+
+## 1. `MouseButton`
+
+Used in `tapGesture`, `longPressGesture`, and `doubleTapGesture` `request` objects (and may be reused for future pointer fields).
+
+| Value    | Meaning                                               |
+| -------- | ----------------------------------------------------- |
+| `left`   | Primary button (**default** when `button` is omitted) |
+| `right`  | Secondary button                                      |
+| `middle` | Middle / auxiliary button                             |
+
+Wire format: **string** — one of `left`, `right`, `middle` (lowercase).
+
+---
+
+## 2. Single gestures
+
+### 2.1 `tapGesture`
+
+**`request`:**
+
+```json
+{
+  "button": "left"
+}
+```
+
+- `button`: **string**, `MouseButton`. **Default:** `left` if the key is omitted (`{}` is still valid and means `left`).
+
+**Player effect:** **Single click** at the current cursor for `button`.
+
+---
+
+### 2.2 `longPressGesture`
+
+**`request`:**
+
+```json
+{
+  "button": "left"
+}
+```
+
+- `button`: **string**, `MouseButton`. **Default:** `left` if omitted (`{}` means `left`).
+
+**Player effect:** **Long-press** at the current cursor for `button`.
+
+---
+
+### 2.3 `doubleTapGesture`
+
+**`request`:**
+
+```json
+{
+  "button": "left"
+}
+```
+
+- `button`: **string**, `MouseButton`. **Default:** `left` if omitted (`{}` means `left`).
+
+**Player effect:** **Double-click** at the current cursor for `button`, and (when followed by `dragGesture` on the same interaction) **arms** click-and-drag per the table at the top of this document.
+
+---
+
+### 2.4 `dragGesture` (move-only or drag deltas)
+
+**`request`:**
+
+```json
+{
+  "cursorOffsets": [{ "dx": 1.23, "dy": -0.45 }]
+}
+```
+
+- `cursorOffsets`: array of steps; each `dx` / `dy` is a **number** rounded to **2** decimal places.
+- Player interpretation: **move-only** vs **click-and-drag** is defined by the table at the top of this document.
+
+---
+
+### 2.5 `sendKeyboardEvent`
+
+**`request`:**
+
+```json
+{
+  "code": 97
+}
+```
+
+- `code`: **int** — character code (e.g. `String.codeUnitAt(0)` from the typed character).
+
+**Player effect:** Delivers a **keyboard** input to the focused target.
+
+---
+
+## 3. Click-and-drag (`doubleTapGesture` + `dragGesture`)
+
+| Step | Command | Role |
+| ---- | ------- | ---- |
+| 3.1 | `doubleTapGesture` | **Double-click** at the current cursor **and** **arms** click-and-drag for the ongoing touch. |
+| 3.2 | `dragGesture` (one or more messages) | Same `request` shape as move-only (`cursorOffsets`); player applies deltas as **primary-button drag** when armed by **3.1**. |
+
+**Client rule:** For press-and-drag, send **3.1** then **3.2** until finger up. For pan-only, send **only** `dragGesture` (no **3.1** in that interaction) so the player uses move-only behavior.

--- a/docs/project_spec.md
+++ b/docs/project_spec.md
@@ -135,7 +135,9 @@
   - consume live player/device status via Wi-Fi control streams
   - now-displaying bar shows current item and allows navigation to work detail
   - collapsed bar can send shuffle and repeat (`setShuffle`, `setLoop`) when the device reports the corresponding fields in `player_status`; repeat uses a three-state loop contract aligned with FF1 wire values `none` | `playlist` | `one` (repeat off, repeat all, repeat one)
-  - optional: use keyboard/touchpad interactions for remote control
+  - optional: use keyboard/touchpad interactions for remote control; the touchpad
+    supports tap, double tap, long-press, move-only drag, click-and-drag, and
+    pinch zoom gestures for FF1 Wi-Fi control
 - Outcome: art is playing on FF1 with live status visible in app overlays/screens.
 - Important edge cases:
   - no active device: now-displaying bar shows pair/connect guidance (invisible when not pairing)
@@ -174,7 +176,7 @@
   - Who: FF1 owners.
   - Touches: `ff1_providers`, `connect_ff1_providers`, `connect_wifi_provider`, ObjectBox device service.
 - FF1 playback and remote control
-  - What: cast DP-1 payloads, live device/player status, now-displaying + keyboard/touch controls; FF1 loop modes (`none` / `playlist` / `one`) and shuffle via Wi-Fi control; collapsed now-playing shuffle/repeat gated independently and hidden for single-work playback.
+  - What: cast DP-1 payloads, live device/player status, now-displaying + keyboard/touch controls; the touchpad maps tap, double tap, long-press, move-only drag, click-and-drag, and pinch zoom into FF1 Wi-Fi commands; FF1 loop modes (`none` / `playlist` / `one`) and shuffle via Wi-Fi control; collapsed now-playing shuffle/repeat gated independently and hidden for single-work playback.
   - Who: paired-device users.
   - Touches: canvas client, `ff1_wifi_*` providers/control/transport, now-displaying providers/UI, `LoopMode` / `FF1PlayerStatus` in domain + `ff1_wifi_protocol`.
 - Offline-first seed database lifecycle
@@ -256,9 +258,9 @@
 
 - Purpose: monitor current playback and send interaction commands.
 - Entry points: global now-displaying bar (navigates to work detail), `/keyboard-control`.
-- Key actions: view current work/device state; when firmware reports shuffle/loop fields and the playlist has more than one work, toggle shuffle and cycle repeat off → repeat all → repeat one (`setShuffle`, `setLoop` with wire `none` | `playlist` | `one`); open interact mode; send keyboard/touchpad commands.
+- Key actions: view current work/device state; when firmware reports shuffle/loop fields and the playlist has more than one work, toggle shuffle and cycle repeat off → repeat all → repeat one (`setShuffle`, `setLoop` with wire `none` | `playlist` | `one`); open interact mode; send keyboard input and touchpad gestures. The touchpad routes single tap, double tap, long press, move-only drag, click-and-drag, and pinch zoom into the FF1 Wi-Fi command surface, and batches deltas before flushing to reduce command chatter.
 - Important data: active device, connection state, current item list/index, `player_status.shuffle` / parsed `loopMode`, and enough metadata to keep playback UI usable when enrichment is incomplete.
-- Related modules: `now_displaying_provider`, `ff1_wifi_providers` (`ff1SupportsShuffleProvider`, `ff1SupportsLoopProvider`), `loop_button.dart`, `shuffle_button.dart`, `collapsed_now_playing_bar.dart`, touchpad/keyboard events.
+- Related modules: `now_displaying_provider`, `ff1_wifi_providers` (`ff1SupportsShuffleProvider`, `ff1SupportsLoopProvider`), `loop_button.dart`, `shuffle_button.dart`, `collapsed_now_playing_bar.dart`, touchpad/keyboard events, `TouchPad`, `FfMouseGestureDetector`.
 
 ### Screen group: Settings / Release Notes / Document Viewer
 

--- a/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
+++ b/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
@@ -1295,6 +1295,35 @@ transport reconnected — waiting for device connection notification''',
     }
   }
 
+  /// Send pinch-zoom scale steps. Relayer command: `zoomGesture`
+  /// ([FF1WifiZoomGestureRequest]).
+  Future<FF1CommandResponse> zoomGesture({
+    required String topicId,
+    required List<double> scaleSteps,
+  }) async {
+    if (_restClient == null) {
+      throw StateError('REST client not available');
+    }
+    if (scaleSteps.isEmpty) return FF1CommandResponse();
+    try {
+      _log.info(
+        'Sending zoomGesture (${scaleSteps.length} scaleSteps) to device',
+      );
+      final request = FF1WifiZoomGestureRequest(scaleSteps: scaleSteps);
+      final response =
+          await _restClient.sendCommand(
+                topicId: topicId,
+                command: request.command,
+                params: request.params,
+              )
+              as Map<String, dynamic>;
+      return FF1CommandResponse.fromJson(response);
+    } catch (e) {
+      _log.severe('Failed to send zoomGesture: $e');
+      rethrow;
+    }
+  }
+
   /// Shutdown device.
   ///
   /// [topicId] — device topic ID

--- a/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
+++ b/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
@@ -34,8 +34,6 @@ import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-enum _DragInteraction { moveOnly, clickAndDrag }
-
 // ============================================================================
 // WiFi Control (orchestration)
 // ============================================================================
@@ -1228,47 +1226,20 @@ transport reconnected — waiting for device connection notification''',
     }
   }
 
-  /// Send move-only drag (`dragGesture`) — cursor moves without primary button
-  /// held (pan on the touchpad).
+  /// Send move-only drag — pan on the touchpad; cursor moves without the
+  /// primary button held. Relayer command: `dragGesture`.
   Future<FF1CommandResponse> drag({
     required String topicId,
     required List<Offset> cursorOffsets,
-  }) async {
-    return _sendDragGesture(
-      topicId: topicId,
-      cursorOffsets: cursorOffsets,
-      interaction: _DragInteraction.moveOnly,
-    );
-  }
-
-  /// Send click-and-drag deltas (`dragGesture`) after the player has been
-  /// armed with [doubleTap] for this interaction (primary button held).
-  Future<FF1CommandResponse> clickAndDrag({
-    required String topicId,
-    required List<Offset> cursorOffsets,
-  }) async {
-    return _sendDragGesture(
-      topicId: topicId,
-      cursorOffsets: cursorOffsets,
-      interaction: _DragInteraction.clickAndDrag,
-    );
-  }
-
-  Future<FF1CommandResponse> _sendDragGesture({
-    required String topicId,
-    required List<Offset> cursorOffsets,
-    required _DragInteraction interaction,
   }) async {
     if (_restClient == null) {
       throw StateError('REST client not available');
     }
     if (cursorOffsets.isEmpty) return FF1CommandResponse();
-    final label = interaction == _DragInteraction.moveOnly
-        ? 'move-only'
-        : 'click-and-drag';
     try {
       _log.info(
-        'Sending dragGesture ($label, ${cursorOffsets.length} offsets) to device',
+        'Sending move-only dragGesture (${cursorOffsets.length} offsets) '
+        'to device',
       );
       final request = FF1WifiDragRequest(
         cursorOffsets: cursorOffsets
@@ -1284,7 +1255,42 @@ transport reconnected — waiting for device connection notification''',
               as Map<String, dynamic>;
       return FF1CommandResponse.fromJson(response);
     } catch (e) {
-      _log.severe('Failed to send dragGesture ($label): $e');
+      _log.severe('Failed to send move-only dragGesture: $e');
+      rethrow;
+    }
+  }
+
+  /// Send click-and-drag (double-tap-hold then drag) deltas — primary button
+  /// held. Relayer command: `clickAndDragGesture` ([FF1WifiClickAndDragRequest]);
+  /// `request` shape matches [FF1WifiDragRequest] (cursor offset batches).
+  Future<FF1CommandResponse> clickAndDrag({
+    required String topicId,
+    required List<Offset> cursorOffsets,
+  }) async {
+    if (_restClient == null) {
+      throw StateError('REST client not available');
+    }
+    if (cursorOffsets.isEmpty) return FF1CommandResponse();
+    try {
+      _log.info(
+        'Sending clickAndDragGesture (${cursorOffsets.length} offsets) '
+        'to device',
+      );
+      final request = FF1WifiClickAndDragRequest(
+        cursorOffsets: cursorOffsets
+            .map((o) => <String, double>{'dx': o.dx, 'dy': o.dy})
+            .toList(),
+      );
+      final response =
+          await _restClient.sendCommand(
+                topicId: topicId,
+                command: request.command,
+                params: request.params,
+              )
+              as Map<String, dynamic>;
+      return FF1CommandResponse.fromJson(response);
+    } catch (e) {
+      _log.severe('Failed to send clickAndDragGesture: $e');
       rethrow;
     }
   }

--- a/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
+++ b/lib/infra/ff1/wifi_control/ff1_wifi_control.dart
@@ -34,6 +34,8 @@ import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+enum _DragInteraction { moveOnly, clickAndDrag }
+
 // ============================================================================
 // WiFi Control (orchestration)
 // ============================================================================
@@ -1182,17 +1184,92 @@ transport reconnected — waiting for device connection notification''',
     }
   }
 
-  /// Send drag gesture (cursor offsets) to the device.
+  /// Send double-tap gesture to the device.
+  Future<FF1CommandResponse> doubleTap({required String topicId}) async {
+    if (_restClient == null) {
+      throw StateError('REST client not available');
+    }
+    try {
+      _log.info('Sending doubleTap to device');
+      const request = FF1WifiDoubleTapRequest();
+      final response =
+          await _restClient.sendCommand(
+                topicId: topicId,
+                command: request.command,
+                params: request.params,
+              )
+              as Map<String, dynamic>;
+      return FF1CommandResponse.fromJson(response);
+    } catch (e) {
+      _log.severe('Failed to send doubleTap command: $e');
+      rethrow;
+    }
+  }
+
+  /// Send long-press gesture to the device.
+  Future<FF1CommandResponse> longPress({required String topicId}) async {
+    if (_restClient == null) {
+      throw StateError('REST client not available');
+    }
+    try {
+      _log.info('Sending longPress to device');
+      const request = FF1WifiLongPressRequest();
+      final response =
+          await _restClient.sendCommand(
+                topicId: topicId,
+                command: request.command,
+                params: request.params,
+              )
+              as Map<String, dynamic>;
+      return FF1CommandResponse.fromJson(response);
+    } catch (e) {
+      _log.severe('Failed to send longPress command: $e');
+      rethrow;
+    }
+  }
+
+  /// Send move-only drag (`dragGesture`) — cursor moves without primary button
+  /// held (pan on the touchpad).
   Future<FF1CommandResponse> drag({
     required String topicId,
     required List<Offset> cursorOffsets,
+  }) async {
+    return _sendDragGesture(
+      topicId: topicId,
+      cursorOffsets: cursorOffsets,
+      interaction: _DragInteraction.moveOnly,
+    );
+  }
+
+  /// Send click-and-drag deltas (`dragGesture`) after the player has been
+  /// armed with [doubleTap] for this interaction (primary button held).
+  Future<FF1CommandResponse> clickAndDrag({
+    required String topicId,
+    required List<Offset> cursorOffsets,
+  }) async {
+    return _sendDragGesture(
+      topicId: topicId,
+      cursorOffsets: cursorOffsets,
+      interaction: _DragInteraction.clickAndDrag,
+    );
+  }
+
+  Future<FF1CommandResponse> _sendDragGesture({
+    required String topicId,
+    required List<Offset> cursorOffsets,
+    required _DragInteraction interaction,
   }) async {
     if (_restClient == null) {
       throw StateError('REST client not available');
     }
     if (cursorOffsets.isEmpty) return FF1CommandResponse();
+    final label = interaction == _DragInteraction.moveOnly
+        ? 'move-only'
+        : 'click-and-drag';
     try {
-      _log.info('Sending drag(${cursorOffsets.length} offsets) to device');
+      _log.info(
+        'Sending dragGesture ($label, ${cursorOffsets.length} offsets) to device',
+      );
       final request = FF1WifiDragRequest(
         cursorOffsets: cursorOffsets
             .map((o) => <String, double>{'dx': o.dx, 'dy': o.dy})
@@ -1207,7 +1284,7 @@ transport reconnected — waiting for device connection notification''',
               as Map<String, dynamic>;
       return FF1CommandResponse.fromJson(response);
     } catch (e) {
-      _log.severe('Failed to send drag command: $e');
+      _log.severe('Failed to send dragGesture ($label): $e');
       rethrow;
     }
   }

--- a/lib/infra/ff1/wifi_protocol/ff1_wifi_messages.dart
+++ b/lib/infra/ff1/wifi_protocol/ff1_wifi_messages.dart
@@ -682,9 +682,9 @@ class FF1WifiLongPressRequest extends FF1WifiCommandRequest {
   Map<String, dynamic> get params => {};
 }
 
-/// Drag gesture command (cursor offsets).
-/// Command name must match old repo: dragGesture.
-/// dx/dy rounded to 2 decimals like old CursorOffset.toJson().
+/// Drag gesture command (cursor offsets) — **move-only** / pan; cursor moves
+/// without the primary button held. Command name must match old repo:
+/// `dragGesture`. dx/dy rounded to 2 decimals like old CursorOffset.toJson().
 class FF1WifiDragRequest extends FF1WifiCommandRequest {
   /// Creates a drag request.
   ///
@@ -696,6 +696,32 @@ class FF1WifiDragRequest extends FF1WifiCommandRequest {
 
   @override
   String get command => 'dragGesture';
+
+  @override
+  Map<String, dynamic> get params => {
+    'cursorOffsets': cursorOffsets
+        .map(
+          (o) => {
+            'dx': _round2(o['dx']!),
+            'dy': _round2(o['dy']!),
+          },
+        )
+        .toList(),
+  };
+}
+
+/// Click-and-drag gesture (double-tap-hold then drag) — same `request` shape
+/// as [FF1WifiDragRequest], distinct [command] so the player can treat primary-
+/// button drag as separate from move-only [dragGesture].
+class FF1WifiClickAndDragRequest extends FF1WifiCommandRequest {
+  /// Creates a click-and-drag request.
+  const FF1WifiClickAndDragRequest({required this.cursorOffsets});
+
+  /// Cursor offsets (same structure as [FF1WifiDragRequest]).
+  final List<Map<String, double>> cursorOffsets;
+
+  @override
+  String get command => 'clickAndDragGesture';
 
   @override
   Map<String, dynamic> get params => {

--- a/lib/infra/ff1/wifi_protocol/ff1_wifi_messages.dart
+++ b/lib/infra/ff1/wifi_protocol/ff1_wifi_messages.dart
@@ -711,8 +711,8 @@ class FF1WifiDragRequest extends FF1WifiCommandRequest {
 }
 
 /// Click-and-drag gesture (double-tap-hold then drag) — same `request` shape
-/// as [FF1WifiDragRequest], distinct [command] so the player can treat primary-
-/// button drag as separate from move-only [dragGesture].
+/// as [FF1WifiDragRequest], distinct wire `command` so the player can treat
+/// primary-button drag as separate from move-only `dragGesture`.
 class FF1WifiClickAndDragRequest extends FF1WifiCommandRequest {
   /// Creates a click-and-drag request.
   const FF1WifiClickAndDragRequest({required this.cursorOffsets});
@@ -736,7 +736,32 @@ class FF1WifiClickAndDragRequest extends FF1WifiCommandRequest {
   };
 }
 
+/// Pinch-zoom steps — multiplicative scale ratios for one or more updates.
+///
+/// Command name: `zoomGesture`. Each [scaleSteps] entry is a per-update ratio
+/// (`> 1` zoom in, `< 1` zoom out), matching touchpad pinch `onZoomGesture`
+/// ratios from the UI layer.
+class FF1WifiZoomGestureRequest extends FF1WifiCommandRequest {
+  /// Creates a zoom gesture request.
+  ///
+  /// [scaleSteps] — batch of multiplicative scale steps from the touchpad.
+  const FF1WifiZoomGestureRequest({required this.scaleSteps});
+
+  /// Multiplicative scale steps (rounded for wire).
+  final List<double> scaleSteps;
+
+  @override
+  String get command => 'zoomGesture';
+
+  @override
+  Map<String, dynamic> get params => {
+    'scaleSteps': scaleSteps.map(_roundScaleStep).toList(),
+  };
+}
+
 double _round2(double v) => double.parse(v.toStringAsFixed(2));
+
+double _roundScaleStep(double v) => double.parse(v.toStringAsFixed(4));
 
 /// Set device volume command.
 ///

--- a/lib/infra/ff1/wifi_protocol/ff1_wifi_messages.dart
+++ b/lib/infra/ff1/wifi_protocol/ff1_wifi_messages.dart
@@ -300,10 +300,9 @@ class FF1DeviceStatus {
 
     final rawDisplayUrl = json['displayURL'] as String?;
     final trimmedDisplay = rawDisplayUrl?.trim();
-    final displayUrl =
-        trimmedDisplay != null && trimmedDisplay.isNotEmpty
-            ? trimmedDisplay
-            : null;
+    final displayUrl = trimmedDisplay != null && trimmedDisplay.isNotEmpty
+        ? trimmedDisplay
+        : null;
 
     return FF1DeviceStatus(
       connectedWifi: json['connectedWifi'] as String?,
@@ -650,6 +649,34 @@ class FF1WifiTapRequest extends FF1WifiCommandRequest {
 
   @override
   String get command => 'tapGesture';
+
+  @override
+  Map<String, dynamic> get params => {};
+}
+
+/// Double-tap gesture command.
+///
+/// Command name must match old repo: doubleTapGesture.
+class FF1WifiDoubleTapRequest extends FF1WifiCommandRequest {
+  /// Creates a double-tap request.
+  const FF1WifiDoubleTapRequest();
+
+  @override
+  String get command => 'doubleTapGesture';
+
+  @override
+  Map<String, dynamic> get params => {};
+}
+
+/// Long-press gesture command.
+///
+/// Command name must match old repo: longPressGesture.
+class FF1WifiLongPressRequest extends FF1WifiCommandRequest {
+  /// Creates a long-press request.
+  const FF1WifiLongPressRequest();
+
+  @override
+  String get command => 'longPressGesture';
 
   @override
   Map<String, dynamic> get params => {};

--- a/lib/widgets/ff_mouse_gesture_detector.dart
+++ b/lib/widgets/ff_mouse_gesture_detector.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger('FfMouseGestureDetector');
 
 /// A small gesture detector that maps touch gestures to FF1-like mouse
 /// interactions.
@@ -11,10 +14,14 @@ import 'package:flutter/material.dart';
 /// - `onMove`: move-only drag (no button held).
 /// - `onClickAndDrag`: click-and-drag (double-tap-hold then drag).
 /// - `onLongPress`: long press.
+/// - `onZoomGesture`: two-finger pinch; each update reports a multiplicative
+///   scale step since the last update (see [ScaleUpdateDetails.scale]).
 ///
 /// Drag callbacks receive a per-update `Offset delta` so callers can batch
 /// into `dragGesture` or `clickAndDragGesture` `cursorOffsets` as needed.
+/// `Offset.zero` updates are ignored (not forwarded).
 class FfMouseGestureDetector extends StatefulWidget {
+  /// Creates a detector that maps touch to FF1-like mouse interactions.
   const FfMouseGestureDetector({
     required this.child,
     this.onTap,
@@ -22,16 +29,37 @@ class FfMouseGestureDetector extends StatefulWidget {
     this.onMove,
     this.onClickAndDrag,
     this.onLongPress,
+    this.onZoomGesture,
     this.behavior,
     super.key,
   });
 
+  /// Child painted below the gesture arena.
   final Widget child;
+
+  /// Single tap (primary click).
   final VoidCallback? onTap;
+
+  /// Double tap (double click).
   final VoidCallback? onDoubleTap;
+
+  /// Move-only drag; receives each non-zero [Offset] delta.
   final ValueChanged<Offset>? onMove;
+
+  /// Click-and-drag after double-tap-hold; non-zero [Offset] deltas only.
   final ValueChanged<Offset>? onClickAndDrag;
+
+  /// Long press.
   final VoidCallback? onLongPress;
+
+  /// Pinch-to-zoom steps for forwarding as `zoomGesture` on the player.
+  ///
+  /// Values are **multiplicative** per update: `> 1` spreads fingers (zoom in),
+  /// `< 1` pinches inward (zoom out). Derived from successive
+  /// [ScaleUpdateDetails.scale] samples during the same pinch.
+  final ValueChanged<double>? onZoomGesture;
+
+  /// Hit-test behavior; defaults to opaque when null.
   final HitTestBehavior? behavior;
 
   @override
@@ -41,6 +69,7 @@ class FfMouseGestureDetector extends StatefulWidget {
 class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
   bool _isClickAndDrag = false;
   Timer? _singleTapTimer;
+  double _pinchLastCumulativeScale = 1;
 
   void _resetDragMode() {
     _isClickAndDrag = false;
@@ -69,66 +98,130 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
     _cancelPendingTap();
   }
 
+  void _resetPinchScaleTracking() {
+    _pinchLastCumulativeScale = 1;
+  }
+
+  void _handleZoomStart(ScaleStartDetails details) {
+    _log.fine('onZoomStart');
+    _resetPinchScaleTracking();
+  }
+
+  void _handleZoomUpdate(ScaleUpdateDetails details) {
+    final onZoom = widget.onZoomGesture;
+    if (onZoom == null) return;
+    final cumulative = details.scale;
+    if (cumulative == 0) return;
+    final ratio = cumulative / _pinchLastCumulativeScale;
+    _pinchLastCumulativeScale = cumulative;
+    if ((ratio - 1).abs() < 0.0001) return;
+    _log.fine('onZoomUpdate ratio=$ratio cumulative=$cumulative');
+    onZoom(ratio);
+  }
+
+  void _handleZoomEnd(ScaleEndDetails details) {
+    _log.fine('onZoomEnd');
+    _resetPinchScaleTracking();
+  }
+
   @override
   Widget build(BuildContext context) {
+    final gestures = <Type, GestureRecognizerFactory>{
+      TapAndPanGestureRecognizer:
+          GestureRecognizerFactoryWithHandlers<TapAndPanGestureRecognizer>(
+            () => TapAndPanGestureRecognizer(
+              supportedDevices: const {PointerDeviceKind.touch},
+            ),
+            (instance) {
+              // Defer tap-and-pan drag victory when pinch-zoom is enabled so
+              // scale can compete after a second pointer lands.
+              instance
+                ..eagerVictoryOnDrag = widget.onZoomGesture == null
+                ..onTapDown = (details) {
+                  _log.fine(
+                    'onTapDown '
+                    'count=${details.consecutiveTapCount}',
+                  );
+                  if (details.consecutiveTapCount == 2) {
+                    // Cancel pending single tap when starting a double-tap
+                    // sequence.
+                    _cancelPendingTap();
+                  }
+                }
+                ..onTapUp = (details) {
+                  _log.fine(
+                    'onTapUp count=${details.consecutiveTapCount}',
+                  );
+                  if (details.consecutiveTapCount == 1) {
+                    _scheduleSingleTap();
+                  } else if (details.consecutiveTapCount == 2) {
+                    _handleDoubleTap();
+                  }
+                }
+                ..onDragStart = (details) {
+                  _log.fine(
+                    'onDragStart count=${details.consecutiveTapCount}',
+                  );
+                  _cancelPendingTap();
+                  _isClickAndDrag = details.consecutiveTapCount == 2;
+                }
+                ..onDragUpdate = (details) {
+                  final delta = details.delta;
+                  if (delta == Offset.zero) return;
+                  _log.fine(
+                    'onDragUpdate delta=$delta '
+                    'isClickAndDrag=$_isClickAndDrag',
+                  );
+                  if (_isClickAndDrag) {
+                    widget.onClickAndDrag?.call(delta);
+                  } else {
+                    widget.onMove?.call(delta);
+                  }
+                }
+                ..onDragEnd = (details) {
+                  _log.fine('onDragEnd');
+                  _resetDragMode();
+                }
+                ..onCancel = () {
+                  _log.fine('onCancel');
+                  _resetAllModes();
+                };
+            },
+          ),
+      LongPressGestureRecognizer:
+          GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
+            () => LongPressGestureRecognizer(
+              supportedDevices: const {PointerDeviceKind.touch},
+            ),
+            (instance) {
+              instance.onLongPress = () {
+                _log.fine('onLongPress');
+                // Long press wins: treat any in-flight drag as ended.
+                _resetAllModes();
+                widget.onLongPress?.call();
+              };
+            },
+          ),
+    };
+
+    if (widget.onZoomGesture != null) {
+      gestures[ScaleGestureRecognizer] =
+          GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
+            () => ScaleGestureRecognizer(
+              supportedDevices: const {PointerDeviceKind.touch},
+            ),
+            (instance) {
+              instance
+                ..onStart = _handleZoomStart
+                ..onUpdate = _handleZoomUpdate
+                ..onEnd = _handleZoomEnd;
+            },
+          );
+    }
+
     return RawGestureDetector(
       behavior: widget.behavior ?? HitTestBehavior.opaque,
-      gestures: <Type, GestureRecognizerFactory>{
-        TapAndPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<
-            TapAndPanGestureRecognizer>(
-          () => TapAndPanGestureRecognizer(
-            supportedDevices: const {PointerDeviceKind.touch},
-          ),
-          (TapAndPanGestureRecognizer instance) {
-            instance
-              ..onTapDown = (TapDragDownDetails details) {
-                if (details.consecutiveTapCount == 2) {
-                  // Prevent the pending single-tap callback from firing if we are
-                  // entering a double-tap sequence.
-                  _cancelPendingTap();
-                }
-              }
-              ..onTapUp = (TapDragUpDetails details) {
-                if (details.consecutiveTapCount == 1) {
-                  _scheduleSingleTap();
-                } else if (details.consecutiveTapCount == 2) {
-                  _handleDoubleTap();
-                }
-              }
-              ..onDragStart = (TapDragStartDetails details) {
-                _cancelPendingTap();
-                _isClickAndDrag = details.consecutiveTapCount == 2;
-              }
-              ..onDragUpdate = (TapDragUpdateDetails details) {
-                final delta = details.delta;
-                if (_isClickAndDrag) {
-                  widget.onClickAndDrag?.call(delta);
-                } else {
-                  widget.onMove?.call(delta);
-                }
-              }
-              ..onDragEnd = (TapDragEndDetails details) {
-                _resetDragMode();
-              }
-              ..onCancel = () {
-                _resetAllModes();
-              };
-          },
-        ),
-        LongPressGestureRecognizer:
-            GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
-          () => LongPressGestureRecognizer(
-            supportedDevices: const {PointerDeviceKind.touch},
-          ),
-          (LongPressGestureRecognizer instance) {
-            instance.onLongPress = () {
-              // If long press wins, any drag interaction should be treated as ended.
-              _resetAllModes();
-              widget.onLongPress?.call();
-            };
-          },
-        ),
-      },
+      gestures: gestures,
       child: widget.child,
     );
   }

--- a/lib/widgets/ff_mouse_gesture_detector.dart
+++ b/lib/widgets/ff_mouse_gesture_detector.dart
@@ -71,6 +71,7 @@ class FfMouseGestureDetector extends StatefulWidget {
 class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
   bool _isClickAndDrag = false;
   bool _isPinching = false;
+  bool _suppressTap = false;
   Timer? _singleTapTimer;
 
   /// Active touch positions for pinch (global); only used when
@@ -105,7 +106,17 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
   void _resetAllModes() {
     _resetDragMode();
     _isPinching = false;
+    _suppressTap = false;
     _cancelPendingTap();
+  }
+
+  void _startPinch() {
+    _resetDragMode();
+    _cancelPendingTap();
+    _isPinching = true;
+    _suppressTap = true;
+    _pinchLastSpan = _pinchSpanForTwoTouches();
+    _log.fine('pinch start span=$_pinchLastSpan');
   }
 
   double? _pinchSpanForTwoTouches() {
@@ -117,12 +128,13 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
   void _handlePinchPointerDown(PointerDownEvent event) {
     if (widget.onZoomGesture == null) return;
     _pinchPointerPositions[event.pointer] = event.position;
+    if (_singleTapTimer != null) {
+      _cancelPendingTap();
+    }
     if (_pinchPointerPositions.length == 2) {
       // Once two pointers are active, treat the interaction as pinch-only so
       // one-finger pan updates do not leak through while the user is zooming.
-      _isPinching = true;
-      _pinchLastSpan = _pinchSpanForTwoTouches();
-      _log.fine('pinch start span=$_pinchLastSpan');
+      _startPinch();
     }
   }
 
@@ -154,6 +166,9 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
     } else if (_pinchPointerPositions.length == 2) {
       _pinchLastSpan = _pinchSpanForTwoTouches();
     }
+    if (_pinchPointerPositions.isEmpty) {
+      _suppressTap = false;
+    }
   }
 
   @override
@@ -167,6 +182,7 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
             (instance) {
               instance
                 ..onTapDown = (details) {
+                  if (_suppressTap) return;
                   _log.fine(
                     'onTapDown '
                     'count=${details.consecutiveTapCount}',
@@ -178,6 +194,7 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
                   }
                 }
                 ..onTapUp = (details) {
+                  if (_suppressTap) return;
                   _log.fine(
                     'onTapUp count=${details.consecutiveTapCount}',
                   );

--- a/lib/widgets/ff_mouse_gesture_detector.dart
+++ b/lib/widgets/ff_mouse_gesture_detector.dart
@@ -6,6 +6,16 @@ import 'package:logging/logging.dart';
 
 final _log = Logger('FfMouseGestureDetector');
 
+class _CancelableLongPressGestureRecognizer extends LongPressGestureRecognizer {
+  _CancelableLongPressGestureRecognizer({
+    super.supportedDevices,
+  });
+
+  void cancel() {
+    resolve(GestureDisposition.rejected);
+  }
+}
+
 /// A small gesture detector that maps touch gestures to FF1-like mouse
 /// interactions.
 ///
@@ -73,6 +83,7 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
   bool _isPinching = false;
   bool _suppressTap = false;
   Timer? _singleTapTimer;
+  _CancelableLongPressGestureRecognizer? _longPressRecognizer;
 
   /// Active touch positions for pinch (global); only used when
   /// [FfMouseGestureDetector.onZoomGesture] is non-null.
@@ -113,6 +124,7 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
   void _startPinch() {
     _resetDragMode();
     _cancelPendingTap();
+    _longPressRecognizer?.cancel();
     _isPinching = true;
     _suppressTap = true;
     _pinchLastSpan = _pinchSpanForTwoTouches();
@@ -235,11 +247,14 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
                 };
             },
           ),
-      LongPressGestureRecognizer:
-          GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
-            () => LongPressGestureRecognizer(
-              supportedDevices: const {PointerDeviceKind.touch},
-            ),
+      _CancelableLongPressGestureRecognizer:
+          GestureRecognizerFactoryWithHandlers<_CancelableLongPressGestureRecognizer>(
+            () {
+              _longPressRecognizer = _CancelableLongPressGestureRecognizer(
+                supportedDevices: const {PointerDeviceKind.touch},
+              );
+              return _longPressRecognizer!;
+            },
             (instance) {
               instance.onLongPress = () {
                 _log.fine('onLongPress');

--- a/lib/widgets/ff_mouse_gesture_detector.dart
+++ b/lib/widgets/ff_mouse_gesture_detector.dart
@@ -15,7 +15,9 @@ final _log = Logger('FfMouseGestureDetector');
 /// - `onClickAndDrag`: click-and-drag (double-tap-hold then drag).
 /// - `onLongPress`: long press.
 /// - `onZoomGesture`: two-finger pinch; each update reports a multiplicative
-///   scale step since the last update (see [ScaleUpdateDetails.scale]).
+///   scale step from the change in distance between the two touches (global
+///   coordinates). Implemented with a [Listener] so taps and drags are not
+///   competing in the gesture arena against [ScaleGestureRecognizer].
 ///
 /// Drag callbacks receive a per-update `Offset delta` so callers can batch
 /// into `dragGesture` or `clickAndDragGesture` `cursorOffsets` as needed.
@@ -55,8 +57,8 @@ class FfMouseGestureDetector extends StatefulWidget {
   /// Pinch-to-zoom steps for forwarding as `zoomGesture` on the player.
   ///
   /// Values are **multiplicative** per update: `> 1` spreads fingers (zoom in),
-  /// `< 1` pinches inward (zoom out). Derived from successive
-  /// [ScaleUpdateDetails.scale] samples during the same pinch.
+  /// `< 1` pinches inward (zoom out). Ratios come from successive distances
+  /// between the two active touches.
   final ValueChanged<double>? onZoomGesture;
 
   /// Hit-test behavior; defaults to opaque when null.
@@ -68,8 +70,15 @@ class FfMouseGestureDetector extends StatefulWidget {
 
 class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
   bool _isClickAndDrag = false;
+  bool _isPinching = false;
   Timer? _singleTapTimer;
-  double _pinchLastCumulativeScale = 1;
+
+  /// Active touch positions for pinch (global); only used when
+  /// [FfMouseGestureDetector.onZoomGesture] is non-null.
+  final Map<int, Offset> _pinchPointerPositions = <int, Offset>{};
+
+  /// Previous inter-touch distance during an active two-finger pinch.
+  double? _pinchLastSpan;
 
   void _resetDragMode() {
     _isClickAndDrag = false;
@@ -95,33 +104,56 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
 
   void _resetAllModes() {
     _resetDragMode();
+    _isPinching = false;
     _cancelPendingTap();
   }
 
-  void _resetPinchScaleTracking() {
-    _pinchLastCumulativeScale = 1;
+  double? _pinchSpanForTwoTouches() {
+    if (_pinchPointerPositions.length != 2) return null;
+    final positions = _pinchPointerPositions.values.toList();
+    return (positions[0] - positions[1]).distance;
   }
 
-  void _handleZoomStart(ScaleStartDetails details) {
-    _log.fine('onZoomStart');
-    _resetPinchScaleTracking();
+  void _handlePinchPointerDown(PointerDownEvent event) {
+    if (widget.onZoomGesture == null) return;
+    _pinchPointerPositions[event.pointer] = event.position;
+    if (_pinchPointerPositions.length == 2) {
+      // Once two pointers are active, treat the interaction as pinch-only so
+      // one-finger pan updates do not leak through while the user is zooming.
+      _isPinching = true;
+      _pinchLastSpan = _pinchSpanForTwoTouches();
+      _log.fine('pinch start span=$_pinchLastSpan');
+    }
   }
 
-  void _handleZoomUpdate(ScaleUpdateDetails details) {
-    final onZoom = widget.onZoomGesture;
-    if (onZoom == null) return;
-    final cumulative = details.scale;
-    if (cumulative == 0) return;
-    final ratio = cumulative / _pinchLastCumulativeScale;
-    _pinchLastCumulativeScale = cumulative;
+  void _handlePinchPointerMove(PointerMoveEvent event) {
+    if (widget.onZoomGesture == null) return;
+    if (!_pinchPointerPositions.containsKey(event.pointer)) return;
+    _pinchPointerPositions[event.pointer] = event.position;
+    if (_pinchPointerPositions.length != 2) return;
+    final span = _pinchSpanForTwoTouches();
+    if (span == null || span == 0) return;
+    final last = _pinchLastSpan;
+    if (last == null || last <= 0) {
+      _pinchLastSpan = span;
+      return;
+    }
+    final ratio = span / last;
+    _pinchLastSpan = span;
     if ((ratio - 1).abs() < 0.0001) return;
-    _log.fine('onZoomUpdate ratio=$ratio cumulative=$cumulative');
-    onZoom(ratio);
+    _log.fine('pinch ratio=$ratio span=$span');
+    widget.onZoomGesture!.call(ratio);
   }
 
-  void _handleZoomEnd(ScaleEndDetails details) {
-    _log.fine('onZoomEnd');
-    _resetPinchScaleTracking();
+  void _handlePinchPointerEnd(PointerEvent event) {
+    if (widget.onZoomGesture == null) return;
+    _pinchPointerPositions.remove(event.pointer);
+    if (_pinchPointerPositions.length < 2) {
+      _pinchLastSpan = null;
+      _isPinching = false;
+    } else if (_pinchPointerPositions.length == 2) {
+      _pinchLastSpan = _pinchSpanForTwoTouches();
+    }
   }
 
   @override
@@ -133,10 +165,7 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
               supportedDevices: const {PointerDeviceKind.touch},
             ),
             (instance) {
-              // Defer tap-and-pan drag victory when pinch-zoom is enabled so
-              // scale can compete after a second pointer lands.
               instance
-                ..eagerVictoryOnDrag = widget.onZoomGesture == null
                 ..onTapDown = (details) {
                   _log.fine(
                     'onTapDown '
@@ -168,6 +197,7 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
                 ..onDragUpdate = (details) {
                   final delta = details.delta;
                   if (delta == Offset.zero) return;
+                  if (_isPinching) return;
                   _log.fine(
                     'onDragUpdate delta=$delta '
                     'isClickAndDrag=$_isClickAndDrag',
@@ -204,25 +234,22 @@ class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
           ),
     };
 
-    if (widget.onZoomGesture != null) {
-      gestures[ScaleGestureRecognizer] =
-          GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
-            () => ScaleGestureRecognizer(
-              supportedDevices: const {PointerDeviceKind.touch},
-            ),
-            (instance) {
-              instance
-                ..onStart = _handleZoomStart
-                ..onUpdate = _handleZoomUpdate
-                ..onEnd = _handleZoomEnd;
-            },
-          );
-    }
-
-    return RawGestureDetector(
+    final core = RawGestureDetector(
       behavior: widget.behavior ?? HitTestBehavior.opaque,
       gestures: gestures,
       child: widget.child,
+    );
+
+    if (widget.onZoomGesture == null) {
+      return core;
+    }
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: _handlePinchPointerDown,
+      onPointerMove: _handlePinchPointerMove,
+      onPointerUp: _handlePinchPointerEnd,
+      onPointerCancel: _handlePinchPointerEnd,
+      child: core,
     );
   }
 

--- a/lib/widgets/ff_mouse_gesture_detector.dart
+++ b/lib/widgets/ff_mouse_gesture_detector.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+/// A small gesture detector that maps touch gestures to FF1-like mouse
+/// interactions.
+///
+/// - `onTap`: single click.
+/// - `onDoubleTap`: double click.
+/// - `onMove`: move-only drag (no button held).
+/// - `onClickAndDrag`: click-and-drag (double-tap-hold then drag).
+/// - `onLongPress`: long press.
+///
+/// Drag callbacks receive a per-update `Offset delta` so callers can batch
+/// into FF1 `dragGesture.cursorOffsets` as needed.
+class FfMouseGestureDetector extends StatefulWidget {
+  const FfMouseGestureDetector({
+    required this.child,
+    this.onTap,
+    this.onDoubleTap,
+    this.onMove,
+    this.onClickAndDrag,
+    this.onLongPress,
+    this.behavior,
+    super.key,
+  });
+
+  final Widget child;
+  final VoidCallback? onTap;
+  final VoidCallback? onDoubleTap;
+  final ValueChanged<Offset>? onMove;
+  final ValueChanged<Offset>? onClickAndDrag;
+  final VoidCallback? onLongPress;
+  final HitTestBehavior? behavior;
+
+  @override
+  State<FfMouseGestureDetector> createState() => _FfMouseGestureDetectorState();
+}
+
+class _FfMouseGestureDetectorState extends State<FfMouseGestureDetector> {
+  bool _isClickAndDrag = false;
+  Timer? _singleTapTimer;
+
+  void _resetDragMode() {
+    _isClickAndDrag = false;
+  }
+
+  void _cancelPendingTap() {
+    _singleTapTimer?.cancel();
+    _singleTapTimer = null;
+  }
+
+  void _scheduleSingleTap() {
+    _cancelPendingTap();
+    if (widget.onTap == null) return;
+    _singleTapTimer = Timer(kDoubleTapTimeout, () {
+      widget.onTap?.call();
+    });
+  }
+
+  void _handleDoubleTap() {
+    _cancelPendingTap();
+    widget.onDoubleTap?.call();
+  }
+
+  void _resetAllModes() {
+    _resetDragMode();
+    _cancelPendingTap();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RawGestureDetector(
+      behavior: widget.behavior ?? HitTestBehavior.opaque,
+      gestures: <Type, GestureRecognizerFactory>{
+        TapAndPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<
+            TapAndPanGestureRecognizer>(
+          () => TapAndPanGestureRecognizer(
+            supportedDevices: const {PointerDeviceKind.touch},
+          ),
+          (TapAndPanGestureRecognizer instance) {
+            instance
+              ..onTapDown = (TapDragDownDetails details) {
+                if (details.consecutiveTapCount == 2) {
+                  // Prevent the pending single-tap callback from firing if we are
+                  // entering a double-tap sequence.
+                  _cancelPendingTap();
+                }
+              }
+              ..onTapUp = (TapDragUpDetails details) {
+                if (details.consecutiveTapCount == 1) {
+                  _scheduleSingleTap();
+                } else if (details.consecutiveTapCount == 2) {
+                  _handleDoubleTap();
+                }
+              }
+              ..onDragStart = (TapDragStartDetails details) {
+                _cancelPendingTap();
+                _isClickAndDrag = details.consecutiveTapCount == 2;
+              }
+              ..onDragUpdate = (TapDragUpdateDetails details) {
+                final delta = details.delta;
+                if (_isClickAndDrag) {
+                  widget.onClickAndDrag?.call(delta);
+                } else {
+                  widget.onMove?.call(delta);
+                }
+              }
+              ..onDragEnd = (TapDragEndDetails details) {
+                _resetDragMode();
+              }
+              ..onCancel = () {
+                _resetAllModes();
+              };
+          },
+        ),
+        LongPressGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
+          () => LongPressGestureRecognizer(
+            supportedDevices: const {PointerDeviceKind.touch},
+          ),
+          (LongPressGestureRecognizer instance) {
+            instance.onLongPress = () {
+              // If long press wins, any drag interaction should be treated as ended.
+              _resetAllModes();
+              widget.onLongPress?.call();
+            };
+          },
+        ),
+      },
+      child: widget.child,
+    );
+  }
+
+  @override
+  void dispose() {
+    _cancelPendingTap();
+    super.dispose();
+  }
+}

--- a/lib/widgets/ff_mouse_gesture_detector.dart
+++ b/lib/widgets/ff_mouse_gesture_detector.dart
@@ -13,7 +13,7 @@ import 'package:flutter/material.dart';
 /// - `onLongPress`: long press.
 ///
 /// Drag callbacks receive a per-update `Offset delta` so callers can batch
-/// into FF1 `dragGesture.cursorOffsets` as needed.
+/// into `dragGesture` or `clickAndDragGesture` `cursorOffsets` as needed.
 class FfMouseGestureDetector extends StatefulWidget {
   const FfMouseGestureDetector({
     required this.child,

--- a/lib/widgets/touchpad.dart
+++ b/lib/widgets/touchpad.dart
@@ -65,6 +65,16 @@ class _TouchPadState extends ConsumerState<TouchPad> {
     }
   }
 
+  void _flushMoveDeltasIfNeeded(FF1WifiControl wifiControl) {
+    if (_moveDragOffsets.length <= 5) return;
+    _flushMoveDeltas(wifiControl);
+  }
+
+  void _flushClickAndDragDeltasIfNeeded(FF1WifiControl wifiControl) {
+    if (_clickAndDragOffsets.length <= 5) return;
+    _flushClickAndDragDeltas(wifiControl);
+  }
+
   void _flushZoomStepsIfNeeded(FF1WifiControl wifiControl) {
     if (_zoomScaleSteps.length <= 5) return;
     _flushZoomSteps(wifiControl);
@@ -164,6 +174,7 @@ class _TouchPadState extends ConsumerState<TouchPad> {
                   return;
                 }
                 _queueMoveDelta(delta);
+                _flushMoveDeltasIfNeeded(wifiControl);
               },
               onClickAndDrag: (delta) {
                 if (!_isGestureActive) {
@@ -173,6 +184,7 @@ class _TouchPadState extends ConsumerState<TouchPad> {
                   return;
                 }
                 _queueClickAndDragDelta(delta);
+                _flushClickAndDragDeltasIfNeeded(wifiControl);
               },
               onLongPress: () async {
                 await wifiControl.longPress(topicId: widget.topicId);

--- a/lib/widgets/touchpad.dart
+++ b/lib/widgets/touchpad.dart
@@ -35,11 +35,12 @@ class _TouchPadState extends ConsumerState<TouchPad> {
   final List<Offset> _moveDragOffsets = [];
   final List<Offset> _clickAndDragOffsets = [];
   final List<double> _zoomScaleSteps = [];
+  final Set<int> _activePointers = <int>{};
   // Guards against drag updates arriving after the pointer has already ended.
   // Gesture recognizers can finish slightly out of order relative to pointer
-  // up/cancel delivery, so the touchpad treats pointer state as the source of
-  // truth before buffering deltas.
-  bool _isPointerDown = false;
+  // up/cancel delivery, so the touchpad treats the active pointer set as the
+  // source of truth before buffering deltas.
+  bool get _isGestureActive => _activePointers.isNotEmpty;
 
   void _queueMoveDelta(Offset delta) {
     _moveDragOffsets.add(delta);
@@ -53,8 +54,8 @@ class _TouchPadState extends ConsumerState<TouchPad> {
     _zoomScaleSteps.add(ratio);
   }
 
-  void _beginPointerGesture() {
-    _isPointerDown = true;
+  void _beginPointerGesture(PointerEvent event) {
+    _activePointers.add(event.pointer);
   }
 
   void _flushMoveDeltasIfNeeded(FF1WifiControl wifiControl) {
@@ -108,8 +109,11 @@ class _TouchPadState extends ConsumerState<TouchPad> {
     );
   }
 
-  void _onPointerGestureEnd(FF1WifiControl wifiControl) {
-    _isPointerDown = false;
+  void _endPointerGesture(FF1WifiControl wifiControl, PointerEvent event) {
+    _activePointers.remove(event.pointer);
+    if (_isGestureActive) {
+      return;
+    }
     _flushMoveDeltas(wifiControl);
     _flushClickAndDragDeltas(wifiControl);
     _flushZoomSteps(wifiControl);
@@ -129,13 +133,13 @@ class _TouchPadState extends ConsumerState<TouchPad> {
           Listener(
             behavior: HitTestBehavior.opaque,
             onPointerDown: (event) {
-              _beginPointerGesture();
+              _beginPointerGesture(event);
             },
             onPointerUp: (event) {
-              _onPointerGestureEnd(wifiControl);
+              _endPointerGesture(wifiControl, event);
             },
             onPointerCancel: (event) {
-              _onPointerGestureEnd(wifiControl);
+              _endPointerGesture(wifiControl, event);
             },
             child: FfMouseGestureDetector(
               onTap: () async {
@@ -145,14 +149,14 @@ class _TouchPadState extends ConsumerState<TouchPad> {
                 await wifiControl.doubleTap(topicId: widget.topicId);
               },
               onMove: (delta) {
-                if (!_isPointerDown) {
+                if (!_isGestureActive) {
                   return;
                 }
                 _queueMoveDelta(delta);
                 _flushMoveDeltasIfNeeded(wifiControl);
               },
               onClickAndDrag: (delta) {
-                if (!_isPointerDown) {
+                if (!_isGestureActive) {
                   return;
                 }
                 _queueClickAndDragDelta(delta);

--- a/lib/widgets/touchpad.dart
+++ b/lib/widgets/touchpad.dart
@@ -9,9 +9,6 @@ import 'package:app/theme/app_color.dart';
 import 'package:app/widgets/ff_mouse_gesture_detector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:logging/logging.dart';
-
-final _log = Logger('TouchPad');
 
 /// Touchpad for keyboard control screen. Tap and drag send to FF1 via
 /// [ff1WifiControlProvider].
@@ -41,7 +38,7 @@ class _TouchPadState extends ConsumerState<TouchPad> {
   // Guards against drag updates arriving after the pointer has already ended.
   // Gesture recognizers can finish slightly out of order relative to pointer
   // up/cancel delivery, so the touchpad treats pointer state as the source of
-  // truth before logging or buffering deltas.
+  // truth before buffering deltas.
   bool _isPointerDown = false;
 
   void _queueMoveDelta(Offset delta) {
@@ -132,40 +129,25 @@ class _TouchPadState extends ConsumerState<TouchPad> {
           Listener(
             behavior: HitTestBehavior.opaque,
             onPointerDown: (event) {
-              _log.fine('[Touchpad] onPointerDown pointer=${event.pointer}');
               _beginPointerGesture();
             },
             onPointerUp: (event) {
-              _log.fine('[Touchpad] onPointerUp pointer=${event.pointer}');
               _onPointerGestureEnd(wifiControl);
             },
             onPointerCancel: (event) {
-              _log.fine('[Touchpad] onPointerCancel pointer=${event.pointer}');
               _onPointerGestureEnd(wifiControl);
             },
             child: FfMouseGestureDetector(
               onTap: () async {
-                _log.info(
-                  '[Touchpad] onTap topicId=${widget.topicId} '
-                  '(tapGesture)',
-                );
                 await wifiControl.tap(topicId: widget.topicId);
               },
               onDoubleTap: () async {
-                _log.info(
-                  '[Touchpad] onDoubleTap topicId=${widget.topicId} '
-                  '(doubleTapGesture)',
-                );
                 await wifiControl.doubleTap(topicId: widget.topicId);
               },
               onMove: (delta) {
                 if (!_isPointerDown) {
                   return;
                 }
-                _log.fine(
-                  '[Touchpad] onMove topicId=${widget.topicId} '
-                  'delta=$delta',
-                );
                 _queueMoveDelta(delta);
                 _flushMoveDeltasIfNeeded(wifiControl);
               },
@@ -173,25 +155,13 @@ class _TouchPadState extends ConsumerState<TouchPad> {
                 if (!_isPointerDown) {
                   return;
                 }
-                _log.fine(
-                  '[Touchpad] onClickAndDrag topicId=${widget.topicId} '
-                  'delta=$delta',
-                );
                 _queueClickAndDragDelta(delta);
                 _flushClickAndDragDeltasIfNeeded(wifiControl);
               },
               onLongPress: () async {
-                _log.info(
-                  '[Touchpad] onLongPress topicId=${widget.topicId} '
-                  '(longPressGesture)',
-                );
                 await wifiControl.longPress(topicId: widget.topicId);
               },
               onZoomGesture: (ratio) {
-                _log.fine(
-                  '[Touchpad] onZoomGesture topicId=${widget.topicId} '
-                  'ratio=$ratio',
-                );
                 _queueZoomStep(ratio);
                 _flushZoomStepsIfNeeded(wifiControl);
               },

--- a/lib/widgets/touchpad.dart
+++ b/lib/widgets/touchpad.dart
@@ -37,7 +37,6 @@ class TouchPad extends ConsumerStatefulWidget {
 class _TouchPadState extends ConsumerState<TouchPad> {
   final List<Offset> _moveDragOffsets = [];
   final List<Offset> _clickAndDragOffsets = [];
-  bool _didSendDoubleTapForClickAndDrag = false;
 
   void _queueMoveDelta(Offset delta) {
     _moveDragOffsets.add(delta);
@@ -82,7 +81,6 @@ class _TouchPadState extends ConsumerState<TouchPad> {
   }
 
   void _onPointerGestureEnd(FF1WifiControl wifiControl) {
-    _didSendDoubleTapForClickAndDrag = false;
     _flushMoveDeltas(wifiControl);
     _flushClickAndDragDeltas(wifiControl);
   }
@@ -122,21 +120,10 @@ class _TouchPadState extends ConsumerState<TouchPad> {
                   '[Touchpad] onMove topicId=${widget.topicId} '
                   'delta=$delta',
                 );
-                _didSendDoubleTapForClickAndDrag = false;
                 _queueMoveDelta(delta);
                 _flushMoveDeltasIfNeeded(wifiControl);
               },
               onClickAndDrag: (delta) {
-                if (!_didSendDoubleTapForClickAndDrag) {
-                  _didSendDoubleTapForClickAndDrag = true;
-                  _log.info(
-                    '[Touchpad] onClickAndDrag arm doubleTapGesture '
-                    'topicId=${widget.topicId}',
-                  );
-                  unawaited(
-                    wifiControl.doubleTap(topicId: widget.topicId),
-                  );
-                }
                 _log.fine(
                   '[Touchpad] onClickAndDrag topicId=${widget.topicId} '
                   'delta=$delta',
@@ -149,7 +136,6 @@ class _TouchPadState extends ConsumerState<TouchPad> {
                   '[Touchpad] onLongPress topicId=${widget.topicId} '
                   '(longPressGesture)',
                 );
-                _didSendDoubleTapForClickAndDrag = false;
                 await wifiControl.longPress(topicId: widget.topicId);
               },
               child: const SizedBox.expand(),

--- a/lib/widgets/touchpad.dart
+++ b/lib/widgets/touchpad.dart
@@ -4,7 +4,9 @@ import 'package:app/app/providers/ff1_wifi_providers.dart';
 import 'package:app/design/app_typography.dart';
 import 'package:app/design/build/primitives.dart';
 import 'package:app/design/layout_constants.dart';
+import 'package:app/infra/ff1/wifi_control/ff1_wifi_control.dart';
 import 'package:app/theme/app_color.dart';
+import 'package:app/widgets/ff_mouse_gesture_detector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
@@ -12,15 +14,20 @@ import 'package:logging/logging.dart';
 final _log = Logger('TouchPad');
 
 /// Touchpad for keyboard control screen. Tap and drag send to FF1 via
-/// [ff1WifiControlProvider]. [topicId] from now displaying provider.
+/// [ff1WifiControlProvider].
 class TouchPad extends ConsumerStatefulWidget {
+  /// Creates a touchpad surface that forwards gestures to the active FF1
+  /// device.
   const TouchPad({
     required this.topicId,
     this.onExpand,
     super.key,
   });
 
+  /// Relayer topic id of the target FF1 device.
   final String topicId;
+
+  /// Optional action to expand the touchpad UI.
   final VoidCallback? onExpand;
 
   @override
@@ -28,8 +35,57 @@ class TouchPad extends ConsumerStatefulWidget {
 }
 
 class _TouchPadState extends ConsumerState<TouchPad> {
-  Offset? _lastPosition;
-  final List<Offset> _dragOffsets = [];
+  final List<Offset> _moveDragOffsets = [];
+  final List<Offset> _clickAndDragOffsets = [];
+  bool _didSendDoubleTapForClickAndDrag = false;
+
+  void _queueMoveDelta(Offset delta) {
+    _moveDragOffsets.add(delta);
+  }
+
+  void _queueClickAndDragDelta(Offset delta) {
+    _clickAndDragOffsets.add(delta);
+  }
+
+  void _flushMoveDeltasIfNeeded(FF1WifiControl wifiControl) {
+    if (_moveDragOffsets.length <= 5) return;
+    _flushMoveDeltas(wifiControl);
+  }
+
+  void _flushClickAndDragDeltasIfNeeded(FF1WifiControl wifiControl) {
+    if (_clickAndDragOffsets.length <= 5) return;
+    _flushClickAndDragDeltas(wifiControl);
+  }
+
+  void _flushMoveDeltas(FF1WifiControl wifiControl) {
+    if (_moveDragOffsets.isEmpty) return;
+    final offsets = List<Offset>.from(_moveDragOffsets);
+    _moveDragOffsets.clear();
+    unawaited(
+      wifiControl.drag(
+        topicId: widget.topicId,
+        cursorOffsets: offsets,
+      ),
+    );
+  }
+
+  void _flushClickAndDragDeltas(FF1WifiControl wifiControl) {
+    if (_clickAndDragOffsets.isEmpty) return;
+    final offsets = List<Offset>.from(_clickAndDragOffsets);
+    _clickAndDragOffsets.clear();
+    unawaited(
+      wifiControl.clickAndDrag(
+        topicId: widget.topicId,
+        cursorOffsets: offsets,
+      ),
+    );
+  }
+
+  void _onPointerGestureEnd(FF1WifiControl wifiControl) {
+    _didSendDoubleTapForClickAndDrag = false;
+    _flushMoveDeltas(wifiControl);
+    _flushClickAndDragDeltas(wifiControl);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -42,32 +98,62 @@ class _TouchPadState extends ConsumerState<TouchPad> {
       ),
       child: Stack(
         children: [
-          GestureDetector(
-            onTap: () async {
-              _log.info('[Touchpad] onTap');
-              await wifiControl.tap(topicId: widget.topicId);
-            },
-            onPanStart: (panDetails) {
-              _log.info('[Touchpad] onPanStart: ${panDetails.localPosition}');
-              _lastPosition = panDetails.localPosition;
-            },
-            onPanUpdate: (panDetails) {
-              final delta =
-                  panDetails.localPosition -
-                  (_lastPosition ?? panDetails.localPosition);
-              _lastPosition = panDetails.localPosition;
-              _dragOffsets.add(delta);
-              if (_dragOffsets.length > 5) {
-                final offsets = List<Offset>.from(_dragOffsets);
-                _dragOffsets.clear();
-                unawaited(
-                  wifiControl.drag(
-                    topicId: widget.topicId,
-                    cursorOffsets: offsets,
-                  ),
+          Listener(
+            behavior: HitTestBehavior.opaque,
+            onPointerUp: (_) => _onPointerGestureEnd(wifiControl),
+            onPointerCancel: (_) => _onPointerGestureEnd(wifiControl),
+            child: FfMouseGestureDetector(
+              onTap: () async {
+                _log.info(
+                  '[Touchpad] onTap topicId=${widget.topicId} '
+                  '(tapGesture)',
                 );
-              }
-            },
+                await wifiControl.tap(topicId: widget.topicId);
+              },
+              onDoubleTap: () async {
+                _log.info(
+                  '[Touchpad] onDoubleTap topicId=${widget.topicId} '
+                  '(doubleTapGesture)',
+                );
+                await wifiControl.doubleTap(topicId: widget.topicId);
+              },
+              onMove: (delta) {
+                _log.fine(
+                  '[Touchpad] onMove topicId=${widget.topicId} '
+                  'delta=$delta',
+                );
+                _didSendDoubleTapForClickAndDrag = false;
+                _queueMoveDelta(delta);
+                _flushMoveDeltasIfNeeded(wifiControl);
+              },
+              onClickAndDrag: (delta) {
+                if (!_didSendDoubleTapForClickAndDrag) {
+                  _didSendDoubleTapForClickAndDrag = true;
+                  _log.info(
+                    '[Touchpad] onClickAndDrag arm doubleTapGesture '
+                    'topicId=${widget.topicId}',
+                  );
+                  unawaited(
+                    wifiControl.doubleTap(topicId: widget.topicId),
+                  );
+                }
+                _log.fine(
+                  '[Touchpad] onClickAndDrag topicId=${widget.topicId} '
+                  'delta=$delta',
+                );
+                _queueClickAndDragDelta(delta);
+                _flushClickAndDragDeltasIfNeeded(wifiControl);
+              },
+              onLongPress: () async {
+                _log.info(
+                  '[Touchpad] onLongPress topicId=${widget.topicId} '
+                  '(longPressGesture)',
+                );
+                _didSendDoubleTapForClickAndDrag = false;
+                await wifiControl.longPress(topicId: widget.topicId);
+              },
+              child: const SizedBox.expand(),
+            ),
           ),
           Positioned(
             bottom: 0,

--- a/lib/widgets/touchpad.dart
+++ b/lib/widgets/touchpad.dart
@@ -37,6 +37,12 @@ class TouchPad extends ConsumerStatefulWidget {
 class _TouchPadState extends ConsumerState<TouchPad> {
   final List<Offset> _moveDragOffsets = [];
   final List<Offset> _clickAndDragOffsets = [];
+  final List<double> _zoomScaleSteps = [];
+  // Guards against drag updates arriving after the pointer has already ended.
+  // Gesture recognizers can finish slightly out of order relative to pointer
+  // up/cancel delivery, so the touchpad treats pointer state as the source of
+  // truth before logging or buffering deltas.
+  bool _isPointerDown = false;
 
   void _queueMoveDelta(Offset delta) {
     _moveDragOffsets.add(delta);
@@ -44,6 +50,14 @@ class _TouchPadState extends ConsumerState<TouchPad> {
 
   void _queueClickAndDragDelta(Offset delta) {
     _clickAndDragOffsets.add(delta);
+  }
+
+  void _queueZoomStep(double ratio) {
+    _zoomScaleSteps.add(ratio);
+  }
+
+  void _beginPointerGesture() {
+    _isPointerDown = true;
   }
 
   void _flushMoveDeltasIfNeeded(FF1WifiControl wifiControl) {
@@ -54,6 +68,11 @@ class _TouchPadState extends ConsumerState<TouchPad> {
   void _flushClickAndDragDeltasIfNeeded(FF1WifiControl wifiControl) {
     if (_clickAndDragOffsets.length <= 5) return;
     _flushClickAndDragDeltas(wifiControl);
+  }
+
+  void _flushZoomStepsIfNeeded(FF1WifiControl wifiControl) {
+    if (_zoomScaleSteps.length <= 5) return;
+    _flushZoomSteps(wifiControl);
   }
 
   void _flushMoveDeltas(FF1WifiControl wifiControl) {
@@ -80,9 +99,23 @@ class _TouchPadState extends ConsumerState<TouchPad> {
     );
   }
 
+  void _flushZoomSteps(FF1WifiControl wifiControl) {
+    if (_zoomScaleSteps.isEmpty) return;
+    final steps = List<double>.from(_zoomScaleSteps);
+    _zoomScaleSteps.clear();
+    unawaited(
+      wifiControl.zoomGesture(
+        topicId: widget.topicId,
+        scaleSteps: steps,
+      ),
+    );
+  }
+
   void _onPointerGestureEnd(FF1WifiControl wifiControl) {
+    _isPointerDown = false;
     _flushMoveDeltas(wifiControl);
     _flushClickAndDragDeltas(wifiControl);
+    _flushZoomSteps(wifiControl);
   }
 
   @override
@@ -98,8 +131,18 @@ class _TouchPadState extends ConsumerState<TouchPad> {
         children: [
           Listener(
             behavior: HitTestBehavior.opaque,
-            onPointerUp: (_) => _onPointerGestureEnd(wifiControl),
-            onPointerCancel: (_) => _onPointerGestureEnd(wifiControl),
+            onPointerDown: (event) {
+              _log.fine('[Touchpad] onPointerDown pointer=${event.pointer}');
+              _beginPointerGesture();
+            },
+            onPointerUp: (event) {
+              _log.fine('[Touchpad] onPointerUp pointer=${event.pointer}');
+              _onPointerGestureEnd(wifiControl);
+            },
+            onPointerCancel: (event) {
+              _log.fine('[Touchpad] onPointerCancel pointer=${event.pointer}');
+              _onPointerGestureEnd(wifiControl);
+            },
             child: FfMouseGestureDetector(
               onTap: () async {
                 _log.info(
@@ -116,6 +159,9 @@ class _TouchPadState extends ConsumerState<TouchPad> {
                 await wifiControl.doubleTap(topicId: widget.topicId);
               },
               onMove: (delta) {
+                if (!_isPointerDown) {
+                  return;
+                }
                 _log.fine(
                   '[Touchpad] onMove topicId=${widget.topicId} '
                   'delta=$delta',
@@ -124,6 +170,9 @@ class _TouchPadState extends ConsumerState<TouchPad> {
                 _flushMoveDeltasIfNeeded(wifiControl);
               },
               onClickAndDrag: (delta) {
+                if (!_isPointerDown) {
+                  return;
+                }
                 _log.fine(
                   '[Touchpad] onClickAndDrag topicId=${widget.topicId} '
                   'delta=$delta',
@@ -137,6 +186,14 @@ class _TouchPadState extends ConsumerState<TouchPad> {
                   '(longPressGesture)',
                 );
                 await wifiControl.longPress(topicId: widget.topicId);
+              },
+              onZoomGesture: (ratio) {
+                _log.fine(
+                  '[Touchpad] onZoomGesture topicId=${widget.topicId} '
+                  'ratio=$ratio',
+                );
+                _queueZoomStep(ratio);
+                _flushZoomStepsIfNeeded(wifiControl);
               },
               child: const SizedBox.expand(),
             ),

--- a/lib/widgets/touchpad.dart
+++ b/lib/widgets/touchpad.dart
@@ -36,6 +36,7 @@ class _TouchPadState extends ConsumerState<TouchPad> {
   final List<Offset> _clickAndDragOffsets = [];
   final List<double> _zoomScaleSteps = [];
   final Set<int> _activePointers = <int>{};
+  bool _didPinchDuringGesture = false;
   // Guards against drag updates arriving after the pointer has already ended.
   // Gesture recognizers can finish slightly out of order relative to pointer
   // up/cancel delivery, so the touchpad treats the active pointer set as the
@@ -55,17 +56,13 @@ class _TouchPadState extends ConsumerState<TouchPad> {
   }
 
   void _beginPointerGesture(PointerEvent event) {
+    if (!_isGestureActive) {
+      _didPinchDuringGesture = false;
+    }
     _activePointers.add(event.pointer);
-  }
-
-  void _flushMoveDeltasIfNeeded(FF1WifiControl wifiControl) {
-    if (_moveDragOffsets.length <= 5) return;
-    _flushMoveDeltas(wifiControl);
-  }
-
-  void _flushClickAndDragDeltasIfNeeded(FF1WifiControl wifiControl) {
-    if (_clickAndDragOffsets.length <= 5) return;
-    _flushClickAndDragDeltas(wifiControl);
+    if (_activePointers.length >= 2) {
+      _markPinchStarted();
+    }
   }
 
   void _flushZoomStepsIfNeeded(FF1WifiControl wifiControl) {
@@ -109,14 +106,27 @@ class _TouchPadState extends ConsumerState<TouchPad> {
     );
   }
 
+  void _markPinchStarted() {
+    if (_didPinchDuringGesture) return;
+    _didPinchDuringGesture = true;
+    _moveDragOffsets.clear();
+    _clickAndDragOffsets.clear();
+  }
+
   void _endPointerGesture(FF1WifiControl wifiControl, PointerEvent event) {
     _activePointers.remove(event.pointer);
     if (_isGestureActive) {
       return;
     }
-    _flushMoveDeltas(wifiControl);
-    _flushClickAndDragDeltas(wifiControl);
+    if (_didPinchDuringGesture) {
+      _moveDragOffsets.clear();
+      _clickAndDragOffsets.clear();
+    } else {
+      _flushMoveDeltas(wifiControl);
+      _flushClickAndDragDeltas(wifiControl);
+    }
     _flushZoomSteps(wifiControl);
+    _didPinchDuringGesture = false;
   }
 
   @override
@@ -132,9 +142,7 @@ class _TouchPadState extends ConsumerState<TouchPad> {
         children: [
           Listener(
             behavior: HitTestBehavior.opaque,
-            onPointerDown: (event) {
-              _beginPointerGesture(event);
-            },
+            onPointerDown: _beginPointerGesture,
             onPointerUp: (event) {
               _endPointerGesture(wifiControl, event);
             },
@@ -152,15 +160,19 @@ class _TouchPadState extends ConsumerState<TouchPad> {
                 if (!_isGestureActive) {
                   return;
                 }
+                if (_didPinchDuringGesture || _activePointers.length != 1) {
+                  return;
+                }
                 _queueMoveDelta(delta);
-                _flushMoveDeltasIfNeeded(wifiControl);
               },
               onClickAndDrag: (delta) {
                 if (!_isGestureActive) {
                   return;
                 }
+                if (_didPinchDuringGesture || _activePointers.length != 1) {
+                  return;
+                }
                 _queueClickAndDragDelta(delta);
-                _flushClickAndDragDeltasIfNeeded(wifiControl);
               },
               onLongPress: () async {
                 await wifiControl.longPress(topicId: widget.topicId);

--- a/test/unit/infra/ff1/ff1_wifi_control_test.dart
+++ b/test/unit/infra/ff1/ff1_wifi_control_test.dart
@@ -251,6 +251,100 @@ void main() {
     });
   });
 
+  group('FF1WifiControl gesture commands', () {
+    test('tap sends tapGesture command', () async {
+      final restClient = _RecordingRestClient();
+      final control = FF1WifiControl(
+        transport: _FakeWifiTransport(),
+        restClient: restClient,
+      );
+      addTearDown(control.dispose);
+
+      await control.tap(topicId: 'topic_1');
+
+      expect(restClient.lastTopicId, 'topic_1');
+      expect(restClient.lastCommand, 'tapGesture');
+      expect(restClient.lastParams, <String, dynamic>{});
+    });
+
+    test('doubleTap sends doubleTapGesture command', () async {
+      final restClient = _RecordingRestClient();
+      final control = FF1WifiControl(
+        transport: _FakeWifiTransport(),
+        restClient: restClient,
+      );
+      addTearDown(control.dispose);
+
+      await control.doubleTap(topicId: 'topic_1');
+
+      expect(restClient.lastTopicId, 'topic_1');
+      expect(restClient.lastCommand, 'doubleTapGesture');
+      expect(restClient.lastParams, <String, dynamic>{});
+    });
+
+    test('longPress sends longPressGesture command', () async {
+      final restClient = _RecordingRestClient();
+      final control = FF1WifiControl(
+        transport: _FakeWifiTransport(),
+        restClient: restClient,
+      );
+      addTearDown(control.dispose);
+
+      await control.longPress(topicId: 'topic_1');
+
+      expect(restClient.lastTopicId, 'topic_1');
+      expect(restClient.lastCommand, 'longPressGesture');
+      expect(restClient.lastParams, <String, dynamic>{});
+    });
+
+    test('drag sends dragGesture command with cursorOffsets', () async {
+      final restClient = _RecordingRestClient();
+      final control = FF1WifiControl(
+        transport: _FakeWifiTransport(),
+        restClient: restClient,
+      );
+      addTearDown(control.dispose);
+
+      await control.drag(
+        topicId: 'topic_1',
+        cursorOffsets: const [Offset(1.234, -0.456)],
+      );
+
+      expect(restClient.lastTopicId, 'topic_1');
+      expect(restClient.lastCommand, 'dragGesture');
+      expect(restClient.lastParams, <String, dynamic>{
+        'cursorOffsets': <Map<String, double>>[
+          <String, double>{'dx': 1.23, 'dy': -0.46},
+        ],
+      });
+    });
+
+    test(
+      'clickAndDrag sends dragGesture command with cursorOffsets',
+      () async {
+        final restClient = _RecordingRestClient();
+        final control = FF1WifiControl(
+          transport: _FakeWifiTransport(),
+          restClient: restClient,
+        );
+        addTearDown(control.dispose);
+
+        await control.clickAndDrag(
+          topicId: 'topic_1',
+          cursorOffsets: const [Offset(2, -1)],
+        );
+
+        expect(restClient.lastTopicId, 'topic_1');
+        expect(restClient.lastCommand, 'dragGesture');
+        expect(restClient.lastParams, <String, dynamic>{
+          'cursorOffsets': <Map<String, double>>[
+            <String, double>{'dx': 2.0, 'dy': -1.0},
+          ],
+        });
+      },
+    );
+  });
+
   group('FF1WifiControl.dispose', () {
     test(
       'await subscription cancel before closing subjects (delayed transport '
@@ -928,6 +1022,7 @@ class _SuppressedDispatchTransport implements FF1WifiTransport {
 class _RecordingRestClient {
   String? lastTopicId;
   String? lastCommand;
+  Map<String, dynamic>? lastParams;
   Duration? lastTimeout;
 
   Future<Map<String, dynamic>> sendCommand({
@@ -938,6 +1033,7 @@ class _RecordingRestClient {
   }) async {
     lastTopicId = topicId;
     lastCommand = command;
+    lastParams = params;
     lastTimeout = timeout;
 
     return <String, dynamic>{

--- a/test/unit/infra/ff1/ff1_wifi_control_test.dart
+++ b/test/unit/infra/ff1/ff1_wifi_control_test.dart
@@ -320,7 +320,7 @@ void main() {
     });
 
     test(
-      'clickAndDrag sends dragGesture command with cursorOffsets',
+      'clickAndDrag sends clickAndDragGesture command with cursorOffsets',
       () async {
         final restClient = _RecordingRestClient();
         final control = FF1WifiControl(
@@ -335,7 +335,7 @@ void main() {
         );
 
         expect(restClient.lastTopicId, 'topic_1');
-        expect(restClient.lastCommand, 'dragGesture');
+        expect(restClient.lastCommand, 'clickAndDragGesture');
         expect(restClient.lastParams, <String, dynamic>{
           'cursorOffsets': <Map<String, double>>[
             <String, double>{'dx': 2.0, 'dy': -1.0},

--- a/test/unit/infra/ff1/ff1_wifi_control_test.dart
+++ b/test/unit/infra/ff1/ff1_wifi_control_test.dart
@@ -343,6 +343,26 @@ void main() {
         });
       },
     );
+
+    test('zoomGesture sends zoomGesture command with scaleSteps', () async {
+      final restClient = _RecordingRestClient();
+      final control = FF1WifiControl(
+        transport: _FakeWifiTransport(),
+        restClient: restClient,
+      );
+      addTearDown(control.dispose);
+
+      await control.zoomGesture(
+        topicId: 'topic_1',
+        scaleSteps: const [1.05, 1.02],
+      );
+
+      expect(restClient.lastTopicId, 'topic_1');
+      expect(restClient.lastCommand, 'zoomGesture');
+      expect(restClient.lastParams, <String, dynamic>{
+        'scaleSteps': <double>[1.05, 1.02],
+      });
+    });
   });
 
   group('FF1WifiControl.dispose', () {

--- a/test/unit/infra/ff1/wifi_protocol/ff1_wifi_messages_test.dart
+++ b/test/unit/infra/ff1/wifi_protocol/ff1_wifi_messages_test.dart
@@ -403,4 +403,30 @@ void main() {
       expect(response.data?['message'], isNotNull);
     });
   });
+
+  group('pointer drag requests', () {
+    const offsets = <Map<String, double>>[
+      <String, double>{'dx': 1.234, 'dy': -0.456},
+    ];
+
+    test('FF1WifiDragRequest uses dragGesture and rounds params', () {
+      const request = FF1WifiDragRequest(cursorOffsets: offsets);
+      expect(request.command, 'dragGesture');
+      expect(request.params, <String, dynamic>{
+        'cursorOffsets': <Map<String, double>>[
+          <String, double>{'dx': 1.23, 'dy': -0.46},
+        ],
+      });
+    });
+
+    test(
+      'FF1WifiClickAndDragRequest uses clickAndDragGesture; params match drag',
+      () {
+        const drag = FF1WifiDragRequest(cursorOffsets: offsets);
+        const clickAndDrag = FF1WifiClickAndDragRequest(cursorOffsets: offsets);
+        expect(clickAndDrag.command, 'clickAndDragGesture');
+        expect(clickAndDrag.params, drag.params);
+      },
+    );
+  });
 }

--- a/test/unit/infra/ff1/wifi_protocol/ff1_wifi_messages_test.dart
+++ b/test/unit/infra/ff1/wifi_protocol/ff1_wifi_messages_test.dart
@@ -428,5 +428,18 @@ void main() {
         expect(clickAndDrag.params, drag.params);
       },
     );
+
+    test(
+      'FF1WifiZoomGestureRequest uses zoomGesture and rounds scaleSteps',
+      () {
+        const request = FF1WifiZoomGestureRequest(
+          scaleSteps: <double>[1.23456, 0.987654],
+        );
+        expect(request.command, 'zoomGesture');
+        expect(request.params, <String, dynamic>{
+          'scaleSteps': <double>[1.2346, 0.9877],
+        });
+      },
+    );
   });
 }

--- a/test/unit/widgets/ff_mouse_gesture_detector_test.dart
+++ b/test/unit/widgets/ff_mouse_gesture_detector_test.dart
@@ -283,5 +283,49 @@ void main() {
       expect(zoomRatios, isNotEmpty);
       expect(zoomRatios.every((r) => r > 1), isTrue);
     });
+
+    testWidgets('pinch zoom does not emit move deltas', (tester) async {
+      final moveDeltas = <Offset>[];
+      final zoomRatios = <double>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 200,
+                height: 200,
+                child: FfMouseGestureDetector(
+                  onTap: () {},
+                  onDoubleTap: () {},
+                  onMove: moveDeltas.add,
+                  onClickAndDrag: (_) {},
+                  onLongPress: () {},
+                  onZoomGesture: zoomRatios.add,
+                  child: const ColoredBox(color: Colors.black),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final center = tester.getCenter(find.byType(FfMouseGestureDetector));
+      final g1 = await tester.startGesture(center - const Offset(10, 0));
+      final g2 = await tester.startGesture(center + const Offset(10, 0));
+      await tester.pump();
+      await g1.moveBy(const Offset(-40, 0));
+      await g2.moveBy(const Offset(40, 0));
+      await tester.pump();
+      await g1.moveBy(const Offset(-5, 0));
+      await g2.moveBy(const Offset(5, 0));
+      await tester.pump();
+      await g1.up();
+      await g2.up();
+      await tester.pump();
+
+      expect(zoomRatios, isNotEmpty);
+      expect(moveDeltas, isEmpty);
+    });
   });
 }

--- a/test/unit/widgets/ff_mouse_gesture_detector_test.dart
+++ b/test/unit/widgets/ff_mouse_gesture_detector_test.dart
@@ -1,0 +1,197 @@
+import 'package:app/widgets/ff_mouse_gesture_detector.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FfMouseGestureDetector', () {
+    testWidgets('single tap triggers onTap (deferred until double-tap timeout)', (tester) async {
+      var tapCount = 0;
+      var doubleTapCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 200,
+              height: 200,
+              child: FfMouseGestureDetector(
+                onTap: () => tapCount++,
+                onDoubleTap: () => doubleTapCount++,
+                child: const ColoredBox(color: Colors.black),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final center = tester.getCenter(find.byType(FfMouseGestureDetector));
+      await tester.tapAt(center);
+      await tester.pump();
+
+      // Not yet fired: still waiting to see if this becomes a double tap.
+      expect(tapCount, 0);
+      expect(doubleTapCount, 0);
+
+      await tester.pump(kDoubleTapTimeout);
+      expect(tapCount, 1);
+      expect(doubleTapCount, 0);
+    });
+
+    testWidgets('double tap triggers onDoubleTap and does not trigger onTap', (tester) async {
+      var tapCount = 0;
+      var doubleTapCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 200,
+              height: 200,
+              child: FfMouseGestureDetector(
+                onTap: () => tapCount++,
+                onDoubleTap: () => doubleTapCount++,
+                child: const ColoredBox(color: Colors.black),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final center = tester.getCenter(find.byType(FfMouseGestureDetector));
+      await tester.tapAt(center);
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tapAt(center);
+      await tester.pump();
+
+      expect(doubleTapCount, 1);
+
+      // If a single tap was pending, it should be cancelled by the double tap.
+      await tester.pump(kDoubleTapTimeout);
+      expect(tapCount, 0);
+    });
+
+    testWidgets('routes single drag to onMove', (tester) async {
+      final moveDeltas = <Offset>[];
+      final clickAndDragDeltas = <Offset>[];
+      var longPressCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 200,
+                height: 200,
+                child: FfMouseGestureDetector(
+                  onTap: () {},
+                  onDoubleTap: () {},
+                  onMove: moveDeltas.add,
+                  onClickAndDrag: clickAndDragDeltas.add,
+                  onLongPress: () => longPressCount++,
+                  child: const ColoredBox(color: Colors.black),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final center = tester.getCenter(find.byType(FfMouseGestureDetector));
+      final gesture = await tester.startGesture(center);
+      await tester.pump();
+      await gesture.moveBy(const Offset(30, 10));
+      await tester.pump();
+      await gesture.moveBy(const Offset(-5, 0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(moveDeltas, isNotEmpty);
+      expect(clickAndDragDeltas, isEmpty);
+      expect(longPressCount, 0);
+    });
+
+    testWidgets('routes double-tap-hold then drag to onClickAndDrag', (tester) async {
+      final moveDeltas = <Offset>[];
+      final clickAndDragDeltas = <Offset>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 200,
+                height: 200,
+                child: FfMouseGestureDetector(
+                  onTap: () {},
+                  onDoubleTap: () {},
+                  onMove: moveDeltas.add,
+                  onClickAndDrag: clickAndDragDeltas.add,
+                  onLongPress: () {},
+                  child: const ColoredBox(color: Colors.black),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final center = tester.getCenter(find.byType(FfMouseGestureDetector));
+
+      // Tap #1 (down+up).
+      await tester.tapAt(center);
+      await tester.pump();
+
+      // Tap #2 down, hold, then drag.
+      await tester.pump(const Duration(milliseconds: 50));
+      final gesture = await tester.startGesture(center);
+      await tester.pump();
+      await gesture.moveBy(const Offset(40, 0)); // exceed pan slop
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, 10));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(clickAndDragDeltas, isNotEmpty);
+      expect(moveDeltas, isEmpty);
+    });
+
+    testWidgets('long press triggers onLongPress and does not emit move/clickAndDrag', (tester) async {
+      final moveDeltas = <Offset>[];
+      final clickAndDragDeltas = <Offset>[];
+      var longPressCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 200,
+                height: 200,
+                child: FfMouseGestureDetector(
+                  onTap: () {},
+                  onDoubleTap: () {},
+                  onMove: moveDeltas.add,
+                  onClickAndDrag: clickAndDragDeltas.add,
+                  onLongPress: () => longPressCount++,
+                  child: const ColoredBox(color: Colors.black),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final center = tester.getCenter(find.byType(FfMouseGestureDetector));
+      await tester.longPressAt(center);
+      await tester.pump();
+
+      expect(longPressCount, 1);
+      expect(moveDeltas, isEmpty);
+      expect(clickAndDragDeltas, isEmpty);
+    });
+  });
+}
+

--- a/test/unit/widgets/ff_mouse_gesture_detector_test.dart
+++ b/test/unit/widgets/ff_mouse_gesture_detector_test.dart
@@ -5,20 +5,96 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('FfMouseGestureDetector', () {
-    testWidgets('single tap triggers onTap (deferred until double-tap timeout)', (tester) async {
-      var tapCount = 0;
-      var doubleTapCount = 0;
+    testWidgets(
+      'single tap triggers onTap (deferred until double-tap timeout)',
+      (tester) async {
+        var tapCount = 0;
+        var doubleTapCount = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 200,
+                height: 200,
+                child: FfMouseGestureDetector(
+                  onTap: () => tapCount++,
+                  onDoubleTap: () => doubleTapCount++,
+                  child: const ColoredBox(color: Colors.black),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final center = tester.getCenter(find.byType(FfMouseGestureDetector));
+        await tester.tapAt(center);
+        await tester.pump();
+
+        // Not yet fired: still waiting to see if this becomes a double tap.
+        expect(tapCount, 0);
+        expect(doubleTapCount, 0);
+
+        await tester.pump(kDoubleTapTimeout);
+        expect(tapCount, 1);
+        expect(doubleTapCount, 0);
+      },
+    );
+
+    testWidgets(
+      'double tap triggers onDoubleTap and does not trigger onTap',
+      (tester) async {
+        var tapCount = 0;
+        var doubleTapCount = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 200,
+                height: 200,
+                child: FfMouseGestureDetector(
+                  onTap: () => tapCount++,
+                  onDoubleTap: () => doubleTapCount++,
+                  child: const ColoredBox(color: Colors.black),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final center = tester.getCenter(find.byType(FfMouseGestureDetector));
+        await tester.tapAt(center);
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.tapAt(center);
+        await tester.pump();
+
+        expect(doubleTapCount, 1);
+
+        // If a single tap was pending, cancel it when double tap wins.
+        await tester.pump(kDoubleTapTimeout);
+        expect(tapCount, 0);
+      },
+    );
+
+    testWidgets('does not forward zero drag delta to onMove', (tester) async {
+      final moveDeltas = <Offset>[];
 
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: SizedBox(
-              width: 200,
-              height: 200,
-              child: FfMouseGestureDetector(
-                onTap: () => tapCount++,
-                onDoubleTap: () => doubleTapCount++,
-                child: const ColoredBox(color: Colors.black),
+            body: Center(
+              child: SizedBox(
+                width: 200,
+                height: 200,
+                child: FfMouseGestureDetector(
+                  onTap: () {},
+                  onDoubleTap: () {},
+                  onMove: moveDeltas.add,
+                  onClickAndDrag: (_) {},
+                  onLongPress: () {},
+                  child: const ColoredBox(color: Colors.black),
+                ),
               ),
             ),
           ),
@@ -26,49 +102,16 @@ void main() {
       );
 
       final center = tester.getCenter(find.byType(FfMouseGestureDetector));
-      await tester.tapAt(center);
+      final gesture = await tester.startGesture(center);
+      await tester.pump();
+      await gesture.moveBy(const Offset(20, 0));
+      await tester.pump();
+      await gesture.moveBy(Offset.zero);
+      await tester.pump();
+      await gesture.up();
       await tester.pump();
 
-      // Not yet fired: still waiting to see if this becomes a double tap.
-      expect(tapCount, 0);
-      expect(doubleTapCount, 0);
-
-      await tester.pump(kDoubleTapTimeout);
-      expect(tapCount, 1);
-      expect(doubleTapCount, 0);
-    });
-
-    testWidgets('double tap triggers onDoubleTap and does not trigger onTap', (tester) async {
-      var tapCount = 0;
-      var doubleTapCount = 0;
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SizedBox(
-              width: 200,
-              height: 200,
-              child: FfMouseGestureDetector(
-                onTap: () => tapCount++,
-                onDoubleTap: () => doubleTapCount++,
-                child: const ColoredBox(color: Colors.black),
-              ),
-            ),
-          ),
-        ),
-      );
-
-      final center = tester.getCenter(find.byType(FfMouseGestureDetector));
-      await tester.tapAt(center);
-      await tester.pump(const Duration(milliseconds: 50));
-      await tester.tapAt(center);
-      await tester.pump();
-
-      expect(doubleTapCount, 1);
-
-      // If a single tap was pending, it should be cancelled by the double tap.
-      await tester.pump(kDoubleTapTimeout);
-      expect(tapCount, 0);
+      expect(moveDeltas.where((d) => d == Offset.zero), isEmpty);
     });
 
     testWidgets('routes single drag to onMove', (tester) async {
@@ -112,9 +155,97 @@ void main() {
       expect(longPressCount, 0);
     });
 
-    testWidgets('routes double-tap-hold then drag to onClickAndDrag', (tester) async {
-      final moveDeltas = <Offset>[];
-      final clickAndDragDeltas = <Offset>[];
+    testWidgets(
+      'routes double-tap-hold then drag to onClickAndDrag',
+      (tester) async {
+        final moveDeltas = <Offset>[];
+        final clickAndDragDeltas = <Offset>[];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: 200,
+                  height: 200,
+                  child: FfMouseGestureDetector(
+                    onTap: () {},
+                    onDoubleTap: () {},
+                    onMove: moveDeltas.add,
+                    onClickAndDrag: clickAndDragDeltas.add,
+                    onLongPress: () {},
+                    child: const ColoredBox(color: Colors.black),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final center = tester.getCenter(find.byType(FfMouseGestureDetector));
+
+        // Tap #1 (down+up).
+        await tester.tapAt(center);
+        await tester.pump();
+
+        // Tap #2 down, hold, then drag.
+        await tester.pump(const Duration(milliseconds: 50));
+        final gesture = await tester.startGesture(center);
+        await tester.pump();
+        await gesture.moveBy(const Offset(40, 0)); // exceed pan slop
+        await tester.pump();
+        await gesture.moveBy(const Offset(0, 10));
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+
+        expect(clickAndDragDeltas, isNotEmpty);
+        expect(moveDeltas, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'long press triggers onLongPress and does not emit move/clickAndDrag',
+      (tester) async {
+        final moveDeltas = <Offset>[];
+        final clickAndDragDeltas = <Offset>[];
+        var longPressCount = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: 200,
+                  height: 200,
+                  child: FfMouseGestureDetector(
+                    onTap: () {},
+                    onDoubleTap: () {},
+                    onMove: moveDeltas.add,
+                    onClickAndDrag: clickAndDragDeltas.add,
+                    onLongPress: () => longPressCount++,
+                    child: const ColoredBox(color: Colors.black),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final center = tester.getCenter(find.byType(FfMouseGestureDetector));
+        await tester.longPressAt(center);
+        await tester.pump();
+
+        expect(longPressCount, 1);
+        expect(moveDeltas, isEmpty);
+        expect(clickAndDragDeltas, isEmpty);
+      },
+    );
+
+    testWidgets('two-finger spread triggers onZoomGesture with ratio > 1', (
+      tester,
+    ) async {
+      final zoomRatios = <double>[];
 
       await tester.pumpWidget(
         MaterialApp(
@@ -126,9 +257,10 @@ void main() {
                 child: FfMouseGestureDetector(
                   onTap: () {},
                   onDoubleTap: () {},
-                  onMove: moveDeltas.add,
-                  onClickAndDrag: clickAndDragDeltas.add,
+                  onMove: (_) {},
+                  onClickAndDrag: (_) {},
                   onLongPress: () {},
+                  onZoomGesture: zoomRatios.add,
                   child: const ColoredBox(color: Colors.black),
                 ),
               ),
@@ -138,60 +270,18 @@ void main() {
       );
 
       final center = tester.getCenter(find.byType(FfMouseGestureDetector));
-
-      // Tap #1 (down+up).
-      await tester.tapAt(center);
+      final g1 = await tester.startGesture(center - const Offset(10, 0));
+      final g2 = await tester.startGesture(center + const Offset(10, 0));
+      await tester.pump();
+      await g1.moveBy(const Offset(-40, 0));
+      await g2.moveBy(const Offset(40, 0));
+      await tester.pump();
+      await g1.up();
+      await g2.up();
       await tester.pump();
 
-      // Tap #2 down, hold, then drag.
-      await tester.pump(const Duration(milliseconds: 50));
-      final gesture = await tester.startGesture(center);
-      await tester.pump();
-      await gesture.moveBy(const Offset(40, 0)); // exceed pan slop
-      await tester.pump();
-      await gesture.moveBy(const Offset(0, 10));
-      await tester.pump();
-      await gesture.up();
-      await tester.pump();
-
-      expect(clickAndDragDeltas, isNotEmpty);
-      expect(moveDeltas, isEmpty);
-    });
-
-    testWidgets('long press triggers onLongPress and does not emit move/clickAndDrag', (tester) async {
-      final moveDeltas = <Offset>[];
-      final clickAndDragDeltas = <Offset>[];
-      var longPressCount = 0;
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Center(
-              child: SizedBox(
-                width: 200,
-                height: 200,
-                child: FfMouseGestureDetector(
-                  onTap: () {},
-                  onDoubleTap: () {},
-                  onMove: moveDeltas.add,
-                  onClickAndDrag: clickAndDragDeltas.add,
-                  onLongPress: () => longPressCount++,
-                  child: const ColoredBox(color: Colors.black),
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-
-      final center = tester.getCenter(find.byType(FfMouseGestureDetector));
-      await tester.longPressAt(center);
-      await tester.pump();
-
-      expect(longPressCount, 1);
-      expect(moveDeltas, isEmpty);
-      expect(clickAndDragDeltas, isEmpty);
+      expect(zoomRatios, isNotEmpty);
+      expect(zoomRatios.every((r) => r > 1), isTrue);
     });
   });
 }
-

--- a/test/unit/widgets/ff_mouse_gesture_detector_test.dart
+++ b/test/unit/widgets/ff_mouse_gesture_detector_test.dart
@@ -327,5 +327,55 @@ void main() {
       expect(zoomRatios, isNotEmpty);
       expect(moveDeltas, isEmpty);
     });
+
+    testWidgets(
+      'pinch start cancels pending single tap',
+      (tester) async {
+        var tapCount = 0;
+        var doubleTapCount = 0;
+        final zoomRatios = <double>[];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: 200,
+                  height: 200,
+                  child: FfMouseGestureDetector(
+                    onTap: () => tapCount++,
+                    onDoubleTap: () => doubleTapCount++,
+                    onMove: (_) {},
+                    onClickAndDrag: (_) {},
+                    onLongPress: () {},
+                    onZoomGesture: zoomRatios.add,
+                    child: const ColoredBox(color: Colors.black),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final center = tester.getCenter(find.byType(FfMouseGestureDetector));
+        await tester.tapAt(center);
+        await tester.pump(const Duration(milliseconds: 20));
+
+        final g1 = await tester.startGesture(center - const Offset(10, 0));
+        final g2 = await tester.startGesture(center + const Offset(10, 0));
+        await tester.pump();
+        await g1.moveBy(const Offset(-15, 0));
+        await g2.moveBy(const Offset(15, 0));
+        await tester.pump();
+        await g1.up();
+        await g2.up();
+        await tester.pump();
+
+        await tester.pump(kDoubleTapTimeout);
+        expect(tapCount, 0);
+        expect(doubleTapCount, 0);
+        expect(zoomRatios, isNotEmpty);
+      },
+    );
   });
 }

--- a/test/unit/widgets/ff_mouse_gesture_detector_test.dart
+++ b/test/unit/widgets/ff_mouse_gesture_detector_test.dart
@@ -329,6 +329,52 @@ void main() {
     });
 
     testWidgets(
+      'pinch cancels pending long press',
+      (tester) async {
+        final zoomRatios = <double>[];
+        var longPressCount = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: 200,
+                  height: 200,
+                  child: FfMouseGestureDetector(
+                    onTap: () {},
+                    onDoubleTap: () {},
+                    onMove: (_) {},
+                    onClickAndDrag: (_) {},
+                    onLongPress: () => longPressCount++,
+                    onZoomGesture: zoomRatios.add,
+                    child: const ColoredBox(color: Colors.black),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final center = tester.getCenter(find.byType(FfMouseGestureDetector));
+        final g1 = await tester.startGesture(center - const Offset(10, 0));
+        await tester.pump();
+        final g2 = await tester.startGesture(center + const Offset(10, 0));
+        await tester.pump();
+        await g1.moveBy(const Offset(-25, 0));
+        await g2.moveBy(const Offset(25, 0));
+        await tester.pump();
+        await tester.pump(kLongPressTimeout);
+        await g1.up();
+        await g2.up();
+        await tester.pump();
+
+        expect(longPressCount, 0);
+        expect(zoomRatios, isNotEmpty);
+      },
+    );
+
+    testWidgets(
       'pinch start cancels pending single tap',
       (tester) async {
         var tapCount = 0;

--- a/test/unit/widgets/touchpad_test.dart
+++ b/test/unit/widgets/touchpad_test.dart
@@ -50,10 +50,11 @@ void main() {
       for (var i = 0; i < 6; i++) {
         detector.onMove?.call(const Offset(4, 0));
       }
+      await tester.pump();
+      expect(control.dragCalls, 1);
       await moveGesture.up();
       await tester.pump();
 
-      expect(control.dragCalls, 1);
       expect(control.dragOffsets.single.length, 6);
       expect(control.clickAndDragCalls, 0);
 
@@ -62,10 +63,11 @@ void main() {
       for (var i = 0; i < 6; i++) {
         detector.onClickAndDrag?.call(const Offset(3, 1));
       }
+      await tester.pump();
+      expect(control.clickAndDragCalls, 1);
       await clickAndDragGesture.up();
       await tester.pump();
 
-      expect(control.clickAndDragCalls, 1);
       expect(control.clickAndDragOffsets.single.length, 6);
     });
 

--- a/test/unit/widgets/touchpad_test.dart
+++ b/test/unit/widgets/touchpad_test.dart
@@ -1,0 +1,241 @@
+import 'package:app/app/providers/ff1_wifi_providers.dart';
+import 'package:app/domain/models/ff1_device.dart';
+import 'package:app/infra/ff1/wifi_control/ff1_wifi_control.dart';
+import 'package:app/infra/ff1/wifi_protocol/ff1_wifi_messages.dart';
+import 'package:app/infra/ff1/wifi_transport/ff1_wifi_transport.dart';
+import 'package:app/widgets/ff_mouse_gesture_detector.dart';
+import 'package:app/widgets/touchpad.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+import 'package:rxdart/rxdart.dart';
+
+void main() {
+  group('TouchPad', () {
+    testWidgets('routes tap, double tap, and long press to FF1 control', (
+      tester,
+    ) async {
+      final control = _RecordingWifiControl();
+
+      await tester.pumpWidget(_buildTestApp(control));
+      final detector = tester.widget<FfMouseGestureDetector>(
+        find.byType(FfMouseGestureDetector),
+      );
+
+      detector.onTap?.call();
+      detector.onDoubleTap?.call();
+      detector.onLongPress?.call();
+
+      expect(control.tapCalls, 1);
+      expect(control.doubleTapCalls, 1);
+      expect(control.longPressCalls, 1);
+    });
+
+    testWidgets('routes move-only drag and click-and-drag with batching', (
+      tester,
+    ) async {
+      final control = _RecordingWifiControl();
+
+      await tester.pumpWidget(_buildTestApp(control));
+      final center = tester.getCenter(find.byType(TouchPad));
+      final detector = tester.widget<FfMouseGestureDetector>(
+        find.byType(FfMouseGestureDetector),
+      );
+
+      final moveGesture = await tester.startGesture(center);
+      await tester.pump();
+      for (var i = 0; i < 6; i++) {
+        detector.onMove?.call(const Offset(4, 0));
+      }
+      await moveGesture.up();
+      await tester.pump();
+
+      expect(control.dragCalls, 1);
+      expect(control.dragOffsets.single.length, 6);
+      expect(control.clickAndDragCalls, 0);
+
+      final clickAndDragGesture = await tester.startGesture(center);
+      await tester.pump();
+      for (var i = 0; i < 6; i++) {
+        detector.onClickAndDrag?.call(const Offset(3, 1));
+      }
+      await clickAndDragGesture.up();
+      await tester.pump();
+
+      expect(control.clickAndDragCalls, 1);
+      expect(control.clickAndDragOffsets.single.length, 6);
+    });
+
+    testWidgets(
+      'routes pinch zoom and keeps the session active until the last pointer lifts',
+      (tester) async {
+        final control = _RecordingWifiControl();
+
+        await tester.pumpWidget(_buildTestApp(control));
+        final center = tester.getCenter(find.byType(TouchPad));
+        final detector = tester.widget<FfMouseGestureDetector>(
+          find.byType(FfMouseGestureDetector),
+        );
+
+        final firstFinger = await tester.startGesture(
+          center - const Offset(20, 0),
+        );
+        final secondFinger = await tester.startGesture(
+          center + const Offset(20, 0),
+        );
+        await tester.pump();
+
+        detector.onZoomGesture?.call(1.05);
+        detector.onZoomGesture?.call(1.05);
+
+        await firstFinger.up();
+        await tester.pump();
+        expect(control.zoomGestureCalls, 0);
+        expect(control.dragCalls, 0);
+        expect(control.clickAndDragCalls, 0);
+
+        await secondFinger.up();
+        await tester.pump();
+        expect(control.zoomGestureCalls, 1);
+        expect(control.zoomGestureScaleSteps.single, isNotEmpty);
+      },
+    );
+  });
+}
+
+Widget _buildTestApp(_RecordingWifiControl control) {
+  return ProviderScope(
+    overrides: [
+      ff1WifiControlProvider.overrideWithValue(control),
+    ],
+    child: const MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 240,
+          height: 240,
+          child: TouchPad(topicId: 'topic-1'),
+        ),
+      ),
+    ),
+  );
+}
+
+class _RecordingWifiControl extends FF1WifiControl {
+  _RecordingWifiControl()
+    : super(
+        transport: _NoopWifiTransport(),
+        restClient: null,
+        logger: Logger('_RecordingWifiControl'),
+      );
+
+  int tapCalls = 0;
+  int doubleTapCalls = 0;
+  int longPressCalls = 0;
+  int dragCalls = 0;
+  int clickAndDragCalls = 0;
+  int zoomGestureCalls = 0;
+  final List<List<Offset>> dragOffsets = <List<Offset>>[];
+  final List<List<Offset>> clickAndDragOffsets = <List<Offset>>[];
+  final List<List<double>> zoomGestureScaleSteps = <List<double>>[];
+
+  @override
+  Future<FF1CommandResponse> tap({required String topicId}) async {
+    tapCalls++;
+    return FF1CommandResponse();
+  }
+
+  @override
+  Future<FF1CommandResponse> doubleTap({required String topicId}) async {
+    doubleTapCalls++;
+    return FF1CommandResponse();
+  }
+
+  @override
+  Future<FF1CommandResponse> longPress({required String topicId}) async {
+    longPressCalls++;
+    return FF1CommandResponse();
+  }
+
+  @override
+  Future<FF1CommandResponse> drag({
+    required String topicId,
+    required List<Offset> cursorOffsets,
+  }) async {
+    dragCalls++;
+    dragOffsets.add(List<Offset>.from(cursorOffsets));
+    return FF1CommandResponse();
+  }
+
+  @override
+  Future<FF1CommandResponse> clickAndDrag({
+    required String topicId,
+    required List<Offset> cursorOffsets,
+  }) async {
+    clickAndDragCalls++;
+    clickAndDragOffsets.add(List<Offset>.from(cursorOffsets));
+    return FF1CommandResponse();
+  }
+
+  @override
+  Future<FF1CommandResponse> zoomGesture({
+    required String topicId,
+    required List<double> scaleSteps,
+  }) async {
+    zoomGestureCalls++;
+    zoomGestureScaleSteps.add(List<double>.from(scaleSteps));
+    return FF1CommandResponse();
+  }
+}
+
+class _NoopWifiTransport implements FF1WifiTransport {
+  final _notifications = BehaviorSubject<FF1NotificationMessage>();
+  final _connections = BehaviorSubject<bool>();
+  final _errors = BehaviorSubject<FF1WifiTransportError>();
+
+  @override
+  Stream<FF1NotificationMessage> get notificationStream => _notifications.stream;
+
+  @override
+  Stream<bool> get connectionStateStream => _connections.stream;
+
+  @override
+  Stream<FF1WifiTransportError> get errorStream => _errors.stream;
+
+  @override
+  bool get isConnected => false;
+
+  @override
+  bool get isConnecting => false;
+
+  @override
+  Future<bool> connect({
+    required FF1Device device,
+    required String userId,
+    required String apiKey,
+    bool forceReconnect = false,
+  }) async {
+    return true;
+  }
+
+  @override
+  void pauseConnection() {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> sendCommand(Map<String, dynamic> command) async {}
+
+  @override
+  void dispose() {
+    _notifications.close();
+    _connections.close();
+    _errors.close();
+  }
+
+  @override
+  Future<void> disposeFuture() async {
+    dispose();
+  }
+}

--- a/test/unit/widgets/touchpad_test.dart
+++ b/test/unit/widgets/touchpad_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app/app/providers/ff1_wifi_providers.dart';
 import 'package:app/domain/models/ff1_device.dart';
 import 'package:app/infra/ff1/wifi_control/ff1_wifi_control.dart';
@@ -68,7 +70,8 @@ void main() {
     });
 
     testWidgets(
-      'routes pinch zoom and keeps the session active until the last pointer lifts',
+      'routes pinch zoom and keeps the session active '
+      'until the last pointer lifts',
       (tester) async {
         final control = _RecordingWifiControl();
 
@@ -99,6 +102,38 @@ void main() {
         await tester.pump();
         expect(control.zoomGestureCalls, 1);
         expect(control.zoomGestureScaleSteps.single, isNotEmpty);
+      },
+    );
+
+    testWidgets(
+      'mixed pinch sequence drops pending move/click batches',
+      (tester) async {
+        final control = _RecordingWifiControl();
+
+        await tester.pumpWidget(_buildTestApp(control));
+        final center = tester.getCenter(find.byType(TouchPad));
+        final detector = tester.widget<FfMouseGestureDetector>(
+          find.byType(FfMouseGestureDetector),
+        );
+
+        final firstFinger = await tester.startGesture(center);
+        await tester.pump();
+        detector.onMove?.call(const Offset(8, 0));
+        detector.onMove?.call(const Offset(8, 0));
+
+        final secondFinger = await tester.startGesture(
+          center + const Offset(16, 0),
+        );
+        await tester.pump();
+        detector.onZoomGesture?.call(1.05);
+
+        await firstFinger.up();
+        await secondFinger.up();
+        await tester.pump();
+
+        expect(control.dragCalls, 0);
+        expect(control.clickAndDragCalls, 0);
+        expect(control.zoomGestureCalls, 1);
       },
     );
   });
@@ -194,7 +229,8 @@ class _NoopWifiTransport implements FF1WifiTransport {
   final _errors = BehaviorSubject<FF1WifiTransportError>();
 
   @override
-  Stream<FF1NotificationMessage> get notificationStream => _notifications.stream;
+  Stream<FF1NotificationMessage> get notificationStream =>
+      _notifications.stream;
 
   @override
   Stream<bool> get connectionStateStream => _connections.stream;
@@ -229,9 +265,9 @@ class _NoopWifiTransport implements FF1WifiTransport {
 
   @override
   void dispose() {
-    _notifications.close();
-    _connections.close();
-    _errors.close();
+    unawaited(_notifications.close());
+    unawaited(_connections.close());
+    unawaited(_errors.close());
   }
 
   @override


### PR DESCRIPTION
## Summary

Adds and wires touchpad pointer gestures for FF1 over Wi‑Fi: tap, double-tap, long-press, move-only drag, click-and-drag, and pinch zoom (`zoomGesture` with batched `scaleSteps`). Pinch is implemented with a `Listener` (two-finger span) so single-finger taps are not broken by the gesture arena.

## Related

- feral-file/feral-file#3403 — _Improve the artwork interaction_
- Project card: https://github.com/orgs/feral-file/projects/4/views/1?pane=issue&itemId=174317332&issue=feral-file%7Cferal-file%7C3403

## Notes

- See `docs/mouse_events_spec.md` for relayer `request` shapes.


Made with [Cursor](https://cursor.com)